### PR TITLE
Fix CITATION.cff URL and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ title: "WrinkleFE"
 version: 1.0.0
 date-released: 2025-03-24
 license: MIT
-repository-code: "https://github.com/elhajjar1/WrinkleFE"
-url: "https://github.com/elhajjar1/WrinkleFE"
+repository-code: "https://github.com/ranipdx-glitch/wrinkleFE"
+url: "https://github.com/ranipdx-glitch/wrinkleFE"
 abstract: >-
   WrinkleFE is a Python finite element package for predicting strength
   and stiffness knockdown in composite laminates containing fiber waviness


### PR DESCRIPTION
Two committable items from the public-repo audit (#61–#65). The other three audit issues (#61 commit-email hygiene, #63 wiki, #64 branch protection) require GitHub Settings UI changes and are tracked separately — #63 and #64 are already closed.

## Changes

- **`CITATION.cff`**: `repository-code` and `url` now point at `https://github.com/ranipdx-glitch/wrinkleFE` instead of the obsolete `elhajjar1/WrinkleFE`. Closes #62.
- **`.github/dependabot.yml`** *(new)*: weekly grouped updates for two ecosystems, capped at 5 open PRs each:
  - `pip` at repo root (covers `requirements.txt`, `requirements-test.txt`, `pyproject.toml`)
  - `github-actions` (the three workflows under `.github/workflows/`)

  Closes the config half of #65. The "enable Dependabot security alerts" toggle in Settings → Code security still has to be flipped manually.

## Background

This commit was originally pushed onto the morphology-icon feature branch but PR #60 was merged at the prior SHA, leaving these two changes orphaned. Re-cherry-picked onto a clean branch off current `main` so the diff is minimal.

## Test plan

- [ ] CI (`tests` + `ci`) passes on the PR
- [ ] After merge, confirm Dependabot picks up the config (a "Dependabot opened a PR" event within ~24h, or visit the [Insights → Dependency graph → Dependabot](https://github.com/ranipdx-glitch/wrinkleFE/network/updates) tab)

https://claude.ai/code/session_01TuPJ13ASL4YBSSfVaD3v39

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuPJ13ASL4YBSSfVaD3v39)_