### PR TITLE
Fix Hex8: raise on non-positive Jacobian determinant (closes #45)

### DIFF
--- a/src/wrinklefe/elements/hex8.py
+++ b/src/wrinklefe/elements/hex8.py
@@ -81,6 +81,8 @@ class Hex8Element:
         material: OrthotropicMaterial,
         ply_angle: float = 0.0,
         wrinkle_angles: np.ndarray | None = None,
+        elem_id: int | None = None,
+        strict_jacobian: bool = True,
     ) -> None:
         self.node_coords = np.asarray(node_coords, dtype=float)
         if self.node_coords.shape != (8, 3):
@@ -100,8 +102,63 @@ class Hex8Element:
                 f"wrinkle_angles must have shape (8,), got {self.wrinkle_angles.shape}."
             )
 
+        self.elem_id = elem_id
+        self.strict_jacobian = bool(strict_jacobian)
+
         # Pre-compute Gauss quadrature points and weights (2x2x2 for hex8)
         self._gauss_points, self._gauss_weights = gauss_points_hex(order=2)
+
+    # ------------------------------------------------------------------
+    # Jacobian determinant validation
+    # ------------------------------------------------------------------
+
+    # Tolerance below which |detJ| is treated as zero (degenerate element).
+    _JAC_ZERO_TOL: float = 1.0e-14
+
+    def _check_detJ(self, detJ: float, gp_index: int | None = None) -> float:
+        """Validate a Jacobian determinant value at a quadrature point.
+
+        Raises a descriptive ``ValueError`` if ``detJ`` is non-positive
+        (inverted element) or effectively zero (degenerate / zero-volume
+        element).  This guard is enabled by default; pass
+        ``strict_jacobian=False`` to the element constructor to opt out
+        (not recommended — silently using ``abs(detJ)`` yields a
+        non-physical, possibly negative-definite element stiffness).
+
+        Parameters
+        ----------
+        detJ : float
+            Computed determinant of the Jacobian at a quadrature point.
+        gp_index : int or None, optional
+            Index of the offending Gauss point, used only in the error
+            message.
+
+        Returns
+        -------
+        float
+            ``detJ`` unchanged when the check passes (or when strict
+            checking is disabled).
+        """
+        if not self.strict_jacobian:
+            return detJ
+
+        if detJ <= 0.0 or abs(detJ) < self._JAC_ZERO_TOL:
+            elem_label = (
+                f"Hex8 element {self.elem_id}"
+                if self.elem_id is not None
+                else "Hex8 element"
+            )
+            gp_label = (
+                f" at gauss point {gp_index}"
+                if gp_index is not None
+                else ""
+            )
+            raise ValueError(
+                f"{elem_label}: non-positive Jacobian determinant "
+                f"{detJ:.3e}{gp_label}; element is inverted or degenerate. "
+                "Check node ordering and mesh quality."
+            )
+        return detJ
 
     # ------------------------------------------------------------------
     # Shape functions
@@ -202,6 +259,7 @@ class Hex8Element:
         """
         dN_dxi = self.shape_derivatives(xi, eta, zeta)  # (3, 8)
         J = dN_dxi @ self.node_coords  # (3, 3)
+        self._check_detJ(float(np.linalg.det(J)))
         J_inv = np.linalg.inv(J)
         dN_dx = J_inv @ dN_dxi  # (3, 8) — derivatives in physical coords
 
@@ -295,10 +353,15 @@ class Hex8Element:
             xi, eta, zeta = self._gauss_points[gp_idx]
             w = self._gauss_weights[gp_idx]
 
+            # Check Jacobian determinant first so that an inverted or
+            # degenerate element is rejected with a Gauss-point-aware
+            # error message (issue #45) before B_matrix attempts its
+            # own (less informative) check.
+            J = self.jacobian(xi, eta, zeta)  # (3, 3)
+            detJ = self._check_detJ(float(np.linalg.det(J)), gp_index=gp_idx)
+
             B = self.B_matrix(xi, eta, zeta)  # (6, 24)
             C_bar = self.rotated_stiffness(xi, eta, zeta)  # (6, 6)
-            J = self.jacobian(xi, eta, zeta)  # (3, 3)
-            detJ = np.linalg.det(J)
 
             Ke += (B.T @ C_bar @ B) * detJ * w
 
@@ -390,9 +453,9 @@ class Hex8Element:
             xi, eta, zeta = self._gauss_points[gp_idx]
             w = self._gauss_weights[gp_idx]
 
-            N_scalar = self.shape_functions(xi, eta, zeta)  # (8,)
             J = self.jacobian(xi, eta, zeta)
-            detJ = np.linalg.det(J)
+            detJ = self._check_detJ(float(np.linalg.det(J)), gp_index=gp_idx)
+            N_scalar = self.shape_functions(xi, eta, zeta)  # (8,)
 
             # Build (3, 24) shape function matrix: N_mat
             N_mat = np.zeros((3, 24))
@@ -426,7 +489,8 @@ class Hex8Element:
             xi, eta, zeta = self._gauss_points[gp_idx]
             w = self._gauss_weights[gp_idx]
             J = self.jacobian(xi, eta, zeta)
-            vol += np.linalg.det(J) * w
+            detJ = self._check_detJ(float(np.linalg.det(J)), gp_index=gp_idx)
+            vol += detJ * w
         return float(vol)
 
     # ------------------------------------------------------------------

--- a/src/wrinklefe/elements/hex8i.py
+++ b/src/wrinklefe/elements/hex8i.py
@@ -106,8 +106,17 @@ class Hex8IElement(Hex8Element):
         material: OrthotropicMaterial,
         ply_angle: float = 0.0,
         wrinkle_angles: np.ndarray | None = None,
+        elem_id: int | None = None,
+        strict_jacobian: bool = True,
     ) -> None:
-        super().__init__(node_coords, material, ply_angle, wrinkle_angles)
+        super().__init__(
+            node_coords,
+            material,
+            ply_angle,
+            wrinkle_angles,
+            elem_id=elem_id,
+            strict_jacobian=strict_jacobian,
+        )
 
         # Caches for static condensation — populated by stiffness_matrix()
         self._K_aa_inv: np.ndarray | None = None
@@ -135,7 +144,7 @@ class Hex8IElement(Hex8Element):
             Shape ``(3, 3)`` — inverse of *J0*.
         """
         J0 = self.jacobian(0.0, 0.0, 0.0)
-        detJ0 = np.linalg.det(J0)
+        detJ0 = self._check_detJ(float(np.linalg.det(J0)), gp_index=None)
         J0_inv = np.linalg.inv(J0)
         return J0, detJ0, J0_inv
 
@@ -248,7 +257,7 @@ class Hex8IElement(Hex8Element):
 
         # Patch-test correction: scale by detJ0 / detJ(xi, eta, zeta)
         J_local = self.jacobian(xi, eta, zeta)
-        detJ_local = np.linalg.det(J_local)
+        detJ_local = self._check_detJ(float(np.linalg.det(J_local)))
         scale = self._detJ0 / detJ_local
 
         dP_dphys = dP_dphys * scale
@@ -335,10 +344,13 @@ class Hex8IElement(Hex8Element):
             zeta = gp_coords[i_gp, 2]
             w_gp = gp_weights[i_gp]
 
-            # Standard B matrix and Jacobian from parent class
-            B = self.B_matrix(xi, eta, zeta)          # (6, 24)
+            # Check Jacobian determinant first to surface a Gauss-point-
+            # aware error for inverted/degenerate elements (issue #45).
             J = self.jacobian(xi, eta, zeta)           # (3, 3)
-            detJ = np.linalg.det(J)
+            detJ = self._check_detJ(float(np.linalg.det(J)), gp_index=i_gp)
+
+            # Standard B matrix from parent class
+            B = self.B_matrix(xi, eta, zeta)          # (6, 24)
 
             # Rotated material stiffness at this point
             C_bar = self.rotated_stiffness(xi, eta, zeta)  # (6, 6)

--- a/tests/test_elements/test_hex8.py
+++ b/tests/test_elements/test_hex8.py
@@ -545,3 +545,108 @@ class TestRotatedStiffness:
         C_pristine = x850_material.stiffness_matrix
         # Wrinkle rotation should change the stiffness
         assert not np.allclose(C_wrinkled, C_pristine, atol=1e-6)
+
+
+# ======================================================================
+# Jacobian determinant guard (issue #45)
+# ======================================================================
+
+class TestJacobianGuard:
+    """Hex8 must refuse to assemble stiffness for inverted/degenerate
+    elements rather than silently producing negative stiffness.
+    """
+
+    @staticmethod
+    def _inverted_cube_nodes():
+        """Unit cube with two nodes swapped to invert the element.
+
+        Swapping nodes 0 and 4 mirrors the bottom and top faces and
+        reverses the local zeta axis, producing det(J) < 0.
+        """
+        nodes = np.array([
+            [0.0, 0.0, 1.0],  # 0  (was node 4)
+            [1.0, 0.0, 0.0],  # 1
+            [1.0, 1.0, 0.0],  # 2
+            [0.0, 1.0, 0.0],  # 3
+            [0.0, 0.0, 0.0],  # 4  (was node 0)
+            [1.0, 0.0, 1.0],  # 5
+            [1.0, 1.0, 1.0],  # 6
+            [0.0, 1.0, 1.0],  # 7
+        ], dtype=float)
+        return nodes
+
+    @staticmethod
+    def _degenerate_cube_nodes():
+        """Cube flattened to zero thickness in z (zero-volume)."""
+        return np.array([
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ], dtype=float)
+
+    def test_wellformed_hex_passes(self, unit_cube_element):
+        """A well-formed hex assembles its stiffness without raising."""
+        Ke = unit_cube_element.stiffness_matrix()
+        assert Ke.shape == (24, 24)
+        # Positive-definite contribution: diagonal must be strictly positive
+        assert np.all(np.diag(Ke) > 0.0)
+
+    def test_inverted_hex_raises_valueerror(self, x850_material):
+        """An inverted element raises ValueError with a clear message."""
+        nodes = self._inverted_cube_nodes()
+        elem = Hex8Element(nodes, x850_material, elem_id=42)
+
+        with pytest.raises(ValueError, match="non-positive Jacobian"):
+            elem.stiffness_matrix()
+
+    def test_inverted_hex_error_mentions_element_and_gauss_point(
+        self, x850_material
+    ):
+        """The error message identifies the element and Gauss point."""
+        nodes = self._inverted_cube_nodes()
+        elem = Hex8Element(nodes, x850_material, elem_id=7)
+
+        with pytest.raises(ValueError) as exc_info:
+            elem.stiffness_matrix()
+
+        msg = str(exc_info.value)
+        assert "Hex8 element 7" in msg
+        assert "gauss point" in msg
+        assert "inverted or degenerate" in msg
+
+    def test_degenerate_hex_raises(self, x850_material):
+        """A zero-volume (collapsed) element also raises."""
+        nodes = self._degenerate_cube_nodes()
+        elem = Hex8Element(nodes, x850_material)
+
+        with pytest.raises(ValueError, match="non-positive Jacobian"):
+            elem.stiffness_matrix()
+
+    def test_opt_out_allows_inverted(self, x850_material):
+        """With strict_jacobian=False, inverted elements no longer raise."""
+        nodes = self._inverted_cube_nodes()
+        elem = Hex8Element(nodes, x850_material, strict_jacobian=False)
+        # Should not raise — caller has explicitly opted out of the guard.
+        Ke = elem.stiffness_matrix()
+        assert Ke.shape == (24, 24)
+
+    def test_mass_matrix_also_guarded(self, x850_material):
+        """The Jacobian guard applies to mass assembly as well."""
+        nodes = self._inverted_cube_nodes()
+        elem = Hex8Element(nodes, x850_material)
+
+        with pytest.raises(ValueError, match="non-positive Jacobian"):
+            elem.mass_matrix()
+
+    def test_volume_guarded(self, x850_material):
+        """Volume integration also raises for an inverted element."""
+        nodes = self._inverted_cube_nodes()
+        elem = Hex8Element(nodes, x850_material)
+
+        with pytest.raises(ValueError, match="non-positive Jacobian"):
+            _ = elem.volume

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -29,8 +29,12 @@ from wrinklefe.io.export import export_abaqus_inp, export_results_json, export_v
 def analysis_result():
     """Run a small WrinkleAnalysis once for the entire module."""
     mat = MaterialLibrary().get("IM7_8552")
+    # NOTE: amplitude kept below the inversion threshold for this 1-element-
+    # per-ply mesh; the original 0.366 mm value produced inverted hex
+    # elements (see issue #45) and was silently masked by the old
+    # abs(detJ) behaviour.
     cfg = AnalysisConfig(
-        amplitude=0.366,
+        amplitude=0.25,
         wavelength=16.0,
         width=12.0,
         morphology="stack",
@@ -77,7 +81,7 @@ class TestJSONExport:
         out = tmp_path / "results.json"
         export_results_json(analysis_result, out)
         cfg = json.loads(out.read_text())["configuration"]
-        assert cfg["amplitude_mm"] == pytest.approx(0.366)
+        assert cfg["amplitude_mm"] == pytest.approx(0.25)
         assert cfg["wavelength_mm"] == pytest.approx(16.0)
         assert cfg["morphology"] == "stack"
         assert cfg["loading"] == "compression"


### PR DESCRIPTION
## Summary

Closes #45.

`Hex8Element` (and the derived `Hex8IElement`) previously used `detJ = np.linalg.det(J)` directly in stiffness, mass, and volume integration with no sign or zero-volume guard. Reversed node ordering or excessive wrinkle amplitude could yield `det(J) < 0`, silently contributing **negative stiffness** to the global matrix and producing plausible-looking but non-physical results.

- New `_check_detJ` helper on `Hex8Element` raises a descriptive `ValueError` (element id, Gauss-point index, and the offending value) when `det(J) <= 0` or `|det(J)| < 1e-14`.
- Guard is wired into `B_matrix`, `stiffness_matrix`, `mass_matrix`, `volume`, `_jacobian_at_center`, `G_matrix`, and `Hex8IElement.stiffness_matrix`.
- Strict by default; pass `strict_jacobian=False` to the element constructor to opt out (not recommended).
- Element now accepts an optional `elem_id` so messages can identify which element is inverted.

## Bug uncovered

Adding the guard exposed a pre-existing silent-correctness issue in the `test_io/test_export.py` fixture: with `amplitude=0.366 mm` on a 1-element-per-ply mesh, the wrinkle deformation actually inverts hexes. The old `abs(detJ)`-style path was hiding this. The fixture amplitude is reduced to `0.25 mm` (below the inversion threshold for that mesh) so the export tests continue to exercise a valid mesh.

## Test plan

- [x] `python -m pytest -x -q -k "hex8 or jacobian"` -> 88 passed
- [x] Full suite: `python -m pytest -q` -> 596 passed, 1 xfailed
- [x] New `TestJacobianGuard` covers: well-formed hex passes; inverted hex raises with element-id + Gauss-point in the message; degenerate (zero-volume) hex raises; `strict_jacobian=False` allows opt-out; `mass_matrix` and `volume` are likewise guarded.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_