### PR TITLE
LaRC05: harmonize sub-FI scale to linear-in-load (closes #79)

### DIFF
--- a/src/wrinklefe/failure/larc05.py
+++ b/src/wrinklefe/failure/larc05.py
@@ -327,7 +327,9 @@ class LaRC05Criterion(FailureCriterion):
                 return float("inf")
             fi = (tau_12m / denom_l) ** 2 + (tau_23m / denom_t) ** 2
 
-        return max(fi, 0.0)
+        # Return linear-in-load FI (sqrt of the quadratic form) so it can
+        # be compared directly against the other sub-criteria — see #79.
+        return float(np.sqrt(max(fi, 0.0)))
 
     # ------------------------------------------------------------------
     # Matrix failure (fracture-plane search)
@@ -397,7 +399,9 @@ class LaRC05Criterion(FailureCriterion):
                     fi_arr[i] = (tnt / denom_t) ** 2 + (tn1 / denom_l) ** 2
 
         idx_max = int(np.argmax(fi_arr))
-        fi_max = float(fi_arr[idx_max])
+        # Return linear-in-load FI (sqrt of the quadratic form) so it can
+        # be compared directly against the other sub-criteria — see #79.
+        fi_max = float(np.sqrt(max(fi_arr[idx_max], 0.0)))
         mode = "matrix_tension" if sigma_n[idx_max] >= 0 else "matrix_compression"
         return fi_max, mode
 
@@ -464,11 +468,9 @@ class LaRC05Criterion(FailureCriterion):
         else:
             fi, mode = fi_matrix, mode_matrix
 
-        # Reserve factor: sqrt for quadratic criteria
-        if fi > 0:
-            rf = 1.0 / np.sqrt(fi) if mode != "fiber_tension" else 1.0 / fi
-        else:
-            rf = float("inf")
+        # Reserve factor. Every sub-FI is now on the linear-in-load scale
+        # (see #79), so rf = 1 / fi holds uniformly.
+        rf = 1.0 / fi if fi > 0 else float("inf")
 
         # Sub-criterion detail for diagnostics
         phi_c = self._compute_phi_c(

--- a/tests/test_failure/test_criteria.py
+++ b/tests/test_failure/test_criteria.py
@@ -167,3 +167,55 @@ class TestLaRC05Criterion:
         fi_comp = criterion.evaluate(s_comp, x850_material, ctx).index
         fi_tens = criterion.evaluate(s_tens, x850_material, ctx).index
         assert fi_comp > fi_tens
+
+    # ------------------------------------------------------------------
+    # Regression tests for issue #79 — sub-FI scale harmonisation
+    # ------------------------------------------------------------------
+
+    def test_sub_FIs_all_linear_in_load(self, x850_material):
+        """At half-allowable combined fibre+matrix load, every sub-FI must
+        be ~0.5 on the linear-in-load scale, and the governing index must
+        match. Pre-fix, fi_fiber would be 0.5 but fi_matrix would be 0.25
+        (mixed linear/quadratic scales). See issue #79.
+        """
+        criterion = LaRC05Criterion()
+        Yt_is, _ = criterion._in_situ_strengths(x850_material)
+        # Half of Xt longitudinal tension + half of (in-situ) Yt transverse
+        # tension, no shear.
+        stress = np.array([
+            0.5 * x850_material.Xt, 0.5 * Yt_is, 0.0, 0.0, 0.0, 0.0,
+        ])
+        result = criterion.evaluate(stress, x850_material)
+        # Both sub-FIs should be ~0.5 — exact equality up to the
+        # plane-of-action discretisation in _matrix_failure.
+        assert_allclose(result.detail["fi_fiber"], 0.5, atol=1e-6)
+        assert_allclose(result.detail["fi_matrix"], 0.5, atol=0.01)
+        assert_allclose(result.index, 0.5, atol=0.01)
+
+    def test_reserve_factor_is_inverse_of_index_below_failure(
+        self, x850_material
+    ):
+        """rf = 1 / index must hold uniformly now that every sub-FI is on
+        the linear-in-load scale. Pre-fix, rf for fiber_tension was
+        1 / fi but for kinking/matrix was 1 / sqrt(fi). See issue #79.
+        """
+        criterion = LaRC05Criterion()
+        cases = [
+            # (description, stress vector, context)
+            ("half-Xt fibre tension",
+             np.array([0.5 * x850_material.Xt, 0.0, 0.0, 0.0, 0.0, 0.0]),
+             None),
+            ("half-Yt transverse tension",
+             np.array([0.0, 0.5 * x850_material.Yt, 0.0, 0.0, 0.0, 0.0]),
+             None),
+            ("compression with misalignment",
+             np.array([-1000.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+             {"misalignment_angle": 0.10}),
+        ]
+        for label, stress, ctx in cases:
+            result = criterion.evaluate(stress, x850_material, ctx)
+            if result.index > 0:
+                assert_allclose(
+                    result.reserve_factor, 1.0 / result.index, rtol=1e-12,
+                    err_msg=f"rf != 1/index for case '{label}'",
+                )


### PR DESCRIPTION
## Summary
The three LaRC05 sub-criterion helpers returned indices on **different load scales**:

| Helper | `larc05.py:` | Return value | Scale |
|---|---|---|---|
| `_fibre_tension` | 217 | `sqrt(max(fi, 0.0))` | **linear in load** |
| `_fibre_kinking` | 330 | `max(fi, 0.0)` | **quadratic in load** |
| `_matrix_failure` | 400 | `fi_arr[idx_max]` | **quadratic in load** |

`evaluate()` then compared them directly (`if fi_fiber >= fi_matrix: …` at line 462) to pick the governing mode and reported one of them as `FailureResult.index`. Below the FI=1 surface this comparison was dimensionally inconsistent — the wrong governing mode could be flagged whenever both sub-criteria were below failure.

> Worked example with `Xt = 2000`, `σ₁₁ = 1000` (50 % of allowable), `σ₂₂ = 0.5 × Yt_is`, zero everywhere else:
> - `_fibre_tension` returned `sqrt((1000/2000)²) = 0.5`
> - `_matrix_failure` returned `(0.5)² = 0.25`
> - `evaluate()` reported `fiber_tension` with `index = 0.5` — yet both modes are at the same physical proximity to failure.

The reserve-factor logic at lines 468-469 acknowledged the scale split (`1.0 / sqrt(fi) if mode != "fiber_tension" else 1.0 / fi`), confirming the author knew the scales differed — but the mode-selection `max(…)` step didn't.

Closes #79.

## Changes
### `src/wrinklefe/failure/larc05.py`
- `_fibre_kinking`: return `sqrt(max(fi, 0.0))` instead of `max(fi, 0.0)`.
- `_matrix_failure`: wrap the worst-plane `fi_arr[idx_max]` in `sqrt(max(…, 0.0))`.
- `evaluate()`: simplify the reserve-factor branch to `rf = 1.0 / fi if fi > 0 else float('inf')`. The per-mode `sqrt` conditional is gone — `rf = 1 / index` now holds uniformly.

### `tests/test_failure/test_criteria.py`
- **`test_sub_FIs_all_linear_in_load`** — combined fibre + matrix load at half-allowable each (`σ₁₁ = 0.5·Xt`, `σ₂₂ = 0.5·Yt_is`, no shear). Asserts `result.detail["fi_fiber"] ≈ 0.5`, `result.detail["fi_matrix"] ≈ 0.5`, and `result.index ≈ 0.5` (within `atol=0.01` to account for plane-of-action discretisation in `_matrix_failure`). Pre-fix, `fi_matrix` would have been `0.25` and the test would fail loudly.
- **`test_reserve_factor_is_inverse_of_index_below_failure`** — invariant guard. For three intermediate-load cases (half-Xt fibre tension; half-Yt transverse tension; compressive load with misalignment), asserts `result.reserve_factor == 1.0 / result.index` to machine precision (`rtol=1e-12`). Pre-fix, the kinking/matrix cases used `1 / sqrt(fi)` and this would fail.

## Backward compatibility
- **FI=1 boundary unaffected.** At `fi = 1` we have `sqrt(1) = 1`, so existing uniaxial-at-allowable tests (`test_fi_at_Xt`, etc.) still pass exactly.
- **Below failure, reported FI values change.** A pre-fix `fi_matrix = 0.25` now reports as `0.5`. Downstream code that compares FI against `>= 1.0` for failure still behaves identically. Downstream code that consumes the raw FI value (e.g. design-margin reporting) will see numerically larger values for the same load — *that's the bug being fixed*: the new values are on the linear-in-load scale that matches the other criteria in the failure module.
- **No public API changes**, no signature changes.

## Test plan
- [x] `python -m py_compile src/wrinklefe/failure/larc05.py tests/test_failure/test_criteria.py`
- [ ] CI matrix runs pytest. New tests verify the harmonized contract; existing LaRC05 tests should pass unchanged.

https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f)_