### PR TITLE
Docs: include E3 in PlyDiscount matrix-failure degradation list

### DIFF
--- a/src/wrinklefe/failure/progressive.py
+++ b/src/wrinklefe/failure/progressive.py
@@ -134,7 +134,7 @@ class PlyDiscount(ProgressiveDamageModel):
         - ``fiber_tension`` / ``fiber_compression``:
           E1, nu12, nu13 are multiplied by *residual_factor*.
         - ``matrix_tension`` / ``matrix_compression``:
-          E2, G12, G23, nu23 are multiplied by *residual_factor*.
+          E2, E3, G12, G23, nu23 are multiplied by *residual_factor*.
         - ``shear`` / ``shear_12``:
           G12 is multiplied by *residual_factor*.
         - ``shear_13``:


### PR DESCRIPTION
## Summary
- `PlyDiscount.degrade` actually degrades `E3` in the matrix-failure branch (`progressive.py:179` — `props["E3"] = material.E3 * r`), but its method docstring listed only `E2, G12, G23, nu23`.
- Adds `E3` to the docstring at `progressive.py:137`. One-line diff.
- Module-level docstring and `ProgressiveDamageModel.degrade` abstract docstring were already correct.

Also addresses the content of duplicate issue #33 (left untouched for triage).

## Test plan
- [x] `pytest tests/test_failure/ -x` → 128 passed, 1 xfailed

Closes #43

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_