### PR TITLE
Fix _max_consecutive_zero_plies: don't floor count to 1 (closes #14)

### DIFF
--- a/tests/test_max_consecutive_zero_plies.py
+++ b/tests/test_max_consecutive_zero_plies.py
@@ -1,0 +1,49 @@
+"""Regression tests for ``_max_consecutive_zero_plies`` (issue #14).
+
+The function previously floored its return value to 1, fabricating an
+adjacent 0-degree block (and a curved-beam OOP knockdown) for layups
+containing no 0-degree plies.  It must now return the true count: 0
+when no 0-degree plies are present.
+"""
+
+from __future__ import annotations
+
+from wrinklefe.analysis import _max_consecutive_zero_plies
+
+
+def test_no_zero_plies_returns_zero():
+    # [45/-45/90]_s has no 0-degree plies.
+    angles = [45.0, -45.0, 90.0, 90.0, -45.0, 45.0]
+    assert _max_consecutive_zero_plies(angles) == 0
+
+
+def test_empty_layup_returns_zero():
+    assert _max_consecutive_zero_plies([]) == 0
+
+
+def test_single_isolated_zero_ply_returns_one():
+    angles = [45.0, 0.0, -45.0, 90.0]
+    assert _max_consecutive_zero_plies(angles) == 1
+
+
+def test_three_consecutive_zero_plies_returns_three():
+    angles = [45.0, 0.0, 0.0, 0.0, -45.0, 90.0]
+    assert _max_consecutive_zero_plies(angles) == 3
+
+
+def test_two_separated_blocks_returns_max_block():
+    # Two pairs of 0-deg plies separated by 45-deg interleaves.
+    angles = [0.0, 0.0, 45.0, 0.0, 0.0, 0.0, 45.0]
+    assert _max_consecutive_zero_plies(angles) == 3
+
+
+def test_near_zero_within_tolerance_counts_as_zero():
+    # Default tol=5.0 deg; 3 deg is within tolerance.
+    angles = [3.0, -2.0, 1.0]
+    assert _max_consecutive_zero_plies(angles) == 3
+
+
+def test_outside_tolerance_not_counted():
+    # 10 deg is outside the default 5-deg tolerance.
+    angles = [10.0, -10.0, 10.0]
+    assert _max_consecutive_zero_plies(angles) == 0


### PR DESCRIPTION
## Summary

Issue #14 reported that `_max_consecutive_zero_plies` floored its result to 1, fabricating a phantom 0-degree block (and a curved-beam OOP knockdown) for layups like `[45/-45/90]_s` that contain no 0-degree plies.

The functional fix already landed in commit `5c60655` on `main`:

- `src/wrinklefe/analysis.py:232-251` — `max_count` initialises to 0 and is returned directly (no `max(_, 1)` floor).
- `src/wrinklefe/analysis.py:976` — the OOP caller short-circuits with `if n_adj_oop == 0 ...: kd_oop = 1.0`, so the mechanism is correctly inactive when there is no continuous 0-degree block.

What was missing was test coverage. This PR adds a regression test suite that locks in the corrected contract and prevents silent reintroduction of the floor.

## Test plan

- [x] `python -m pytest -x -q -k "zero_ply or max_consecutive"` -> 7 passed
- Cases covered:
  - `[45/-45/90]_s` (no 0-deg plies) -> 0
  - empty layup -> 0
  - single isolated 0-deg ply -> 1
  - three consecutive 0-deg plies -> 3
  - separated blocks -> max block size
  - near-zero within default 5-deg tolerance -> counted
  - 10-deg plies outside tolerance -> not counted

Closes #14.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_