### PR TITLE
Docs: correct built-in material count (5, not 4) and add AC318/S6C10 (closes #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An open-source Python finite element package for predicting strength and stiffne
 - **Five morphologies:** Stack, convex, concave, uniform, graded (with configurable decay floor)
 - **Graded averaging:** Through-thickness ply-averaged knockdown for graded wrinkles
 - **PyQt6 GUI:** Interactive analysis with real-time stress visualization
-- **4 built-in materials:** AS4/3501-6, IM7/8552, T300/914, T700/2510
+- **5 built-in materials:** AS4/3501-6, IM7/8552, T300/914, T700/2510, AC318/S6C10 (S-glass/epoxy)
 - **Comprehensive test suite** covering all modules (run `pytest` to see the current count)
 
 ## Installation

--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -317,8 +317,9 @@ class OrthotropicMaterial:
 class MaterialLibrary:
     """Named collection of :class:`OrthotropicMaterial` instances.
 
-    Provides four built-in carbon/epoxy material systems and supports
-    JSON serialisation for user-defined materials.
+    Provides five built-in composite material systems (four carbon/epoxy
+    and one glass/epoxy) and supports JSON serialisation for user-defined
+    materials.
 
     Built-in materials
     ------------------
@@ -326,6 +327,7 @@ class MaterialLibrary:
     - ``IM7_8552`` : Hexcel IM7 / 8552 (toughened epoxy, widely characterised)
     - ``T300_914`` : Toray T300 / Hexcel 914 (legacy European aerospace)
     - ``T700_2510`` : Toray T700SC / Cytec 2510 (OOA VBO system)
+    - ``AC318_S6C10`` : AC318 / S6C10-800 (S-glass / epoxy, Li et al. 2026)
 
     Examples
     --------
@@ -334,7 +336,7 @@ class MaterialLibrary:
     >>> mat.E1
     171420.0
     >>> lib.list_names()
-    ['AS4_3501_6', 'IM7_8552', 'T300_914', 'T700_2510']
+    ['AC318_S6C10', 'AS4_3501_6', 'IM7_8552', 'T300_914', 'T700_2510']
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
Pure docs fix. The README and the `MaterialLibrary` class docstring both claimed *four* built-in materials and omitted **AC318/S6C10** (S-glass/epoxy, Li et al. 2026), even though `_load_builtins()` at `src/wrinklefe/core/material.py:519` has been registering it for a while. The existing `tests/test_material.py::test_has_five_builtins` already locks the *actual* count to five — only the documentation was stale.

Closes #84.

## Changes
| File | Change |
|---|---|
| `README.md:27` | `4 built-in materials` → `5`; AC318/S6C10 added with `(S-glass/epoxy)` qualifier. |
| `src/wrinklefe/core/material.py:320` | "Provides four built-in carbon/epoxy material systems" → "Provides five built-in composite material systems (four carbon/epoxy and one glass/epoxy)". |
| `src/wrinklefe/core/material.py:325-329` | Add `AC318_S6C10` bullet citing Li et al. 2026. |
| `src/wrinklefe/core/material.py:337` | Update the `list_names()` doctest example to the correct sorted-five output (`['AC318_S6C10', 'AS4_3501_6', 'IM7_8552', 'T300_914', 'T700_2510']`). |

## Note on the issue
The issue text says "*IM7/8552 is not in_load_builtins; the fourth built-in is actually AC318_S6C10*". That's slightly off — IM7/8552 *is* a built-in (line 478, registered without an explicit `name=` kwarg, so it picks up the `OrthotropicMaterial.name` field default of `"IM7_8552"`). The real defect is that there are *five* built-ins and the docs claim four. This PR fixes that. The acceptance criteria from #84 — "README list matches `MaterialLibrary().list_names()`" — is satisfied.

## Test plan
- [x] `python -m py_compile src/wrinklefe/core/material.py`
- [ ] CI matrix runs `pytest`; `test_has_five_builtins` already pins the count.

https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f)_