### PR TITLE
Puck IFF: stress-magnitude-independent Mode B/C threshold (closes #85)

### DIFF
--- a/src/wrinklefe/failure/puck.py
+++ b/src/wrinklefe/failure/puck.py
@@ -188,6 +188,15 @@ class PuckCriterion(FailureCriterion):
         tau_nt = (s3 - s2) * sin_t * cos_t + t23 * (cos_t**2 - sin_t**2)
         tau_n1 = t12 * cos_t + t13 * sin_t
 
+        # Pre-compute the Mode B / Mode C corner slope. Mode B and C live on
+        # the compressive (sigma_n < 0) half of the action-plane failure
+        # envelope, and the corner between them is at a constant geometric
+        # ratio |tau_nt / sigma_n| = sqrt(1 + 2 p_psc). Above that ratio
+        # (shear-dominated) Mode C governs; below it (compression-dominated)
+        # Mode B governs. See issue #85 — previously the threshold simplified
+        # to a constant on |tau_nt| alone, with the labels physically swapped.
+        bc_corner_slope = self._mode_bc_corner_slope(p_psc)
+
         fi_arr = np.zeros_like(thetas)
         mode_arr = np.empty(len(thetas), dtype=object)
 
@@ -210,25 +219,52 @@ class PuckCriterion(FailureCriterion):
                     )
                 mode_arr[i] = "iff_mode_a"
             else:
-                # sigma_n < 0: distinguish Mode B vs Mode C
-                # Threshold: ratio |tau_nt / sigma_n|
-                ratio = abs(tnt / sn) if abs(sn) > 1e-12 else float("inf")
-                threshold = S23 / abs(sn) if abs(sn) > 1e-12 else 0.0
-
-                if ratio >= threshold:
-                    # Mode B
-                    inner = tnt**2 + (tn1 + p_ppc * sn) ** 2
-                    fi_arr[i] = np.sqrt(inner) / S12 + p_psc * sn / S23
-                    mode_arr[i] = "iff_mode_b"
-                else:
-                    # Mode C
+                # sigma_n < 0: distinguish Mode B vs Mode C using the
+                # geometric (stress-magnitude-independent) corner slope.
+                if abs(tnt) > bc_corner_slope * abs(sn):
+                    # Mode C: shear-dominated, mild compression.
                     denom_c = 2.0 * (1.0 + p_psc) * S23
                     bracket = (tnt / denom_c) ** 2 + (tn1 / S12) ** 2
                     fi_arr[i] = bracket * (-Yc / sn)
                     mode_arr[i] = "iff_mode_c"
+                else:
+                    # Mode B: compression-dominated, mild shear.
+                    inner = tnt**2 + (tn1 + p_ppc * sn) ** 2
+                    fi_arr[i] = np.sqrt(inner) / S12 + p_psc * sn / S23
+                    mode_arr[i] = "iff_mode_b"
 
         idx_max = int(np.argmax(fi_arr))
         return float(fi_arr[idx_max]), str(mode_arr[idx_max]), float(thetas[idx_max])
+
+    @staticmethod
+    def _mode_bc_corner_slope(p_psc: float) -> float:
+        """Slope ``|tau_nt / sigma_n|`` at the Mode B / Mode C corner.
+
+        Following Puck & Schurmann (2002), the corner sits at a constant
+        ratio derived from the action-plane strength ``RA_perp_perp`` and
+        the shear stress ``tau_nt_c`` at the corner — both proportional
+        to ``S23 / (1 + p_perp_psi_c)`` — leaving a stress-magnitude-
+        independent slope of ``sqrt(1 + 2 p_perp_psi_c)``.
+
+        Exposed as a static method so the Mode B/C classification can be
+        unit-tested without driving a full action-plane search (the Mode C
+        formula has a 1/|sigma_n| factor that dominates the argmax-over-
+        theta result and would mask classification regressions). See #85.
+        """
+        return float(np.sqrt(1.0 + 2.0 * float(p_psc)))
+
+    @staticmethod
+    def _classify_iff_mode_bc(sn: float, tnt: float, p_psc: float) -> str:
+        """Return ``"iff_mode_b"`` or ``"iff_mode_c"`` for a single plane
+        with ``sigma_n < 0``.
+
+        Mode C governs when the shear-to-compression ratio exceeds the
+        Mode B/C corner slope; Mode B governs below it. Pure helper for
+        tests; production code uses the inline check in
+        :meth:`_inter_fibre_failure` for vectorisation. See #85.
+        """
+        slope = PuckCriterion._mode_bc_corner_slope(p_psc)
+        return "iff_mode_c" if abs(tnt) > slope * abs(sn) else "iff_mode_b"
 
     # ------------------------------------------------------------------
     # Public interface

--- a/tests/test_failure/test_puck.py
+++ b/tests/test_failure/test_puck.py
@@ -77,3 +77,80 @@ class TestPuckUniaxial:
         stress = np.array([0.5 * material.Xt, 0.0, 0.0, 0.0, 0.0, 0.0])
         result = criterion.evaluate(stress, material)
         assert result.reserve_factor == pytest.approx(1.0 / result.index, rel=1e-12)
+
+
+# ======================================================================
+# Regression tests for issue #85 — Mode B / Mode C threshold
+# ======================================================================
+
+class TestPuckIFFModeBCClassification:
+    """Mode B / Mode C should split on a stress-magnitude-independent
+    ratio |tau_nt / sigma_n|. The pre-fix threshold collapsed to a
+    constant on |tau_nt| alone (~S23) and reversed the physics.
+    See issue #85.
+    """
+
+    def test_corner_slope_is_constant_function_of_p_psc(self):
+        """The Mode B/C corner slope is geometric on the failure envelope —
+        it depends on p_perp_psi_c and nothing else, in particular not on
+        the applied stress magnitude.
+        """
+        slope_025 = PuckCriterion._mode_bc_corner_slope(0.25)
+        # sqrt(1 + 2 * 0.25) = sqrt(1.5)
+        assert slope_025 == pytest.approx(np.sqrt(1.5), rel=1e-12)
+        # And it's monotone in p_psc:
+        assert (
+            PuckCriterion._mode_bc_corner_slope(0.10)
+            < PuckCriterion._mode_bc_corner_slope(0.30)
+        )
+
+    def test_high_shear_mild_compression_is_mode_c(self):
+        """(sigma_n, tau_nt) = (-10, 100) is squarely in the shear-dominated
+        wedge and must be classified Mode C. Pre-fix, the broken threshold
+        |tnt| >= S23 selected Mode B here — wrong by Puck's construction.
+        Hand-checked sanity example from issue #85.
+        """
+        mode = PuckCriterion._classify_iff_mode_bc(
+            sn=-10.0, tnt=100.0, p_psc=0.25,
+        )
+        assert mode == "iff_mode_c"
+
+    def test_high_compression_mild_shear_is_mode_b(self):
+        """(sigma_n, tau_nt) = (-100, 10): compression-dominated, deep in
+        the Mode B wedge. The classification must report Mode B. Hand-
+        checked sanity example from issue #85.
+        """
+        mode = PuckCriterion._classify_iff_mode_bc(
+            sn=-100.0, tnt=10.0, p_psc=0.25,
+        )
+        assert mode == "iff_mode_b"
+
+    def test_threshold_independent_of_stress_magnitude(self):
+        """Scaling sn and tnt by the same factor must not change the
+        classification — the threshold is geometric on the ratio, not on
+        absolute magnitudes. Pre-fix, the broken |tnt| >= S23 threshold
+        would have selected differently for (sn, tnt) vs (10*sn, 10*tnt).
+        """
+        for sn, tnt in [(-1.0, 10.0), (-50.0, 500.0), (-0.01, 0.1)]:
+            assert (
+                PuckCriterion._classify_iff_mode_bc(sn, tnt, p_psc=0.25)
+                == "iff_mode_c"
+            ), f"Mode C expected at ({sn}, {tnt})"
+        for sn, tnt in [(-10.0, 1.0), (-500.0, 50.0), (-0.1, 0.01)]:
+            assert (
+                PuckCriterion._classify_iff_mode_bc(sn, tnt, p_psc=0.25)
+                == "iff_mode_b"
+            ), f"Mode B expected at ({sn}, {tnt})"
+
+    def test_classification_at_exact_corner(self):
+        """Exactly on the corner |tnt| == sqrt(1+2*p_psc) * |sn|, the
+        strict-greater-than condition routes to Mode B. Either mode is
+        physically acceptable at the boundary (the formulas coincide
+        there), but pinning the deterministic choice avoids platform-
+        dependent flapping.
+        """
+        slope = PuckCriterion._mode_bc_corner_slope(0.25)
+        mode = PuckCriterion._classify_iff_mode_bc(
+            sn=-10.0, tnt=10.0 * slope, p_psc=0.25,
+        )
+        assert mode == "iff_mode_b"


### PR DESCRIPTION
## Summary
The Mode B / Mode C branch in `PuckCriterion._inter_fibre_failure` (puck.py:215-218) used a `|sigma_n|`-dependent threshold that algebraically collapsed to **`|tau_nt| >= S23`** — a constant on `|tau_nt|` alone, with no involvement of `sigma_n`. As a side effect it also **swapped the Mode B and Mode C labels** relative to the failure envelope geometry: high-shear mild-compression cases (Mode C wedge) ran through the Mode B formula, and vice versa.

Hand-checked sanity example from #85: at `(sigma_n, tau_nt) = (-10, 100)` MPa with `S23 = 60`, the broken code reported Mode B; Puck (1998, 2002) puts that point squarely in the Mode C wedge.

Closes #85.

## Fix
Replace the broken threshold with the geometric corner slope from Puck & Schurmann (2002): the Mode B/C corner sits at a constant `|tau_nt/sigma_n| = sqrt(1 + 2 * p_perp_psi_c)` regardless of stress magnitude. **Mode C governs above that ratio** (shear-dominated), **Mode B governs below** (compression-dominated). The slope is pre-computed once outside the `theta` loop.

```python
# Before — collapses to |tau_nt| >= S23, labels swapped
ratio = abs(tnt / sn) if abs(sn) > 1e-12 else float("inf")
threshold = S23 / abs(sn) if abs(sn) > 1e-12 else 0.0
if ratio >= threshold:
    # Mode B  ← but for high shear this is actually Mode C territory
    …

# After — stress-magnitude-independent, labels correct
if abs(tnt) > bc_corner_slope * abs(sn):
    # Mode C: shear-dominated, mild compression
    …
else:
    # Mode B: compression-dominated, mild shear
    …
```

## Testability
The classification is also exposed as a static helper `_classify_iff_mode_bc(sn, tnt, p_psc)` so it can be unit-tested directly. Testing through the public `evaluate()` worst-plane search would mask classification regressions: the Mode C formula has a `1/|sigma_n|` factor that blows up near the `sn = 0` zero crossing and dominates the `argmax`-over-`theta` result, so the public mode label of the worst plane is driven by the singularity rather than by which Mode B/C branch was selected at any given `theta`.

## Tests added
Five new tests in `tests/test_failure/test_puck.py::TestPuckIFFModeBCClassification`:

| Test | What it pins |
|---|---|
| `test_corner_slope_is_constant_function_of_p_psc` | The corner slope equals `sqrt(1+2*p_psc)` and is monotone in `p_psc`. |
| `test_high_shear_mild_compression_is_mode_c` | `(sn=-10, tnt=100) → Mode C` (issue #85 sanity case 1). |
| `test_high_compression_mild_shear_is_mode_b` | `(sn=-100, tnt=10) → Mode B` (issue #85 sanity case 2). |
| `test_threshold_independent_of_stress_magnitude` | Scaling `sn` and `tnt` by the same factor preserves the classification. |
| `test_classification_at_exact_corner` | Exact-tie resolves deterministically to Mode B. |

Existing uniaxial-at-allowable Puck tests (`test_pure_fibre_tension_at_Xt`, `test_pure_fibre_compression_at_Xc`, `test_pure_inplane_shear_at_S12`) are unaffected — they don't enter the Mode B/C branch.

## Pre-existing concern, **not** addressed here
The Mode C formula `bracket * (-Yc / sigma_n)` has a `1/|sigma_n|` singularity at `sigma_n → 0⁻`, so the worst-plane FI can blow up at theta values where the action-plane normal stress passes through zero. The broken threshold *accidentally* masked this for high-shear states (it forced Mode B for `|tnt| >= S23`, sidestepping the singularity). After this fix the singularity is exposed for those states. A follow-up should either route small-`|sigma_n|` cases to Mode A or introduce explicit transition damping — I'll file as a separate issue if not already tracked.

## Note on the issue's proposed code
The issue's recommended `mode_b = (abs(tnt) * RA_perp_perp) >= (tau_nt_c * abs(sn))` expands to `|tnt| >= sqrt(1 + 2*p_psc) * |sn|` — which would assign Mode B to the issue's own `(sn=-10, tnt=100)` Mode-C sanity case. The label is inverted relative to the acceptance-criteria examples. This PR implements the AC sanity-check semantics (Mode C for high shear-ratio).

## Test plan
- [x] `python -m py_compile src/wrinklefe/failure/puck.py tests/test_failure/test_puck.py`
- [ ] CI matrix runs the new `TestPuckIFFModeBCClassification` class.

https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmxgFuc3jqJAZdsU4SsC6f)_