### PR TITLE
Drop tautological Poisson-symmetry check in OrthotropicMaterial.validate (closes #82)

### DIFF
--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -123,9 +123,20 @@ class OrthotropicMaterial:
         Checks
         ------
         1. All moduli and strengths are strictly positive.
-        2. Poisson's ratios satisfy symmetry: nu_ij / E_i = nu_ji / E_j
-           within a relative tolerance of 5 %.
+        2. Optional LaRC04/05 properties are within their physical ranges.
         3. The 6x6 compliance matrix is positive-definite (all eigenvalues > 0).
+           This implicitly enforces the orthotropic stability bounds on the
+           Poisson ratios (e.g. ``|ν12| < sqrt(E1/E2)``); a user-supplied
+           ν that drives the compliance non-physical fails here.
+
+        Notes
+        -----
+        Poisson symmetry ``nu_ij / E_i == nu_ji / E_j`` is automatic — the
+        dataclass only stores the major ratios (``nu12``, ``nu13``, ``nu23``)
+        and derives the minor ratios from them via the symmetry relation
+        (see :attr:`nu21`, :attr:`nu31`, :attr:`nu32`). A standalone
+        symmetry check would compare a value against itself; the constraint
+        is structurally guaranteed, not validated.
 
         Raises
         ------
@@ -150,28 +161,10 @@ class OrthotropicMaterial:
         if not (0 < self.alpha_0 < 90):
             raise ValueError(f"alpha_0 must be in (0, 90) degrees, got {self.alpha_0}")
 
-        # 2. Symmetric Poisson ratios
-        #    nu_ij / E_i  should equal  nu_ji / E_j
-        #    We derive nu_ji from user-supplied nu_ij.
-        nu21 = self.nu12 * self.E2 / self.E1
-        nu31 = self.nu13 * self.E3 / self.E1
-        nu32 = self.nu23 * self.E3 / self.E2
-
-        pairs = [
-            ("nu12", self.nu12, self.E1, "nu21", nu21, self.E2),
-            ("nu13", self.nu13, self.E1, "nu31", nu31, self.E3),
-            ("nu23", self.nu23, self.E2, "nu32", nu32, self.E3),
-        ]
-        for name_ij, nu_ij, Ei, name_ji, nu_ji, Ej in pairs:
-            lhs = nu_ij / Ei
-            rhs = nu_ji / Ej
-            if abs(lhs) > 0 and abs(rhs - lhs) / abs(lhs) > 0.05:
-                raise ValueError(
-                    f"Poisson symmetry violated: {name_ij}/E{name_ij[-1]} = {lhs:.6e} "
-                    f"vs {name_ji}/E{name_ji[-1]} = {rhs:.6e}"
-                )
-
-        # 3. Positive-definite compliance matrix
+        # 2. Positive-definite compliance matrix. This catches Poisson values
+        # that drive the elastic tensor non-physical (e.g. ν12 ≥ sqrt(E1/E2));
+        # the standalone Poisson-symmetry check that used to live here was a
+        # tautology — see the docstring above.
         S = self._build_compliance()
         eigvals = np.linalg.eigvalsh(S)
         if np.any(eigvals <= 0):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -132,6 +132,32 @@ class TestMaterialValidation:
         with pytest.raises(ValueError, match="gamma_Y must be positive"):
             OrthotropicMaterial(gamma_Y=0.0)
 
+    def test_unphysical_poisson_caught_by_pos_definite(self):
+        """A Poisson value above the orthotropic stability bound
+        (|ν12| ≥ sqrt(E1/E2)) drives the compliance matrix non-physical,
+        and validate() should reject it via the positive-definiteness check.
+
+        This is the contract that replaces the old (tautological)
+        Poisson-symmetry check — see issue #82.
+        """
+        with pytest.raises(ValueError, match="not positive-definite"):
+            # ν12 = 4.5 with E1=171420, E2=9080 gives ν12^2 * E2/E1 ≈ 1.07 > 1,
+            # which violates the orthotropic stability bound
+            # (1 - ν12 * ν21) > 0 and produces a non-PD compliance.
+            OrthotropicMaterial(nu12=4.5)
+
+    def test_validate_docstring_does_not_claim_symmetry_check(self):
+        """Regression guard for issue #82: the docstring used to claim that
+        validate() enforced Poisson symmetry, but the check was a tautology.
+        After the fix, the docstring must not promise a check that doesn't exist.
+        """
+        doc = OrthotropicMaterial.validate.__doc__ or ""
+        # The string "tolerance of 5" was the giveaway in the old docstring.
+        assert "tolerance of 5" not in doc, (
+            "validate() docstring still references the removed 5% Poisson "
+            "symmetry check — see issue #82."
+        )
+
 
 class TestMaterialLibrary:
     """Test MaterialLibrary functionality."""


### PR DESCRIPTION
## Summary
The "Poisson symmetry" block in `OrthotropicMaterial.validate()` compared each user-supplied `ν_ij` against a value *derived from the same input* (`ν_ji = ν_ij * E_i / E_j`). The check therefore held exactly by construction for every input — its 5 % tolerance gate was structurally unreachable. The `validate()` docstring nevertheless promised users that symmetry was being enforced.

This PR picks **option 1** from #82: drop the dead block and update the docstring. The positive-definiteness check on the 6×6 compliance matrix that follows already catches Poisson values that drive the elastic tensor non-physical (e.g. `|ν12| ≥ sqrt(E1/E2)`), so no genuine safety is lost.

Closes #82.

## Changes
### `src/wrinklefe/core/material.py`
- Remove the dead Poisson-symmetry block (was lines 153–172).
- Update the `validate()` docstring to drop the misleading symmetry-tolerance claim and add a **Notes** section explaining why symmetry is structurally guaranteed by the way the dataclass stores major-only ratios and derives the minor ones.
- Inline comment on the surviving PD check explains it now subsumes the orthotropic stability bounds on the Poisson ratios.

### `tests/test_material.py`
- `test_unphysical_poisson_caught_by_pos_definite` — locks in the new contract: constructing `OrthotropicMaterial(nu12=4.5)` (with default E1/E2) drives the compliance non-PD and `validate()` raises with `not positive-definite` in the message. This protects users who push ν beyond the stability bound.
- `test_validate_docstring_does_not_claim_symmetry_check` — docstring guard. Asserts the misleading "tolerance of 5" phrase no longer appears, so a future contributor can't quietly re-introduce the old promise.

## Test plan
- [x] `python -m py_compile src/wrinklefe/core/material.py tests/test_material.py`
- [ ] CI matrix (numpy/pytest unavailable in the local sandbox; CI will run the new tests).

## Backward compatibility
None of the five built-in materials nor any external caller relies on the removed check (it had no real failure modes). The PR is a pure cleanup + documentation fix; the new test merely tightens an existing-but-unstated property of `validate()`.

https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f)_