### PR TITLE
CI: run ruff and mypy on PRs (closes #87)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install lint tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      # Starter scope: only the bug-catching rules that are clean on `main` today.
+      # Full ruff config in pyproject.toml currently has ~840 violations across the
+      # repo; that will be addressed in a follow-up cleanup PR (see issue #87).
+      - name: Ruff (starter scope - E9,F63,F7,F82)
+        run: ruff check --select E9,F63,F7,F82 .
+
+      # Starter scope: package `__init__` only. Broader src/wrinklefe has ~102
+      # mypy errors today (mostly numpy `Any` returns + missing stubs); fixing
+      # those is tracked as a follow-up to issue #87.
+      - name: Mypy (starter scope - package init)
+        run: mypy src/wrinklefe/__init__.py


### PR DESCRIPTION
## Summary

Adds a new `.github/workflows/lint.yml` workflow so ruff and mypy actually run on PRs. Previously both tools were configured in `pyproject.toml` ([tool.ruff.lint] selects E,F,W,I,N,UP and [tool.mypy] with `warn_return_any`) but never invoked by any workflow, letting style and type regressions land on `main` unnoticed.

The new workflow is intentionally a **separate file** rather than steps grafted onto `ci.yml` / `tests.yml`, so a lint failure does not get conflated with a test-matrix failure across 3 Python versions x 2 OSes. It runs on `ubuntu-latest` + Python 3.11 only — no matrix needed for lint.

Closes #87.

## Scope choice: (b) starter scope, with follow-up TODOs

Running the configured ruff / mypy locally against `main` produced a lot of pre-existing debt:

- `ruff check .` (full config E,F,W,I,N,UP): **840 violations**
- `mypy src/wrinklefe`: **102 errors in 31 files** (mostly numpy stubs missing + `Any` returns)

Fixing 800+ ruff hits and 100+ mypy errors in a single PR would balloon the diff and bury the workflow change. Instead this PR picks a **starter scope that is clean on `main` today** so the new check is green on first run:

- **Ruff:** `ruff check --select E9,F63,F7,F82 .` — syntax errors + the most serious pyflakes bugs (undefined names, invalid `print`/`raise`, etc). Passes clean today.
- **Mypy:** `mypy src/wrinklefe/__init__.py` — the only file that passes the project's mypy config today. Passes clean today.

Both commands run locally on this branch and report success.

## Follow-up TODOs (deferred, not in this PR)

These should land as separate PRs so each one is small and reviewable:

1. **Ruff cleanup pass — auto-fixable rules.** `ruff check . --select F --fix` auto-fixes ~42/54 F-rule violations (unused imports, empty f-strings). The remaining 12 F841 unused-variable hits need a human eye. ~70 violations under E,F,W after that cleanup.
2. **Ruff cleanup pass — I (import sort), N (naming), UP (pyupgrade).** Bulk of the 840-count comes from `I001` and `UP` — mostly mechanical.
3. **Mypy: install numpy/scipy stubs in the dev extra** (`types-...` or rely on numpy's own typing) so the bulk of import-not-found errors disappear.
4. **Mypy: widen scope module-by-module** as `Any`-return / `Union`-attribute issues get fixed. `core/` is closest (16 errors).
5. **Optional:** add `.pre-commit-config.yaml` wiring up the same hooks — explicitly asked for in issue #87, deferred here to keep this PR focused on CI.
6. **Optional:** add `ruff format --check .` once the codebase has been auto-formatted once.

The starter scope is documented in comments in `lint.yml` so the next contributor sees exactly which `--select` / path to widen.

## What is **not** done in this PR

- Not added to required-checks (requires repo settings access).
- Not touching `ci.yml` / `tests.yml` — they continue to run pytest as before.
- No code changes outside `.github/workflows/`.

## Test plan

- [ ] GitHub Actions runs the new `Lint` workflow on this PR.
- [ ] Both `Ruff (starter scope - E9,F63,F7,F82)` and `Mypy (starter scope - package init)` steps pass.
- [ ] Existing `CI` and `tests` workflows still run pytest and stay green (no changes to those files).

Local verification on this branch:
```
$ ruff check --select E9,F63,F7,F82 .
All checks passed!
$ mypy src/wrinklefe/__init__.py
Success: no issues found in 1 source file
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_