### PR TITLE
Docs: align README and CONTRIBUTING clone-path casing to wrinklefe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Thank you for your interest in contributing to WrinkleFE! This document provides
 
 ```bash
 # Clone the repository
-git clone https://github.com/elhajjar1/wrinkleFE.git
-cd wrinkleFE
+git clone https://github.com/elhajjar1/wrinklefe.git
+cd wrinklefe
 
 # Create a virtual environment
 python -m venv venv

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ An open-source Python finite element package for predicting strength and stiffne
 ### From source (recommended)
 
 ```bash
-git clone https://github.com/elhajjar1/WrinkleFE.git
-cd WrinkleFE
+git clone https://github.com/elhajjar1/wrinklefe.git
+cd wrinklefe
 pip install -e ".[all]"
 ```
 


### PR DESCRIPTION
## Summary
- README and CONTRIBUTING used inconsistent casing (`WrinkleFE` vs `wrinkleFE`) for clone URL and `cd` directory.
- Normalizes both to lowercase `wrinklefe`, matching the actual GitHub repo slug `ranipdx-glitch/wrinklefe`.
- Project-title / package-import / citation references left untouched; only clone-path/cd-directory casing changed (4 lines total).

## Test plan
- [x] `git diff` shows exactly 4 line changes (2 per file)
- [ ] Copy-paste the `git clone` + `cd` block from each doc and confirm it resolves

Closes #41

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_