### PR TITLE
Surface FE outputs + apply 5-agent audit improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,8 +12,12 @@ Deploy: see DEPLOYMENT_STREAMLIT.md.
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 import sys
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import List
 
@@ -68,7 +72,7 @@ DEFAULT_LAYUP = (
 # ---------------------------------------------------------------------------
 
 with st.sidebar:
-    st.header("Wrinkle geometry")
+    st.markdown("**Wrinkle geometry**")
     amplitude = st.number_input(
         "Amplitude A [mm]",
         min_value=0.0, max_value=5.0, value=0.366, step=0.01,
@@ -81,13 +85,21 @@ with st.sidebar:
     wavelength = st.number_input(
         "Wavelength λ [mm]",
         min_value=1.0, max_value=200.0, value=16.0, step=0.5,
+        help=(
+            "Spatial period of the cosine carrier. Larger λ at fixed A "
+            "lowers the peak fibre angle θ_max ≈ arctan(2πA/λ)."
+        ),
     )
     width = st.number_input(
         "Envelope width w [mm]",
         min_value=1.0, max_value=200.0, value=12.0, step=0.5,
+        help=(
+            "Half-width of the Gaussian envelope multiplying the cosine. "
+            "Smaller w localises the wrinkle to a few wavelengths near x = 0."
+        ),
     )
 
-    st.header("Morphology & loading")
+    st.markdown("**Morphology & loading**")
     morphology = st.selectbox("Morphology", MORPHOLOGIES, index=0)
     with st.popover("What do these morphologies mean?", use_container_width=True):
         st.markdown(
@@ -120,19 +132,28 @@ with st.sidebar:
         )
 
     loading = st.radio("Loading mode", ["compression", "tension"], horizontal=True)
-    applied_strain_pct = st.number_input(
-        "Applied strain [%]",
-        min_value=-5.0, max_value=5.0,
-        value=-1.0 if loading == "compression" else 1.0,
-        step=0.1,
+    strain_mag_pct = st.number_input(
+        "Applied strain magnitude [%]",
+        min_value=0.0, max_value=5.0, value=1.0, step=0.1,
+        help=(
+            "Magnitude only — the sign is taken from the loading mode "
+            "(compression → negative, tension → positive). Editing this "
+            "value is preserved when you toggle the loading mode."
+        ),
     )
+    applied_strain_pct = -strain_mag_pct if loading == "compression" else strain_mag_pct
 
-    st.header("Material & layup")
+    st.markdown("**Material & layup**")
     default_idx = MATERIAL_NAMES.index("IM7_8552") if "IM7_8552" in MATERIAL_NAMES else 0
     material_name = st.selectbox("Material", MATERIAL_NAMES, index=default_idx)
     ply_thickness = st.number_input(
         "Ply thickness [mm]",
         min_value=0.05, max_value=1.0, value=0.183, step=0.01,
+        help=(
+            "Thickness of one ply in mm. Default 0.183 mm matches "
+            "CYCOM X850/T800. Total laminate thickness = ply_thickness × "
+            "number of plies in the layup."
+        ),
     )
     layup_str = st.text_area(
         "Layup (comma-separated angles in degrees)",
@@ -152,9 +173,28 @@ with st.sidebar:
                 "much faster but no FE outputs."
             ),
         )
-        nx = st.number_input("Mesh divisions in x", 4, 64, 12, 2)
-        ny = st.number_input("Mesh divisions in y", 4, 32, 6, 2)
-        nz_per_ply = st.number_input("Mesh divisions per ply (z)", 1, 4, 1)
+        nx = st.number_input(
+            "Mesh divisions in x", 4, 64, 12, 2,
+            help=(
+                "Hex elements along the wrinkle (x) direction across the "
+                "domain length. More elements resolve the curvature but "
+                "scale solve time roughly linearly."
+            ),
+        )
+        ny = st.number_input(
+            "Mesh divisions in y", 4, 32, 6, 2,
+            help=(
+                "Hex elements across the laminate width (y). Wrinkle is "
+                "uniform in y, so a coarse mesh is usually adequate."
+            ),
+        )
+        nz_per_ply = st.number_input(
+            "Mesh divisions per ply (z)", 1, 4, 1,
+            help=(
+                "Hex elements through the thickness of every individual "
+                "ply. Increase to capture interlaminar stress gradients."
+            ),
+        )
         if not analytical_only:
             st.caption(
                 ":hourglass_flowing_sand: Full FE solve. On Streamlit "
@@ -201,10 +241,55 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         analytical_only=cfg_dict["analytical_only"],
     )
     result = WrinkleAnalysis(cfg).run(analytical_only=cfg_dict["analytical_only"])
+
+    fe: dict | None = None
+    if not cfg_dict["analytical_only"] and result.field_results is not None:
+        max_disp_mm, _ = result.field_results.max_displacement()
+        rep = result.failure_report
+        ply_fi: dict[str, list[float]] = {}
+        if rep is not None and getattr(rep, "ply_failure_indices", None):
+            ply_fi = {
+                k: [float(v) for v in np.asarray(arr).ravel().tolist()]
+                for k, arr in rep.ply_failure_indices.items()
+            }
+        fe = {
+            "modulus_retention": float(result.modulus_retention),
+            "retention_factors": {
+                k: float(v) for k, v in (result.retention_factors or {}).items()
+            },
+            "baseline_fi": {
+                k: float(v) for k, v in (result.baseline_fi or {}).items()
+            },
+            "n_nodes": int(result.mesh.n_nodes) if result.mesh else None,
+            "n_elements": int(result.mesh.n_elements) if result.mesh else None,
+            "max_displacement_mm": float(max_disp_mm),
+            "critical_criterion": getattr(rep, "critical_criterion", None),
+            "critical_mode": getattr(rep, "critical_mode", None),
+            "critical_ply": (
+                int(rep.critical_ply)
+                if rep is not None and getattr(rep, "critical_ply", None) is not None
+                else None
+            ),
+            "ply_failure_indices": ply_fi,
+        }
+
     return {
         "summary": result.summary(),
+        "loading": cfg_dict["loading"],
+        "applied_strain_abs": float(cfg_dict["applied_strain"]),
         "max_angle_deg": float(np.degrees(result.max_angle_rad)),
+        "effective_angle_deg": float(np.degrees(result.effective_angle_rad)),
+        "morphology_factor": float(result.morphology_factor),
+        "gamma_Y_eff": float(result.gamma_Y_eff),
         "analytical_knockdown": float(result.analytical_knockdown),
+        "analytical_strength_MPa": float(result.analytical_strength_MPa),
+        "damage_index": float(result.damage_index),
+        "tension_mechanisms": (
+            {k: float(v) if isinstance(v, (int, float, np.floating)) else v
+             for k, v in result.tension_mechanisms.items()}
+            if result.tension_mechanisms else None
+        ),
+        "fe": fe,
     }
 
 
@@ -214,27 +299,10 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
 
 profile = GaussianSinusoidal(amplitude=amplitude, wavelength=wavelength, width=width)
 
-tab_geom, tab_results, tab_export = st.tabs(["Geometry", "Results", "Export"])
 
-with tab_geom:
-    st.subheader("Wrinkle mid-surface profile")
-    x = np.linspace(-3 * width, 3 * width, 800)
-    z = profile.displacement(x)
-    fig, ax = plt.subplots(figsize=(8, 3.2))
-    ax.plot(x, z, color="#1f77b4", linewidth=1.5)
-    ax.axhline(0.0, color="grey", linewidth=0.5)
-    ax.set_xlabel("x [mm]")
-    ax.set_ylabel("z(x) [mm]")
-    ax.set_title(r"$z(x) = A \cdot \exp(-x^2 / w^2) \cdot \cos(2\pi x / \lambda)$")
-    ax.grid(alpha=0.3)
-    st.pyplot(fig, clear_figure=True)
-    st.caption(
-        f"Numerical θ_max = {np.degrees(profile.max_angle()):.2f}°  ·  "
-        f"Closed-form approx arctan(2πA/λ) = "
-        f"{np.degrees(profile.max_angle_approx()):.2f}°"
-    )
-
-
+# Run handler — execute BEFORE tabs render so the Results tab sees the
+# updated session_state and the empty-state placeholder doesn't render
+# alongside the running indicator.
 if run_clicked:
     try:
         layup = parse_layup(layup_str)
@@ -257,16 +325,129 @@ if run_clicked:
         "analytical_only": bool(analytical_only),
     }.items()))
 
-    with st.spinner("Running analysis..."):
+    with st.status("Running analysis…", expanded=True) as status:
+        st.write("Building laminate, wrinkle geometry, and mesh…")
+        if not analytical_only:
+            st.caption(
+                "Use the **Stop** button in the top-right toolbar to "
+                "cancel a long FE solve."
+            )
         try:
             results = run_analysis_cached(cfg_payload)
-        except Exception as exc:
-            st.error(f"Analysis failed: {exc}")
+        except ValueError as exc:
+            status.update(label="Invalid input", state="error", expanded=True)
+            st.error(f"Invalid input: {exc}")
             st.stop()
+        except np.linalg.LinAlgError as exc:
+            status.update(label="FE solve failed", state="error", expanded=True)
+            st.error(
+                "FE matrix is singular. Try increasing the mesh density "
+                "(nx, ny, or nz_per_ply) or check that the layup is "
+                f"symmetric. Underlying error: {exc}"
+            )
+            st.stop()
+        except MemoryError:
+            status.update(label="Out of memory", state="error", expanded=True)
+            st.error(
+                "Out of memory while assembling the FE system. Reduce nx, "
+                "ny, or nz_per_ply, or tick *Analytical only* to skip the "
+                "FE solve."
+            )
+            st.stop()
+        except Exception as exc:
+            status.update(label="Analysis failed", state="error", expanded=True)
+            st.error(f"Analysis failed: {exc}")
+            with st.expander("Traceback"):
+                st.exception(exc)
+            st.stop()
+        st.write("Done.")
+        status.update(label="Analysis complete", state="complete", expanded=False)
 
     st.session_state["results"] = results
     st.session_state["cfg_payload"] = cfg_payload
-    st.success("Analysis complete — see the **Results** tab.")
+
+
+tab_geom, tab_results, tab_export = st.tabs(["Geometry", "Results", "Export"])
+
+with tab_geom:
+    st.subheader("Wrinkle mid-surface profile")
+    x = np.linspace(-3 * width, 3 * width, 800)
+    z = profile.displacement(x)
+    theta_deg = np.degrees(np.arctan(profile.slope(x)))
+    fig, (ax_z, ax_theta) = plt.subplots(
+        2, 1, figsize=(8, 4.6), sharex=True,
+        gridspec_kw={"height_ratios": [1.4, 1.0]},
+    )
+    ax_z.plot(x, z, color="#1f77b4", linewidth=1.5)
+    ax_z.axhline(0.0, color="grey", linewidth=0.5)
+    ax_z.set_ylabel("z(x) [mm]")
+    ax_z.set_title(r"$z(x) = A \cdot \exp(-x^2 / w^2) \cdot \cos(2\pi x / \lambda)$")
+    ax_z.grid(alpha=0.3)
+
+    ax_theta.plot(x, theta_deg, color="#d62728", linewidth=1.2)
+    theta_max_deg = np.degrees(profile.max_angle())
+    ax_theta.axhline(theta_max_deg, color="grey", linestyle="--", linewidth=0.6)
+    ax_theta.axhline(-theta_max_deg, color="grey", linestyle="--", linewidth=0.6)
+    ax_theta.set_xlabel("x [mm]")
+    ax_theta.set_ylabel("θ(x) [deg]")
+    ax_theta.grid(alpha=0.3)
+    fig.tight_layout()
+    st.pyplot(fig, clear_figure=True)
+    st.caption(
+        f"Numerical θ_max = {theta_max_deg:.2f}°  ·  "
+        f"Closed-form approx arctan(2πA/λ) = "
+        f"{np.degrees(profile.max_angle_approx()):.2f}°"
+    )
+
+    if morphology == "graded":
+        try:
+            _angles_preview = parse_layup(layup_str)
+            _n_plies = len(_angles_preview)
+        except Exception:
+            _n_plies = 24
+        with st.expander("Through-thickness amplitude profile", expanded=False):
+            ply_idx = np.arange(_n_plies)
+            p_mid = (_n_plies - 1) / 2.0
+            raw = np.maximum(0.0, 1.0 - np.abs(ply_idx - p_mid) / max(p_mid, 1e-9))
+            decay = decay_floor + (1.0 - decay_floor) * raw
+            fig_d, ax_d = plt.subplots(figsize=(4, 3))
+            ax_d.barh(ply_idx, decay, color="#9467bd")
+            ax_d.set_xlabel("Amplitude fraction")
+            ax_d.set_ylabel("Ply index")
+            ax_d.set_xlim(0, 1.05)
+            ax_d.invert_yaxis()
+            fig_d.tight_layout()
+            st.pyplot(fig_d, clear_figure=True)
+            st.caption(
+                f"Decay floor = {decay_floor:.2f}; surface plies retain "
+                f"{decay_floor*100:.0f}% of the wrinkle-core amplitude."
+            )
+
+    with st.expander("Layup stack visualizer", expanded=False):
+        try:
+            _angles = parse_layup(layup_str)
+        except Exception as e:
+            st.warning(f"Could not parse layup: {e}")
+        else:
+            cmap = plt.get_cmap("twilight")
+            n = len(_angles)
+            fig_l, ax_l = plt.subplots(figsize=(5, max(2.5, 0.18 * n)))
+            for i, a in enumerate(_angles):
+                colour = cmap(((a % 180) + 180) % 180 / 180)
+                ax_l.barh(i, 1.0, color=colour, edgecolor="white", linewidth=0.4)
+                ax_l.text(
+                    0.5, i, f"{int(a):+d}°",
+                    ha="center", va="center", fontsize=8,
+                    color="white" if abs(a) % 180 not in (0, 90) else "black",
+                )
+            ax_l.set_xlim(0, 1)
+            ax_l.set_xticks([])
+            ax_l.set_ylabel("Ply index (top ↓ bottom)")
+            ax_l.set_yticks(range(n))
+            ax_l.invert_yaxis()
+            fig_l.tight_layout()
+            st.pyplot(fig_l, clear_figure=True)
+            st.caption(f"{n} plies · colours hue-mapped on ply angle modulo 180°.")
 
 
 with tab_results:
@@ -274,24 +455,191 @@ with tab_results:
         st.info("Click **Run analysis** in the sidebar to compute results.")
     else:
         r = st.session_state["results"]
-        c1, c2 = st.columns(2)
+
+        st.subheader("Analytical predictions")
+        c1, c2, c3, c4 = st.columns(4)
         c1.metric("Max fibre misalignment", f"{r['max_angle_deg']:.2f}°")
         c2.metric("Analytical knockdown", f"{r['analytical_knockdown']:.3f}")
-        st.subheader("Summary")
+        c3.metric("Predicted strength", f"{r['analytical_strength_MPa']:.1f} MPa")
+        c4.metric("Damage index D", f"{r['damage_index']:.3f}")
+
+        d1, d2, d3 = st.columns(3)
+        d1.metric("Morphology factor M_f", f"{r['morphology_factor']:.3f}")
+        d2.metric("Effective fibre angle θ_eff", f"{r['effective_angle_deg']:.2f}°")
+        d3.metric("Yield strain γ_Y eff", f"{r['gamma_Y_eff']:.4f}")
+
+        if r.get("tension_mechanisms"):
+            with st.expander(
+                "Tension mechanism breakdown", expanded=True
+            ):
+                tm = r["tension_mechanisms"]
+                bar_keys = [k for k in ("kd_fiber", "kd_matrix", "kd_oop")
+                            if isinstance(tm.get(k), (int, float))]
+                if bar_keys:
+                    fig_tm, ax_tm = plt.subplots(figsize=(5, 2.6))
+                    ax_tm.bar(
+                        [k.replace("kd_", "") for k in bar_keys],
+                        [tm[k] for k in bar_keys],
+                        color=["#1f77b4", "#ff7f0e", "#2ca02c"],
+                    )
+                    ax_tm.set_ylabel("Knockdown contribution")
+                    ax_tm.set_ylim(0, max(1.05, max(tm[k] for k in bar_keys) * 1.1))
+                    ax_tm.axhline(1.0, color="grey", linestyle="--", linewidth=0.6)
+                    ax_tm.grid(axis="y", alpha=0.3)
+                    fig_tm.tight_layout()
+                    st.pyplot(fig_tm, clear_figure=True)
+                if tm.get("mode"):
+                    st.markdown(f"Controlling mechanism: **{tm['mode']}**")
+                rest = {k: v for k, v in tm.items()
+                        if k not in {"kd_fiber", "kd_matrix", "kd_oop", "mode"}}
+                if rest:
+                    st.json(rest)
+
+        fe = r.get("fe")
+        if fe is not None:
+            st.subheader("FE solution")
+            f1, f2, f3 = st.columns(3)
+            f1.metric("Modulus retention", f"{fe['modulus_retention']:.3f}")
+            worst = (
+                min(fe["retention_factors"].values())
+                if fe["retention_factors"] else None
+            )
+            f2.metric(
+                "Strength retention (worst criterion)",
+                f"{worst:.3f}" if worst is not None else "—",
+            )
+            f3.metric("Max displacement", f"{fe['max_displacement_mm']:.4f} mm")
+
+            if fe["retention_factors"]:
+                st.markdown("**Strength retention by failure criterion**")
+                crits = list(fe["retention_factors"].keys())
+                ret_vals = [fe["retention_factors"][c] for c in crits]
+                base_vals = [fe["baseline_fi"].get(c) for c in crits]
+                fig_ret, ax_ret = plt.subplots(
+                    figsize=(7, max(1.6, 0.55 * len(crits) + 1.0))
+                )
+                y = np.arange(len(crits))
+                ax_ret.barh(y, ret_vals, color="#2ca02c",
+                            label="Retention (wrinkled / pristine)")
+                ax_ret.axvline(1.0, color="grey", linestyle="--", linewidth=0.8)
+                ax_ret.set_yticks(y)
+                ax_ret.set_yticklabels(crits)
+                ax_ret.set_xlabel("Retention")
+                ax_ret.set_xlim(0, max(1.05, max(ret_vals) * 1.1))
+                ax_ret.grid(axis="x", alpha=0.3)
+                fig_ret.tight_layout()
+                st.pyplot(fig_ret, clear_figure=True)
+                if any(b is not None for b in base_vals):
+                    base_table = {
+                        c: {
+                            "retention": ret_vals[i],
+                            "pristine max FI": base_vals[i],
+                        }
+                        for i, c in enumerate(crits)
+                    }
+                    with st.expander("Per-criterion details", expanded=False):
+                        st.table(base_table)
+
+            if fe.get("ply_failure_indices"):
+                st.markdown("**Per-ply failure index**")
+                pf = fe["ply_failure_indices"]
+                crit_for_plot = (
+                    fe.get("critical_criterion")
+                    if fe.get("critical_criterion") in pf
+                    else next(iter(pf))
+                )
+                fi_arr = np.asarray(pf[crit_for_plot], dtype=float)
+                colours = [
+                    "#d62728" if i == fe.get("critical_ply") else "#1f77b4"
+                    for i in range(len(fi_arr))
+                ]
+                fig_fi, ax_fi = plt.subplots(figsize=(7, 3))
+                ax_fi.bar(range(len(fi_arr)), fi_arr, color=colours)
+                ax_fi.axhline(1.0, color="grey", linestyle="--", linewidth=0.6)
+                ax_fi.set_xlabel("Ply index")
+                ax_fi.set_ylabel(f"FI ({crit_for_plot})")
+                fig_fi.tight_layout()
+                st.pyplot(fig_fi, clear_figure=True)
+                st.caption(
+                    "Critical ply highlighted in red. FI ≥ 1 indicates "
+                    "failure of that ply under the applied strain."
+                )
+
+            crit = fe.get("critical_criterion")
+            if crit:
+                pieces = [f"criterion `{crit}`"]
+                if fe.get("critical_mode"):
+                    pieces.append(f"mode `{fe['critical_mode']}`")
+                if fe.get("critical_ply") is not None:
+                    pieces.append(f"first failing ply index `{fe['critical_ply']}`")
+                st.markdown("**Critical failure:** " + ", ".join(pieces))
+
+            with st.expander("Mesh statistics"):
+                st.write(
+                    f"Nodes: **{fe['n_nodes']:,}**  ·  "
+                    f"Elements: **{fe['n_elements']:,}**"
+                )
+        else:
+            st.info(
+                "FE outputs are hidden because the run used **Analytical "
+                "only**. Untick that option in the sidebar's *Advanced* "
+                "panel and re-run to see modulus and strength retention."
+            )
+
+        st.subheader("Full text summary")
         st.text(r["summary"])
 
 with tab_export:
     if "results" not in st.session_state:
         st.info("Run an analysis to enable export.")
     else:
+        try:
+            _wrinklefe_version = version("wrinklefe")
+        except PackageNotFoundError:
+            _wrinklefe_version = "0.0.0+unknown"
+
         payload = {
+            "meta": {
+                "wrinklefe_version": _wrinklefe_version,
+                "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            },
             "config": dict(st.session_state["cfg_payload"]),
             "results": st.session_state["results"],
         }
         payload["config"]["angles"] = list(payload["config"].pop("angles_tuple"))
+
         st.download_button(
             "Download results as JSON",
             data=json.dumps(payload, indent=2).encode(),
             file_name="wrinklefe_results.json",
             mime="application/json",
+        )
+
+        fe = st.session_state["results"].get("fe")
+        if fe and fe.get("retention_factors"):
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(
+                ["criterion", "retention_factor",
+                 "pristine_max_fi", "wrinkled_max_fi"]
+            )
+            for crit, ret in fe["retention_factors"].items():
+                base = fe.get("baseline_fi", {}).get(crit)
+                wrinkled = (base / ret) if (base is not None and ret) else None
+                writer.writerow([
+                    crit,
+                    f"{ret:.6g}",
+                    f"{base:.6g}" if base is not None else "",
+                    f"{wrinkled:.6g}" if wrinkled is not None else "",
+                ])
+            st.download_button(
+                "Download retention factors as CSV",
+                data=buf.getvalue().encode(),
+                file_name="wrinklefe_retention.csv",
+                mime="text/csv",
+            )
+
+        st.caption(
+            f"WrinkleFE {_wrinklefe_version} · "
+            f"export timestamp {payload['meta']['timestamp_utc']}"
         )


### PR DESCRIPTION
## Summary
Closes the gap left by PR #57 (the FE-rendering follow-up commit was not picked up at merge) and applies the consolidated must-fix / should-have items from a 5-agent UX audit.

### Bug fix
- **Empty-state vs running-state overlap.** Hoist the run handler above `st.tabs()` so the Results tab no longer renders "Click Run analysis…" alongside the running indicator.

### Results tab
- 4 analytical metrics + 3 morphology-context metrics (M_f, θ_eff, γ_Y eff) + 3 FE metrics (modulus retention, worst-case strength retention, max displacement).
- Per-criterion **strength-retention bar chart** with `baseline_fi` exposed in a "Per-criterion details" expander.
- Per-ply **failure-index bar chart** with the critical ply highlighted.
- **Tension mechanism breakdown** expander (only when `loading == tension`) — `kd_fiber` / `kd_matrix` / `kd_oop` bars + controlling mechanism mode.
- Critical-failure callout and mesh-statistics expander.

### Geometry tab
- New **θ(x) subplot** in degrees beneath the mid-surface profile with θ_max guide lines.
- New **decay-floor preview** expander for the `graded` morphology.
- New **layup stack visualizer** expander, plies coloured by angle mod 180°.

### Sidebar / inputs
- `st.header` → bold-markdown subsection labels (audit IA #2).
- `help=` tooltips added to wavelength, envelope width, ply thickness, mesh divisions (audit IA #5).
- Loading-mode toggle no longer overwrites the applied-strain value (audit IA #8).

### Status / error handling
- `st.spinner` → `st.status` with phase markers, completing/erroring cleanly (audit perf #2).
- Specific handlers for `ValueError`, `np.linalg.LinAlgError`, `MemoryError`; final catch-all renders the traceback in an expander (audit perf #3).

### Export tab
- Provenance metadata (`wrinklefe_version`, UTC timestamp) in the JSON.
- Cached results dict expanded with `applied_strain_abs`, `effective_angle_deg`, `morphology_factor`, `gamma_Y_eff`, `tension_mechanisms`, and full FE outputs.
- New **per-criterion retention CSV** download.

### Deliberately deferred (out of scope)
- Dual-wrinkle plot construction, σ_33 contour heatmap, URL-as-config sharing, "Copy as Python" snippet, mesh CSV / VTK / npz dumps, BibTeX block.

## Test plan
- [x] `AppTest` initial render: no exceptions, default values render
- [x] `AppTest` Run analysis (compression default): 10 metrics rendered, no exceptions, status completes cleanly
- [x] `AppTest` Run analysis (loading=tension): tension-mechanism expander appears, knockdown 0.828, strength 1925 MPa
- [ ] After deploy: verify per-ply FI chart highlights the critical ply; verify decay-floor preview updates with the slider; verify layup visualizer renders 24 colour-coded plies; verify CSV download returns 1 row per criterion

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqPXSVeaEy65GfNVfAm5NZ)_