### PR TITLE
Streamlit: show selected-morphology schematic under the selectbox

### DIFF
--- a/app.py
+++ b/app.py
@@ -346,6 +346,12 @@ with st.sidebar:
             help="Minimum amplitude fraction at the outer surfaces.",
         )
 
+    st.image(
+        _morphology_schematic(morphology),
+        caption=f"{morphology.capitalize()} morphology",
+        use_container_width=True,
+    )
+
     loading = st.radio("Loading mode", ["compression", "tension"], horizontal=True)
     strain_mag_pct = st.number_input(
         "Applied strain magnitude [%]",


### PR DESCRIPTION
## Summary
Render the cartoon for the currently-selected morphology directly below the dropdown so users get immediate visual feedback on their pick without having to open the `?` popover.

This reuses the `_morphology_schematic` helper that PR #60 added to `app.py` — the same five-cartoon set that currently lives inside the popover. The popover stays as the all-five reference; this just exposes the active one inline.

## Why this PR exists
PR #66 was merged at `91006f9`. While that branch was waiting to merge, PR #60 (`65627fc`) landed `_morphology_schematic` and the `?` popover on `main`. The earlier draft of this PR tried to ship a separate hand-rolled morphology thumbnail and conflicted with #60. The branch has been reset to current `main`; it now contains a single 6-line addition that calls the existing helper.

## Test plan
- [ ] `streamlit run app.py` locally; cycle through Stack / Convex / Concave / Uniform / Graded and confirm the schematic under the selectbox updates.
- [ ] Open the `?` popover and confirm it still shows all five cartoons.

https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f