### PR TITLE
Fix MeshData.nodes_on_face for wrinkled z surfaces (closes #93)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -200,13 +200,25 @@ class MeshData:
                 f"Unknown face '{face}'. Must be one of {list(axis_map)}"
             )
         axis, side = axis_map[face]
-        coords = self.nodes[:, axis]
-        tol = 1.0e-10 * (coords.max() - coords.min() + 1.0e-30)
-        if side == "min":
-            target = coords.min()
-        else:
-            target = coords.max()
-        return np.flatnonzero(np.abs(coords - target) < tol)
+
+        # Resolve faces topologically using the structured (i, j, k) grid
+        # rather than geometrically.  On wrinkled meshes the z-coordinates of
+        # the k=0 and k=nz planes are perturbed, so an exact-equality test
+        # against ``coords.min()/max()`` silently drops most surface nodes
+        # (see issue #93).  Using the (i, j, k) layout — i fastest, k slowest
+        # with node index ``k*(ny+1)*(nx+1) + j*(nx+1) + i`` — makes the face
+        # sets independent of geometry and correct for both flat and wrinkled
+        # meshes.
+        nxp = self.nx + 1
+        nyp = self.ny + 1
+        n = self.n_nodes
+        # Recover (i, j, k) for every node from its flat index.
+        flat = np.arange(n)
+        k_idx, rem = np.divmod(flat, nxp * nyp)
+        j_idx, i_idx = np.divmod(rem, nxp)
+        grid_idx = (i_idx, j_idx, k_idx)[axis]
+        target_grid = 0 if side == "min" else (self.nx, self.ny, self.nz)[axis]
+        return np.flatnonzero(grid_idx == target_grid)
 
     def elements_in_ply(self, ply_idx: int) -> np.ndarray:
         """Return element indices belonging to a given ply.

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -239,6 +239,41 @@ class TestWrinkledMesh:
         expected = (nx + 1) * (ny + 1) * (nz + 1)
         assert wrinkled_mesh.n_nodes == expected
 
+    def test_wrinkled_z_min_face_count(self, small_laminate, wrinkled_mesh):
+        """On a wrinkled mesh, z_min must still return the full k=0 plane.
+
+        Regression test for issue #93: the old geometric tolerance test
+        silently dropped nodes whose perturbed z deviated from the global
+        minimum z, leaving only the trough nodes.
+        """
+        nx, ny, nz_per_ply = 4, 3, 1
+        nz = small_laminate.n_plies * nz_per_ply
+        face_nodes = wrinkled_mesh.nodes_on_face("z_min")
+        assert len(face_nodes) == (nx + 1) * (ny + 1)
+        # The k=0 plane is the first (nx+1)*(ny+1) nodes in canonical order.
+        expected_nodes = np.arange((nx + 1) * (ny + 1))
+        npt.assert_array_equal(face_nodes, expected_nodes)
+
+    def test_wrinkled_z_max_face_count(self, small_laminate, wrinkled_mesh):
+        """On a wrinkled mesh, z_max must still return the full k=nz plane."""
+        nx, ny, nz_per_ply = 4, 3, 1
+        nz = small_laminate.n_plies * nz_per_ply
+        face_nodes = wrinkled_mesh.nodes_on_face("z_max")
+        assert len(face_nodes) == (nx + 1) * (ny + 1)
+        # The k=nz plane is the last (nx+1)*(ny+1) nodes in canonical order.
+        n_per_layer = (nx + 1) * (ny + 1)
+        expected_nodes = np.arange(nz * n_per_layer, (nz + 1) * n_per_layer)
+        npt.assert_array_equal(face_nodes, expected_nodes)
+
+    def test_wrinkled_x_y_faces_unaffected(self, wrinkled_mesh):
+        """x/y faces should also still produce the correct surface count."""
+        nx, ny, nz_per_ply = 4, 3, 1
+        nz = 4 * nz_per_ply  # 4-ply laminate
+        assert len(wrinkled_mesh.nodes_on_face("x_min")) == (ny + 1) * (nz + 1)
+        assert len(wrinkled_mesh.nodes_on_face("x_max")) == (ny + 1) * (nz + 1)
+        assert len(wrinkled_mesh.nodes_on_face("y_min")) == (nx + 1) * (nz + 1)
+        assert len(wrinkled_mesh.nodes_on_face("y_max")) == (nx + 1) * (nz + 1)
+
 
 class TestMeshValidation:
     """Test WrinkleMesh input validation."""


### PR DESCRIPTION
## Summary
- Resolve `MeshData.nodes_on_face` topologically via the structured `(i, j, k)` grid (i fastest, k slowest) instead of a geometric `coords.min()/max()` equality test.
- The previous tolerance (`1e-10 * coord_range`) was orders of magnitude tighter than the wrinkle amplitude, so on a wrinkled mesh `z_min` and `z_max` returned only the global trough/crest nodes and silently dropped the rest of the k=0 / k=nz plane.
- Effect: boundary-condition application (`solver/boundary.py`), Abaqus NSETs, and VTK/INP exports now get the full `(nx+1)*(ny+1)` surface-node set on wrinkled meshes.

## Root cause
`src/wrinklefe/core/mesh.py:202-209` compared each node's coord against `coords.min()/max()` within `1e-10 * (range)`. For a wrinkled laminate the z range is `H + 2A`, so the tolerance was tiny relative to the wrinkle excursion — only nodes exactly at the global min/max survived.

## Test plan
- [x] `python -m pytest -x -q -k "nodes_on_face or face"` — 23 passed (was 20 before; +3 new regression tests).
- [x] `python -m pytest -q tests/test_mesh.py` — 39 passed.
- [x] New tests assert `z_min`/`z_max` on a wrinkled mesh return exactly `(nx+1)*(ny+1)` nodes and that the indices match the canonical k=0 / k=nz planes.
- [x] x/y face counts on a wrinkled mesh unaffected.

Closes #93.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_