### PR TITLE
Docs: remove dead reference to joss/generate_fig_elhajjar.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,6 @@ Validated against 31 experimental data points from three independent datasets:
 | Li et al. (2026) | Compression | 5 | 4/5 | 8.6% |
 | **Total** | | **31** | **28/31** | **9.5%** |
 
-The validation cases are documented in `figures/` but the regeneration script is not yet committed. Tracking issue: #22.
-
 ## How It Works
 
 ### Compression


### PR DESCRIPTION
## Summary
- README pointed to `joss/generate_fig_elhajjar.py`, which doesn't exist anywhere in the repo. The reference had been softened in a prior commit to a TODO note referencing this very issue.
- No `joss/` directory, no `generate_fig_elhajjar.py` script, and no `figures/fig_validation_elhajjar.png` are present.
- Removes the dead TODO line entirely. The validation table above it already documents the cases honestly.

## Test plan
- [x] `grep -r "generate_fig_elhajjar"` returns no hits after the change
- [x] No `joss/` references remain in README

Closes #22

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_