### PR TITLE
Fix ModuleNotFoundError on Streamlit Cloud by adding src/ to sys.path

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ Deploy: see DEPLOYMENT_STREAMLIT.md.
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 from typing import List
 
 import matplotlib
@@ -22,6 +24,12 @@ matplotlib.use("Agg")  # headless backend; required on Streamlit Cloud
 import matplotlib.pyplot as plt
 import numpy as np
 import streamlit as st
+
+# Make the src-layout package importable on Streamlit Cloud, which does not
+# pip-install the local repo.
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.is_dir() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary


### PR DESCRIPTION
## Summary
- The Streamlit Cloud deploy at `wrinklefe.streamlit.app` was failing with `ModuleNotFoundError: wrinklefe` because `app.py` does `from wrinklefe.analysis import ...`, but Streamlit Cloud doesn't `pip install` the local repo and the package source lives at `src/wrinklefe/` (src-layout).
- Fix: insert the repo's `src/` directory onto `sys.path` before the `wrinklefe.*` imports in `app.py`, gated on `_SRC.is_dir()` so it's a no-op outside the repo.
- 8-line, scope-limited change to `app.py` only.

## Test plan
- [x] `streamlit.testing.v1.AppTest` smoke test on `app.py`: page renders, no exceptions, all selectboxes + Run button present
- [ ] After merge, confirm `wrinklefe.streamlit.app` redeploys cleanly (no `ModuleNotFoundError`) and the "Run analysis" button produces metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqPXSVeaEy65GfNVfAm5NZ)_