### PR TITLE
Add Plotly-based 3D FE viz (stress contour, deformed mesh, FI, y-slice)

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,8 @@ from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 
+import streamlit_viz
+
 
 # ---------------------------------------------------------------------------
 # Page config
@@ -252,6 +254,16 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
                 k: [float(v) for v in np.asarray(arr).ravel().tolist()]
                 for k, arr in rep.ply_failure_indices.items()
             }
+        mesh = result.mesh
+        fr = result.field_results
+        nodes_arr = np.asarray(mesh.nodes, dtype=np.float64)
+        elements_arr = np.asarray(mesh.elements, dtype=np.int64)
+        stress_per_elem = np.asarray(fr.stress_local).mean(axis=1)
+        element_centers = nodes_arr[elements_arr].mean(axis=1)
+        fi_per_gauss = {
+            k: np.asarray(v, dtype=np.float64)
+            for k, v in (result.failure_indices or {}).items()
+        }
         fe = {
             "modulus_retention": float(result.modulus_retention),
             "retention_factors": {
@@ -260,8 +272,8 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             "baseline_fi": {
                 k: float(v) for k, v in (result.baseline_fi or {}).items()
             },
-            "n_nodes": int(result.mesh.n_nodes) if result.mesh else None,
-            "n_elements": int(result.mesh.n_elements) if result.mesh else None,
+            "n_nodes": int(mesh.n_nodes),
+            "n_elements": int(mesh.n_elements),
             "max_displacement_mm": float(max_disp_mm),
             "critical_criterion": getattr(rep, "critical_criterion", None),
             "critical_mode": getattr(rep, "critical_mode", None),
@@ -271,6 +283,14 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
                 else None
             ),
             "ply_failure_indices": ply_fi,
+            # Numpy arrays for the 3D viz. Stripped from the JSON export.
+            "nodes": nodes_arr,
+            "elements": elements_arr,
+            "ply_ids": np.asarray(mesh.ply_ids, dtype=np.int64),
+            "displacement": np.asarray(fr.displacement, dtype=np.float64),
+            "stress_per_elem": stress_per_elem,
+            "element_centers": element_centers,
+            "fi_per_gauss": fi_per_gauss,
         }
 
     return {
@@ -574,6 +594,101 @@ with tab_results:
                     pieces.append(f"first failing ply index `{fe['critical_ply']}`")
                 st.markdown("**Critical failure:** " + ", ".join(pieces))
 
+            if (
+                isinstance(fe.get("nodes"), np.ndarray)
+                and isinstance(fe.get("elements"), np.ndarray)
+            ):
+                st.subheader("3D field viz")
+                st.caption(
+                    "Drag to rotate, scroll to zoom. Sliders below the plot "
+                    "re-render in milliseconds (the FE solve is cached)."
+                )
+                STRESS_COMPONENTS = [
+                    (0, "σ₁₁"), (1, "σ₂₂"), (2, "σ₃₃"),
+                    (3, "τ₂₃"), (4, "τ₁₃"), (5, "τ₁₂"),
+                ]
+                view_mode = st.radio(
+                    "View mode",
+                    ["Stress contour", "Deformed mesh", "Failure index"],
+                    horizontal=True,
+                    key="viz_view_mode",
+                )
+                if view_mode == "Stress contour":
+                    comp = st.selectbox(
+                        "Stress component (Voigt)",
+                        STRESS_COMPONENTS,
+                        index=2,
+                        format_func=lambda t: t[1],
+                        key="viz_stress_component",
+                    )
+                    fig_3d = streamlit_viz.stress_contour_figure(
+                        fe["nodes"], fe["elements"], fe["stress_per_elem"],
+                        component_index=comp[0],
+                        component_label=comp[1],
+                    )
+                    st.plotly_chart(fig_3d, use_container_width=True)
+                elif view_mode == "Deformed mesh":
+                    scale = st.slider(
+                        "Deformation exaggeration",
+                        1.0, 200.0, 50.0, 1.0,
+                        key="viz_deformation_scale",
+                        help=(
+                            "FE displacements are ~10⁻³ mm, far below the "
+                            "mesh dimensions. Multiply by this factor to "
+                            "make the deformation visible."
+                        ),
+                    )
+                    fig_3d = streamlit_viz.deformed_mesh_figure(
+                        fe["nodes"], fe["elements"], fe["displacement"],
+                        scale=scale,
+                    )
+                    st.plotly_chart(fig_3d, use_container_width=True)
+                else:
+                    fi_dict = fe.get("fi_per_gauss", {})
+                    fi_keys = list(fi_dict.keys())
+                    if not fi_keys:
+                        st.info("No per-gauss failure indices were captured.")
+                    else:
+                        crit_for_3d = st.selectbox(
+                            "Failure criterion",
+                            fi_keys,
+                            index=(
+                                fi_keys.index(fe.get("critical_criterion"))
+                                if fe.get("critical_criterion") in fi_keys else 0
+                            ),
+                            key="viz_fi_criterion",
+                        )
+                        fig_3d = streamlit_viz.fi_3d_figure(
+                            fe["nodes"], fe["elements"],
+                            fi_dict[crit_for_3d], crit_for_3d,
+                        )
+                        st.plotly_chart(fig_3d, use_container_width=True)
+
+                st.markdown("**y-slice scrubber**")
+                y_centers = fe["element_centers"][:, 1]
+                y_unique = np.unique(y_centers)
+                if y_unique.size > 1:
+                    y_station = st.select_slider(
+                        "y-station [mm]",
+                        options=[float(y) for y in y_unique],
+                        value=float(y_unique[len(y_unique) // 2]),
+                        key="viz_y_station",
+                    )
+                    slice_comp = st.selectbox(
+                        "Slice stress component",
+                        STRESS_COMPONENTS,
+                        index=2,
+                        format_func=lambda t: t[1],
+                        key="viz_slice_component",
+                    )
+                    fig_slice = streamlit_viz.y_slice_figure(
+                        fe["element_centers"], fe["elements"], fe["nodes"],
+                        fe["stress_per_elem"], slice_comp[0], y_station,
+                        component_label=slice_comp[1],
+                    )
+                    if fig_slice is not None:
+                        st.plotly_chart(fig_slice, use_container_width=True)
+
             with st.expander("Mesh statistics"):
                 st.write(
                     f"Nodes: **{fe['n_nodes']:,}**  ·  "
@@ -598,13 +713,26 @@ with tab_export:
         except PackageNotFoundError:
             _wrinklefe_version = "0.0.0+unknown"
 
+        def _strip_arrays(obj):
+            """Drop numpy arrays so the JSON export stays small. Arrays
+            are only useful for the in-app 3D viz."""
+            if isinstance(obj, dict):
+                return {
+                    k: _strip_arrays(v)
+                    for k, v in obj.items()
+                    if not isinstance(v, np.ndarray)
+                }
+            if isinstance(obj, list):
+                return [_strip_arrays(v) for v in obj]
+            return obj
+
         payload = {
             "meta": {
                 "wrinklefe_version": _wrinklefe_version,
                 "timestamp_utc": datetime.now(timezone.utc).isoformat(),
             },
             "config": dict(st.session_state["cfg_payload"]),
-            "results": st.session_state["results"],
+            "results": _strip_arrays(st.session_state["results"]),
         }
         payload["config"]["angles"] = list(payload["config"].pop("angles_tuple"))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ matplotlib>=3.9,<4
 
 # --- Web app ---
 streamlit>=1.32
+plotly>=5.18

--- a/streamlit_viz.py
+++ b/streamlit_viz.py
@@ -1,0 +1,278 @@
+"""Plotly viz helpers for the WrinkleFE Streamlit app.
+
+Renders the boundary surface of a structured hex mesh as a Plotly Mesh3d,
+optionally deformed by the FE displacement field, coloured by a
+per-element scalar (e.g. sigma_33 or max failure index). Also provides
+a 2D y-slice scatter and a per-criterion failure-index heatmap.
+
+All functions are pure: they take numpy arrays + parameters and return
+a plotly.graph_objects.Figure. The Streamlit app is responsible for
+caching the FE arrays and wiring sliders to function arguments.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import plotly.graph_objects as go
+
+
+# Local node indices for the 6 faces of a hex element following the
+# CGNS / VTK_HEXAHEDRON convention used by wrinklefe.core.mesh:
+#   nodes 0-3: bottom face (z low) CCW from below
+#   nodes 4-7: top face (z high) CCW from above, parallel to bottom
+HEX_FACES: np.ndarray = np.array(
+    [
+        [0, 1, 2, 3],  # z-low
+        [4, 5, 6, 7],  # z-high
+        [0, 1, 5, 4],  # y-low
+        [3, 2, 6, 7],  # y-high
+        [0, 3, 7, 4],  # x-low
+        [1, 2, 6, 5],  # x-high
+    ],
+    dtype=np.int64,
+)
+
+
+def boundary_faces(elements: np.ndarray) -> np.ndarray:
+    """Boundary faces of a hex mesh, with parent element id.
+
+    Returns
+    -------
+    (n_boundary_faces, 5) array. Columns 0-3 are global node indices in
+    the element's local face ordering; column 4 is the parent element id.
+    """
+    face_owners: dict[tuple[int, ...], list[tuple[int, int]]] = {}
+    for ei in range(elements.shape[0]):
+        conn = elements[ei]
+        for fi, face in enumerate(HEX_FACES):
+            key = tuple(sorted(int(v) for v in conn[face]))
+            face_owners.setdefault(key, []).append((ei, fi))
+
+    out: list[list[int]] = []
+    for owners in face_owners.values():
+        if len(owners) == 1:
+            ei, fi = owners[0]
+            face = HEX_FACES[fi]
+            out.append([int(elements[ei][n]) for n in face] + [ei])
+    return np.asarray(out, dtype=np.int64)
+
+
+def quads_to_triangles(quad_faces: np.ndarray) -> np.ndarray:
+    """Split each quad (4 nodes + parent elem id) into two triangles.
+
+    Each input row is [n0, n1, n2, n3, ei]. Output has 2 rows per input,
+    each [na, nb, nc, ei], split along the n0-n2 diagonal.
+    """
+    n = quad_faces.shape[0]
+    tri = np.empty((n * 2, 4), dtype=np.int64)
+    tri[0::2, 0] = quad_faces[:, 0]
+    tri[0::2, 1] = quad_faces[:, 1]
+    tri[0::2, 2] = quad_faces[:, 2]
+    tri[0::2, 3] = quad_faces[:, 4]
+    tri[1::2, 0] = quad_faces[:, 0]
+    tri[1::2, 1] = quad_faces[:, 2]
+    tri[1::2, 2] = quad_faces[:, 3]
+    tri[1::2, 3] = quad_faces[:, 4]
+    return tri
+
+
+def _scene_layout() -> dict:
+    return dict(
+        xaxis_title="x [mm]",
+        yaxis_title="y [mm]",
+        zaxis_title="z [mm]",
+        aspectmode="data",
+    )
+
+
+def mesh3d_figure(
+    vertices: np.ndarray,
+    elements: np.ndarray,
+    *,
+    cell_scalar: np.ndarray | None = None,
+    vertex_scalar: np.ndarray | None = None,
+    colorscale: str = "Viridis",
+    colorbar_title: str = "",
+    title: str = "",
+    symmetric: bool = False,
+    height: int = 480,
+) -> go.Figure:
+    """Render the boundary surface of a hex mesh as a Plotly Mesh3d.
+
+    Pass ``cell_scalar`` (one value per element) for FE field data like
+    sigma_33 or max FI; pass ``vertex_scalar`` (one value per node) for
+    per-node fields like displacement magnitude.
+    """
+    bf = boundary_faces(elements)
+    tri = quads_to_triangles(bf)
+
+    kwargs: dict = dict(
+        x=vertices[:, 0],
+        y=vertices[:, 1],
+        z=vertices[:, 2],
+        i=tri[:, 0],
+        j=tri[:, 1],
+        k=tri[:, 2],
+        flatshading=True,
+    )
+    if cell_scalar is not None:
+        intensity = np.asarray(cell_scalar)[tri[:, 3]]
+        kwargs.update(
+            intensity=intensity,
+            intensitymode="cell",
+            colorscale=colorscale,
+            colorbar=dict(title=colorbar_title, len=0.7),
+            showscale=True,
+        )
+        if symmetric:
+            vmax = float(np.nanmax(np.abs(intensity)))
+            if vmax > 0:
+                kwargs.update(cmin=-vmax, cmax=vmax)
+    elif vertex_scalar is not None:
+        kwargs.update(
+            intensity=np.asarray(vertex_scalar),
+            intensitymode="vertex",
+            colorscale=colorscale,
+            colorbar=dict(title=colorbar_title, len=0.7),
+            showscale=True,
+        )
+    else:
+        kwargs.update(color="#9ec5fe", showscale=False)
+
+    fig = go.Figure(go.Mesh3d(**kwargs))
+    fig.update_layout(
+        title=title,
+        scene=_scene_layout(),
+        margin=dict(l=0, r=0, t=40, b=0),
+        height=height,
+    )
+    return fig
+
+
+def stress_contour_figure(
+    nodes: np.ndarray,
+    elements: np.ndarray,
+    stress_per_elem: np.ndarray,
+    component_index: int = 2,
+    *,
+    component_label: str = "σ₃₃",
+    title: str | None = None,
+) -> go.Figure:
+    """3D surface mesh coloured by a single Voigt stress component."""
+    scalar = stress_per_elem[:, component_index]
+    return mesh3d_figure(
+        nodes,
+        elements,
+        cell_scalar=scalar,
+        colorscale="RdBu_r",
+        colorbar_title=f"{component_label} [MPa]",
+        title=title or f"{component_label} surface contour",
+        symmetric=True,
+    )
+
+
+def deformed_mesh_figure(
+    nodes: np.ndarray,
+    elements: np.ndarray,
+    displacement: np.ndarray,
+    *,
+    scale: float = 10.0,
+) -> go.Figure:
+    """3D deformed mesh coloured by displacement magnitude."""
+    deformed = nodes + scale * displacement
+    disp_mag = np.linalg.norm(displacement, axis=1)
+    return mesh3d_figure(
+        deformed,
+        elements,
+        vertex_scalar=disp_mag,
+        colorscale="Viridis",
+        colorbar_title="|u| [mm]",
+        title=f"Deformed mesh (×{scale:g} exaggeration)",
+    )
+
+
+def fi_3d_figure(
+    nodes: np.ndarray,
+    elements: np.ndarray,
+    fi_per_gauss: np.ndarray,
+    criterion: str,
+) -> go.Figure:
+    """3D surface mesh coloured by per-element max failure index."""
+    fi_max = np.asarray(fi_per_gauss).max(axis=1)
+    return mesh3d_figure(
+        nodes,
+        elements,
+        cell_scalar=fi_max,
+        colorscale="Reds",
+        colorbar_title=f"FI ({criterion})",
+        title=f"Failure index — {criterion}",
+    )
+
+
+def y_slice_figure(
+    element_centers: np.ndarray,
+    elements: np.ndarray,
+    nodes: np.ndarray,
+    stress_per_elem: np.ndarray,
+    component_index: int,
+    y_station: float,
+    *,
+    component_label: str = "σ₃₃",
+) -> go.Figure | None:
+    """Filter elements at the given y-station and render a 2D scatter
+    in the (x, z) plane coloured by the chosen stress component.
+
+    The 'slice' is the layer of elements whose y-row matches the station;
+    we pick the elements whose centre-y is closest to the station to
+    avoid empty slices on coarse meshes.
+    """
+    yc = element_centers[:, 1]
+    unique_y = np.unique(yc)
+    if unique_y.size == 0:
+        return None
+    nearest_y = unique_y[np.argmin(np.abs(unique_y - y_station))]
+    mask = yc == nearest_y
+    if not mask.any():
+        return None
+
+    xs = element_centers[mask, 0]
+    zs = element_centers[mask, 2]
+    vals = stress_per_elem[mask, component_index]
+    vmax = float(np.nanmax(np.abs(vals))) if vals.size else 1.0
+
+    # Approximate per-element x and z extents from the bounding box of
+    # its 8 nodes so the rectangular markers tile cleanly.
+    elem_node_xyz = nodes[elements[mask]]
+    dx = float(np.ptp(elem_node_xyz[:, :, 0], axis=1).mean()) if mask.sum() else 1.0
+    dz = float(np.ptp(elem_node_xyz[:, :, 2], axis=1).mean()) if mask.sum() else 1.0
+
+    fig = go.Figure(
+        go.Scatter(
+            x=xs,
+            y=zs,
+            mode="markers",
+            marker=dict(
+                size=14,
+                color=vals,
+                colorscale="RdBu_r",
+                cmin=-vmax,
+                cmax=vmax,
+                symbol="square",
+                line=dict(width=0),
+                colorbar=dict(title=f"{component_label} [MPa]"),
+            ),
+            hovertemplate=(
+                f"x = %{{x:.2f}} mm<br>z = %{{y:.3f}} mm"
+                f"<br>{component_label} = %{{marker.color:.1f}} MPa<extra></extra>"
+            ),
+        )
+    )
+    fig.update_layout(
+        title=f"{component_label} at y ≈ {nearest_y:.2f} mm  ·  Δx≈{dx:.2f} mm  Δz≈{dz:.3f} mm",
+        xaxis_title="x [mm]",
+        yaxis_title="z [mm]",
+        height=360,
+        margin=dict(l=10, r=10, t=50, b=10),
+    )
+    fig.update_yaxes(scaleanchor="x", scaleratio=1)
+    return fig


### PR DESCRIPTION
## Summary
Adds an interactive 3D FE field visualizer to the Results tab — Plotly `Mesh3d` for the boundary surface, plus a 2D y-slice scrubber — on top of the existing scalar metrics.

### Library choice
- **Plotly** (`Mesh3d` + `Scatter` via `st.plotly_chart`). Pure JavaScript, no apt-package or display dependencies. The 1728-element default mesh renders comfortably client-side.
- **stpyvista was deferred**: it requires `xvfb` in `packages.txt` and `pyvista`/`vtk` in `requirements.txt`, with a bigger deploy blast radius. Worth revisiting if Plotly stops being enough.

### New module `streamlit_viz.py`
- `boundary_faces` / `quads_to_triangles` — extract the outer surface of a hex mesh by counting face occurrences (boundary faces appear once, interior faces twice).
- `mesh3d_figure` — generic Plotly `Mesh3d` builder with cell- or vertex-mode intensity and `aspectmode="data"`.
- `stress_contour_figure` — surface coloured by a single Voigt stress component (defaults to σ₃₃, symmetric RdBu_r).
- `deformed_mesh_figure` — surface deformed by `displacement * scale`, vertex-coloured by `|u|`.
- `fi_3d_figure` — surface coloured by per-element max failure index for the chosen criterion.
- `y_slice_figure` — filters elements at the y-row nearest the requested station and renders a 2D `(x, z)` scatter.

### Cache & data flow
- `run_analysis_cached` now caches the FE field arrays alongside scalar fields. Total ~460 kB for the default mesh — well within Streamlit's cache budget.
- Switching view modes or dragging the deformation / y-station / component sliders re-renders the figure only; the FE solve stays cached.

### Results tab
- New **"3D field viz"** subsection (only shown when an FE solve has produced field_results) with a horizontal radio for **Stress contour / Deformed mesh / Failure index**. Each mode surfaces the relevant control: Voigt component selector, deformation-scale slider (1×–200×), or criterion selector.
- New **"y-slice scrubber"** beneath the 3D plot using `st.select_slider` over the discrete y-rows of the mesh.

### Export tab
- Numpy arrays are now stripped from the JSON payload via a recursive `_strip_arrays` helper so the download stays small — the arrays are only useful for the in-app viz.

### Dependencies
- `plotly>=5.18` added to `requirements.txt`.

## Test plan
- [x] AppTest initial render: no exceptions
- [x] AppTest Run analysis (compression default): 2 plotly charts render (3D + slice), no exceptions
- [x] AppTest switch view mode → Failure index: no exceptions
- [x] AppTest switch view mode → Deformed mesh: deformation-scale slider appears with default 50×, no exceptions
- [ ] After deploy: rotate/zoom on the 3D Mesh3d works in the browser; switching components / criteria / y-station re-renders in <100ms; JSON download still parses

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqPXSVeaEy65GfNVfAm5NZ)_