### PR TITLE
Streamlit: move layup info from tab to ? help tooltip (closes #124)

### DIFF
--- a/app.py
+++ b/app.py
@@ -355,11 +355,7 @@ with st.sidebar:
         value=DEFAULT_LAYUP, height=80,
         help=(
             "Accepts contracted notation like `[0/45/-45/90]_3s` "
-            "or an explicit comma-separated list of angles in degrees."
-        ),
-    )
-    with st.popover("Layup notation help", use_container_width=True):
-        st.markdown(
+            "or an explicit comma-separated list of angles in degrees.\n\n"
             "**Contracted notation** — sublaminate in square brackets, "
             "plies separated by `/`, optional repeat count and trailing "
             "`s` for symmetry:\n\n"
@@ -377,7 +373,8 @@ with st.sidebar:
             "**Explicit list** — comma-, semicolon-, or newline-separated "
             "angles, e.g. `0, 45, -45, 90, 90, -45, 45, 0`. Both forms can be "
             "edited freely in the textarea above."
-        )
+        ),
+    )
 
     st.markdown("**Wrinkle geometry**")
     amplitude = st.number_input(


### PR DESCRIPTION
Closes #124.

## What changed
- **File:** `app.py`
- **Widget:** the `st.text_area("Layup", ...)` in the sidebar (around line 353).
- Merged the body of the adjacent `st.popover("Layup notation help", ...)` block into the widget's `help=` kwarg so the full notation reference now lives in the native `?` tooltip next to the input label.
- Removed the now-redundant `st.popover` block (and its `st.markdown` body) that sat directly below the layup textarea.

## Before
```
[ Layup textarea ]      (help= = one-line summary)
[ ► Layup notation help ]   <-- popover button taking sidebar width
   (table + modifiers + explicit-list explanation)
```

## After
```
[ Layup textarea  (?) ]   <-- ? tooltip = full notation reference
```

The full markdown body (contracted-notation table, modifier bullets, explicit-list note) is preserved verbatim inside `help=`. Streamlit renders markdown — including tables and code spans — in tooltips, so the content reads the same on hover/tap.

Scoped to layup only per the issue; amplitude, wavelength, and morphology inputs are untouched.

## Verification
- `python -c "import ast; ast.parse(open('app.py').read())"` passes.
- Diff is 3 insertions / 6 deletions, purely in the sidebar layup block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_