### PR TITLE
Streamlit onboarding wave 3: demo button + before/after card (refs #98)

### DIFF
--- a/app.py
+++ b/app.py
@@ -249,6 +249,19 @@ st.markdown(
 )
 st.image(_hero_schematic(), use_container_width=True)
 
+_demo_cols = st.columns([2, 1, 2])
+if _demo_cols[1].button(
+    "▶ Try a demo analysis",
+    type="primary",
+    use_container_width=True,
+    help=(
+        "One-click analytical run with IM7/8552 and a quasi-isotropic "
+        "[0/45/-45/90]_3s layup. Lands on the Results tab in ~2 s."
+    ),
+):
+    st.session_state["_demo_pending"] = True
+    st.rerun()
+
 
 # ---------------------------------------------------------------------------
 # Sidebar inputs
@@ -678,42 +691,69 @@ profile = GaussianSinusoidal(amplitude=amplitude, wavelength=wavelength, width=w
 # Run handler — execute BEFORE tabs render so the Results tab sees the
 # updated session_state and the empty-state placeholder doesn't render
 # alongside the running indicator.
-if run_clicked:
-    try:
-        layup = parse_layup(layup_str)
-    except ValueError as e:
-        st.error(f"Could not parse layup: {e}")
-        st.stop()
+_demo_pending = st.session_state.pop("_demo_pending", False)
+if run_clicked or _demo_pending:
+    if _demo_pending:
+        # Hardcoded analytical-only demo so a first-time visitor can land on
+        # the Results tab in ~2 s without touching the sidebar.
+        _demo_seed_name = (
+            "IM7_8552" if "IM7_8552" in MATERIAL_NAMES else MATERIAL_NAMES[0]
+        )
+        _demo_material_dict = LIB.get(_demo_seed_name).to_dict()
+        _demo_layup = (
+            0, 45, -45, 90, 0, 45, -45, 90, 0, 45, -45, 90,
+            90, -45, 45, 0, 90, -45, 45, 0, 90, -45, 45, 0,
+        )
+        cfg_payload = tuple(sorted({
+            "amplitude": 0.366,
+            "wavelength": 16.0,
+            "width": 12.0,
+            "morphology": "stack",
+            "decay_floor": 0.0,
+            "loading": "compression",
+            "ply_thickness": 0.183,
+            "angles_tuple": _demo_layup,
+            "applied_strain": -0.01,
+            "material_tuple": tuple(sorted(_demo_material_dict.items())),
+            "analytical_only": True,
+        }.items()))
+    else:
+        try:
+            layup = parse_layup(layup_str)
+        except ValueError as e:
+            st.error(f"Could not parse layup: {e}")
+            st.stop()
 
-    try:
-        # Validate the custom material up front so the cache isn't keyed on
-        # an invalid OrthotropicMaterial that will only blow up inside
-        # AnalysisConfig.
-        OrthotropicMaterial.from_dict(material_dict)
-    except ValueError as e:
-        st.error(f"Invalid custom material: {e}")
-        st.stop()
+        try:
+            # Validate the custom material up front so the cache isn't keyed
+            # on an invalid OrthotropicMaterial that will only blow up inside
+            # AnalysisConfig.
+            OrthotropicMaterial.from_dict(material_dict)
+        except ValueError as e:
+            st.error(f"Invalid custom material: {e}")
+            st.stop()
 
-    cfg_items: dict = {
-        "amplitude": amplitude,
-        "wavelength": wavelength,
-        "width": width,
-        "morphology": morphology,
-        "decay_floor": decay_floor,
-        "loading": loading,
-        "ply_thickness": ply_thickness,
-        "angles_tuple": tuple(layup),
-        "applied_strain": applied_strain_pct / 100.0,
-        "material_tuple": tuple(sorted(material_dict.items())),
-        "analytical_only": bool(analytical_only),
-    }
-    # Mesh keys only matter for the FE path; omitting them in analytical-only
-    # mode means the cache key doesn't churn when the user tweaks nx/ny/nz.
-    if not analytical_only:
-        cfg_items["nx"] = int(nx)
-        cfg_items["ny"] = int(ny)
-        cfg_items["nz_per_ply"] = int(nz_per_ply)
-    cfg_payload = tuple(sorted(cfg_items.items()))
+        cfg_items: dict = {
+            "amplitude": amplitude,
+            "wavelength": wavelength,
+            "width": width,
+            "morphology": morphology,
+            "decay_floor": decay_floor,
+            "loading": loading,
+            "ply_thickness": ply_thickness,
+            "angles_tuple": tuple(layup),
+            "applied_strain": applied_strain_pct / 100.0,
+            "material_tuple": tuple(sorted(material_dict.items())),
+            "analytical_only": bool(analytical_only),
+        }
+        # Mesh keys only matter for the FE path; omitting them in
+        # analytical-only mode means the cache key doesn't churn when the
+        # user tweaks nx/ny/nz.
+        if not analytical_only:
+            cfg_items["nx"] = int(nx)
+            cfg_items["ny"] = int(ny)
+            cfg_items["nz_per_ply"] = int(nz_per_ply)
+        cfg_payload = tuple(sorted(cfg_items.items()))
 
     with st.status("Running analysis…", expanded=True) as status:
         st.write("Building laminate, wrinkle geometry, and mesh…")
@@ -755,6 +795,14 @@ if run_clicked:
 
     st.session_state["results"] = results
     st.session_state["cfg_payload"] = cfg_payload
+    if _demo_pending:
+        st.success(
+            "✓ Demo analysis complete with sensible defaults "
+            "(IM7/8552, quasi-isotropic 24-ply, 1 % compression). "
+            "Open the **Results** tab below to see the numbers — "
+            "then tweak any sidebar parameter and click *Run analysis* "
+            "to compare against your own configuration."
+        )
 
 
 tab_geom, tab_results, tab_export = st.tabs(["Geometry", "Results", "Export"])
@@ -861,6 +909,70 @@ with tab_results:
         )
     else:
         r = st.session_state["results"]
+
+        # ------------------------------------------------------------------
+        # Before / after comparison card (#98 item 6)
+        # ------------------------------------------------------------------
+        _knockdown = float(r.get("analytical_knockdown", 1.0))
+        _wrinkled_strength = float(r.get("analytical_strength_MPa", 0.0))
+        _pristine_strength = (
+            _wrinkled_strength / _knockdown if _knockdown > 1e-6 else None
+        )
+        _strength_delta_pct = (1.0 - _knockdown) * 100.0
+
+        _cfg_runtime = dict(st.session_state.get("cfg_payload", ()))
+        _mat_runtime = dict(_cfg_runtime.get("material_tuple", ()))
+        _E1_pristine_GPa: float | None = None
+        if _mat_runtime.get("E1"):
+            _E1_pristine_GPa = float(_mat_runtime["E1"]) / 1000.0
+
+        _fe_runtime = r.get("fe")
+        _E1_wrinkled_GPa: float | None = None
+        _stiffness_delta_pct: float | None = None
+        if _fe_runtime is not None and _E1_pristine_GPa is not None:
+            _modulus_ret = float(_fe_runtime.get("modulus_retention", 1.0))
+            _E1_wrinkled_GPa = _E1_pristine_GPa * _modulus_ret
+            _stiffness_delta_pct = (1.0 - _modulus_ret) * 100.0
+
+        st.subheader("Before / after this wrinkle")
+        ba_cols = st.columns(2)
+        with ba_cols[0]:
+            st.markdown("**Pristine baseline**")
+            if _pristine_strength is not None:
+                st.markdown(f"Strength · **{_pristine_strength:,.0f} MPa**")
+            if _E1_pristine_GPa is not None:
+                st.markdown(f"Stiffness (E₁) · **{_E1_pristine_GPa:.1f} GPa**")
+        with ba_cols[1]:
+            st.markdown("**Your wrinkled laminate**")
+            _strength_arrow = "▼" if _strength_delta_pct >= 0 else "▲"
+            st.markdown(
+                f"Strength · **{_wrinkled_strength:,.0f} MPa**  "
+                f"({_strength_arrow} {abs(_strength_delta_pct):.0f} %)"
+            )
+            if _E1_wrinkled_GPa is not None and _stiffness_delta_pct is not None:
+                _stiff_arrow = "▼" if _stiffness_delta_pct >= 0 else "▲"
+                st.markdown(
+                    f"Stiffness (E₁) · **{_E1_wrinkled_GPa:.1f} GPa**  "
+                    f"({_stiff_arrow} {abs(_stiffness_delta_pct):.1f} %)"
+                )
+            else:
+                st.markdown(
+                    "Stiffness (E₁) · _run with FE on to compute_"
+                )
+
+        if _stiffness_delta_pct is not None:
+            st.caption(
+                f"This wrinkle costs you **{abs(_strength_delta_pct):.0f} %** "
+                f"of strength and **{abs(_stiffness_delta_pct):.1f} %** of "
+                "stiffness. Wrinkles almost always hurt strength far more "
+                "than stiffness."
+            )
+        else:
+            st.caption(
+                f"This wrinkle costs you **{abs(_strength_delta_pct):.0f} %** "
+                "of strength. Untick *Analytical only* in the sidebar's "
+                "*Advanced* expander to also see the stiffness drop."
+            )
 
         st.subheader("Analytical predictions")
         c1, c2, c3, c4 = st.columns(4)


### PR DESCRIPTION
## Summary
Third wave of the onboarding tracking issue #98. Two more items, both Streamlit-only, no analysis-pipeline changes.

Refs #98 (items 6, 7).

### Item 7 — One-click demo button
- Centred `▶ Try a demo analysis` button below the hero schematic.
- Click sets `_demo_pending=True` in `st.session_state` and `st.rerun()`s.
- The run handler now branches: when `_demo_pending` is set, it builds a hardcoded `cfg_payload` (IM7/8552, quasi-isotropic 24-ply, A = 0.366 mm, λ = 16 mm, w = 12 mm, stack morphology, compression 1 %, `analytical_only=True`) and falls through to the same `st.status` / `run_analysis_cached` block as a normal run — so the cache, error handling, and result-rendering all reuse the existing plumbing.
- On completion a green banner points the user at the Results tab and reminds them they can tweak the sidebar and re-run.

### Item 6 — Before / after comparison card
- New "Before / after this wrinkle" section on the Results tab, rendered above the existing "Analytical predictions" metric row.
- Two side-by-side columns:
  - **Pristine baseline** — derives pristine strength as `analytical_strength_MPa / analytical_knockdown` and pristine stiffness from `material.E1` (pulled out of `cfg_payload["material_tuple"]`).
  - **Your wrinkled laminate** — `analytical_strength_MPa` and (when FE is available) `pristine_E1 × fe.modulus_retention`. Each delta gets a ▼/▲ arrow and a percent.
- One-sentence summary caption in plain English: *"This wrinkle costs you 38 % of strength and 2 % of stiffness. Wrinkles almost always hurt strength far more than stiffness."*
- Falls back gracefully when E₁ isn't in the payload or when FE was skipped (analytical-only run).

## Net diff
`app.py`: +148 / −36 LOC. No new dependencies; only `st.button`, `st.columns`, `st.markdown`, `st.caption`, `st.success`, `st.rerun`, `st.session_state`.

## Test plan
- [x] `python -m py_compile app.py`
- [ ] `streamlit run app.py` locally:
  - [ ] Click "▶ Try a demo analysis" on a fresh session — confirm a status block runs, then a green success banner appears, and the Results tab is populated.
  - [ ] Switch to Results — confirm the **Before / after** card sits above "Analytical predictions" with sensible numbers (pristine strength higher than wrinkled; ▼ arrows; one-sentence summary).
  - [ ] Run with **Analytical only** ticked — confirm the stiffness side shows "_run with FE on to compute_" and the summary degrades to "...% of strength" only.
  - [ ] Run with **Analytical only** unticked (full FE) — confirm both strength and stiffness deltas appear.
  - [ ] Edit a sidebar widget and click **Run analysis** — confirm the normal path still works.

## Tracking issue progress
After this lands, #98 will have 7 of 9 items shipped: 1, 2, 3 (PR #99), 4, 5 (PR #100), 6, 7 (this PR). Remaining: 8 (expert-mode toggle) and 9 (tab rename/reorder).

https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f)_