### PR TITLE
Fix reaction_forces shape contract (closes #48)

### DIFF
--- a/src/wrinklefe/solver/results.py
+++ b/src/wrinklefe/solver/results.py
@@ -389,7 +389,7 @@ class FieldResults:
         K_global: sparse.csc_matrix,
         constrained_dofs: dict[int, float],
     ) -> np.ndarray:
-        """Compute reaction forces at constrained DOFs.
+        """Compute reaction forces at nodes with constrained DOFs.
 
         The reaction force vector is:
 
@@ -401,6 +401,11 @@ class FieldResults:
         (displacement BCs), the reaction at those DOFs is simply ``K @ u``
         restricted to the constrained rows.
 
+        Results are grouped by node (using the convention ``dof = 3 * node_id + d``
+        with ``d in {0, 1, 2}`` for ``Rx, Ry, Rz``).  For a node where only some
+        of the three DOFs are constrained, the unconstrained components are
+        reported as ``0.0``.
+
         Parameters
         ----------
         K_global : scipy.sparse.csc_matrix
@@ -411,19 +416,26 @@ class FieldResults:
         Returns
         -------
         np.ndarray
-            Shape ``(n_constrained, 4)`` array where each row is
-            ``[dof_index, Rx, Ry, Rz]``.  For a single-DOF constraint,
-            only the constrained component is non-zero, but the full
-            node reaction is returned when all 3 DOFs of a node are constrained.
+            Shape ``(n_nodes_with_reactions, 4)`` array where each row is
+            ``[node_id, Rx, Ry, Rz]``.  Rows are sorted by ``node_id``.
         """
         u_flat = self.displacement.ravel()
-        R_full = K_global @ u_flat  # full residual
+        R_full = np.asarray(K_global @ u_flat).ravel()  # full residual
 
-        dof_indices = sorted(constrained_dofs.keys())
-        result = np.empty((len(dof_indices), 2))
-        for i, dof in enumerate(dof_indices):
-            result[i, 0] = dof
-            result[i, 1] = R_full[dof]
+        # Group constrained DOFs by node id (dof = 3 * node + d).
+        node_reactions: dict[int, np.ndarray] = {}
+        for dof in constrained_dofs:
+            node_id = int(dof) // 3
+            d = int(dof) % 3
+            if node_id not in node_reactions:
+                node_reactions[node_id] = np.zeros(3, dtype=float)
+            node_reactions[node_id][d] = float(R_full[int(dof)])
+
+        node_ids = sorted(node_reactions.keys())
+        result = np.empty((len(node_ids), 4), dtype=float)
+        for i, node_id in enumerate(node_ids):
+            result[i, 0] = node_id
+            result[i, 1:4] = node_reactions[node_id]
 
         return result
 

--- a/tests/test_solver/test_static.py
+++ b/tests/test_solver/test_static.py
@@ -771,6 +771,44 @@ class TestFieldResults:
         n_gp = dummy_results.stress_global.shape[1]
         assert mp.shape == (n_elem, n_gp)
 
+    def test_reaction_forces_shape_and_equilibrium(
+        self, bar_mesh, single_ply_iso_laminate
+    ):
+        """Regression for issue #48: reaction_forces returns (n_nodes, 4).
+
+        Each row is ``[node_id, Rx, Ry, Rz]``.  For a static problem with
+        only displacement BCs and no external forces, the sum of reaction
+        components must equal the (zero) external load per direction
+        (Newton's third law / equilibrium).
+        """
+        # Solve a small compression problem to get a real K, u, and BC set.
+        solver = StaticSolver(bar_mesh, single_ply_iso_laminate)
+        bcs = BoundaryHandler.compression_bcs(bar_mesh, applied_strain=-0.005)
+        results = solver.solve(bcs, solver="direct")
+
+        # Reach into the solver's stored K and constrained DOFs map.
+        K = solver._K
+        constrained = solver._constrained_dofs
+        assert len(constrained) > 0
+
+        R = results.reaction_forces(K, constrained)
+
+        # --- Shape contract (the core of issue #48) ---
+        # One row per *node* that has any constrained DOF, with four columns.
+        expected_nodes = sorted({dof // 3 for dof in constrained})
+        assert R.ndim == 2
+        assert R.shape == (len(expected_nodes), 4)
+
+        # Column 0 is the node id; remaining columns are Rx, Ry, Rz.
+        assert np.array_equal(R[:, 0].astype(int), np.array(expected_nodes))
+
+        # --- Equilibrium: only displacement BCs and zero external load,
+        # so global reaction sums must equal zero (the applied load).
+        # Use a tolerance scaled by the magnitude of the reactions.
+        R_total = R[:, 1:4].sum(axis=0)
+        scale = max(np.abs(R[:, 1:4]).max(), 1.0)
+        np.testing.assert_allclose(R_total, 0.0, atol=1e-6 * scale)
+
 
 # ======================================================================
 # Integration test: manual solve with assembler + handler (no StaticSolver)


### PR DESCRIPTION
## Summary

Fixes #48. `FieldResults.reaction_forces` previously returned an array of shape `(n_constrained, 2)` with `[dof_index, R_dof]` per row, contradicting its docstring promise of `(n, 4)` with `[dof_index, Rx, Ry, Rz]`. A caller written to the documented contract would either hit `IndexError` on `result[:, 1:4]` or silently misinterpret a single scalar as a vector.

Per the issue's recommended Option 1, this PR makes the implementation match the docstring (the more useful API):

- Group constrained DOFs by node id using the `dof = 3 * node_id + d` convention used throughout the solver (`boundary.py:212`).
- Return one row per node containing `[node_id, Rx, Ry, Rz]`, with `0.0` placed in any DOF component that wasn't constrained for that node.
- Tightened the docstring to spell out the column meanings and the sort/zero-fill behaviour.

No production callers of `reaction_forces` existed in the repo (`grep` across `src/` and `tests/`), so no downstream call sites needed updating.

## Test plan

- [x] Added `TestFieldResults.test_reaction_forces_shape_and_equilibrium` — a regression test that:
  - Solves a real compression problem on the existing `bar_mesh` fixture.
  - Asserts `R.shape == (n_constrained_nodes, 4)`.
  - Asserts column 0 holds sorted node ids.
  - Asserts global equilibrium: `R[:, 1:4].sum(axis=0) == 0` (no external load, only displacement BCs) to pin the column meanings via physics, not the implementation.
- [x] `python -m pytest -x -q -k "reaction"` -> 1 passed.
- [x] `python -m pytest -x -q tests/test_solver/test_static.py` -> 55 passed (no regressions).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_