### PR TITLE
Align package __version__ with pyproject/CITATION

### DIFF
--- a/src/wrinklefe/__init__.py
+++ b/src/wrinklefe/__init__.py
@@ -9,4 +9,6 @@ from importlib.metadata import version, PackageNotFoundError
 try:
     __version__ = version("wrinklefe")
 except PackageNotFoundError:
-    __version__ = "0.0.0+unknown"
+    # Fallback for when the package isn't installed (e.g. running from source).
+    # Keep this in sync with pyproject.toml and CITATION.cff.
+    __version__ = "1.0.0"

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -37,7 +37,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.0",
+        version="%(prog)s 1.0.0",
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")

--- a/src/wrinklefe/gui/main_window.py
+++ b/src/wrinklefe/gui/main_window.py
@@ -1395,7 +1395,7 @@ if HAS_PYQT6:
             """Show about dialog."""
             QMessageBox.about(
                 self, "About WrinkleFE",
-                "<h3>WrinkleFE v0.1.0</h3>"
+                "<h3>WrinkleFE v1.0.0</h3>"
                 "<p>Finite element analysis of wrinkled composite laminates.</p>"
                 "<p>Combines 3D cross-laminated plate theory with advanced "
                 "composite failure criteria for modeling fiber waviness "

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,46 @@
+"""Verify the package __version__ stays in sync with pyproject.toml."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+import wrinklefe
+
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _read_pyproject_version() -> str:
+    """Return the [project].version string declared in pyproject.toml.
+
+    Uses the stdlib ``tomllib`` on Python 3.11+ and falls back to the
+    third-party ``tomli`` package on older interpreters.
+    """
+    if sys.version_info >= (3, 11):
+        import tomllib  # type: ignore[import-not-found]
+    else:  # pragma: no cover - exercised only on <3.11 runners
+        try:
+            import tomli as tomllib  # type: ignore[import-not-found]
+        except ImportError:
+            pytest.skip("tomllib/tomli unavailable on this interpreter")
+
+    with PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["version"]
+
+
+def test_version_matches_pyproject() -> None:
+    """``wrinklefe.__version__`` must match the version in pyproject.toml."""
+    expected = _read_pyproject_version()
+    assert wrinklefe.__version__ == expected, (
+        f"wrinklefe.__version__={wrinklefe.__version__!r} but "
+        f"pyproject.toml declares {expected!r}"
+    )
+
+
+def test_version_is_canonical_one_zero_zero() -> None:
+    """Sanity check the canonical published version is 1.0.0."""
+    assert _read_pyproject_version() == "1.0.0"


### PR DESCRIPTION
## Summary
- Updates stale `0.1.0` strings in `src/wrinklefe/cli.py` (`--version`) and `src/wrinklefe/gui/main_window.py` (About dialog) to `1.0.0`, matching `pyproject.toml` and `CITATION.cff`.
- Updates the `__version__` fallback in `src/wrinklefe/__init__.py` from `"0.0.0+unknown"` to `"1.0.0"` (primary path still resolves via `importlib.metadata`).
- Adds `tests/test_version.py` that pins `wrinklefe.__version__` to the version declared in `pyproject.toml` (using `tomllib` / `tomli`).

## Test plan
- [x] `pytest tests/test_version.py -x` → 2 passed
- [ ] Verify `wrinklefe --version` prints `1.0.0` after install

Closes #21

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_