### PR TITLE
Fix _extrapolate_to_nodes: align Gauss-point and node ordering (closes #51)

### DIFF
--- a/src/wrinklefe/solver/static.py
+++ b/src/wrinklefe/solver/static.py
@@ -564,52 +564,152 @@ class StaticSolver:
 
         return stress_global, stress_local, strain_global, strain_local
 
+    # Cached (extrapolation_matrix, node_to_gp) for hex8 / 2x2x2.
+    # Populated lazily by :meth:`_extrapolate_to_nodes`.
+    _hex8_extrap_cache: tuple[np.ndarray, np.ndarray] | None = None
+
+    @classmethod
+    def _build_hex8_extrapolation(cls) -> tuple[np.ndarray, np.ndarray]:
+        """Build (and cache) the hex8 / 2x2x2 Gauss-to-node extrapolation matrix.
+
+        Two ordering conventions are at play and **must not be conflated**:
+
+        - ``gauss_points_hex(order=2)`` orders the 8 Gauss points
+          **lexicographically** in ``(xi, eta, zeta)`` via
+          ``np.meshgrid(..., indexing="ij")`` — zeta varies fastest.
+        - :data:`wrinklefe.elements.hex8._NODE_COORDS` orders the 8 nodes by
+          the **VTK / Abaqus** convention (bottom face CCW, then top face CCW).
+
+        The i-th Gauss point is **not** at the natural coordinate of the
+        i-th node.  Pairing them by index alone (a tempting but wrong
+        simplification) scrambles the extrapolated nodal field — this is
+        the trap reported in issue #51.
+
+        We build the relationship explicitly: for each VTK node *j*, find
+        the lexicographic Gauss-point index ``node_to_gp[j]`` whose natural
+        coordinates have the same sign pattern as node *j*.  That gives
+        the 1-to-1 nearest-neighbour mapping the caller usually wants for
+        diagnostics, and is used by the regression test in
+        ``tests/test_solver/test_extrapolate.py``.
+
+        The extrapolation itself uses the full inverse shape-function
+        matrix (not just the nearest-neighbour pairing), which is exact
+        for a tri-linear field:
+
+        .. math::
+
+            \\mathbf{N}_{gp}[i, j] = N_j(\\xi_{gp,i})
+            \\quad\\Rightarrow\\quad
+            \\mathbf{f}_{nodes} = \\mathbf{N}_{gp}^{-1} \\, \\mathbf{f}_{gp}
+
+        where row *i* uses **lex** Gauss-point ordering and column *j* uses
+        **VTK** node ordering — so the output is naturally indexed by VTK
+        node order, matching ``mesh.elements`` connectivity.
+
+        Returns
+        -------
+        N_inv : np.ndarray
+            Shape ``(8, 8)`` — extrapolation matrix; ``f_nodes = N_inv @ f_gp``
+            where ``f_gp`` is in **lex** order and ``f_nodes`` is in **VTK**
+            order.
+        node_to_gp : np.ndarray
+            Shape ``(8,)`` integer array; ``node_to_gp[j]`` is the lex GP
+            index nearest to VTK node *j*.  For the default conventions
+            this is ``[0, 4, 6, 2, 1, 5, 7, 3]``.
+        """
+        if cls._hex8_extrap_cache is not None:
+            return cls._hex8_extrap_cache
+
+        from wrinklefe.elements.hex8 import Hex8Element, _NODE_COORDS
+        from wrinklefe.elements.gauss import gauss_points_hex
+
+        gp_coords, _ = gauss_points_hex(order=2)  # lex order, shape (8, 3)
+
+        # Build node->GP nearest mapping by matching sign patterns.  Each
+        # GP sits at the centroid of one of the 8 sub-cubes; for a hex8
+        # the unambiguous pairing is by sign of (xi, eta, zeta).
+        node_to_gp = np.empty(8, dtype=int)
+        for j in range(8):
+            target = _NODE_COORDS[j]  # (+/-1, +/-1, +/-1)
+            # Use sign-match: argmin over distance is equivalent here and
+            # is robust to any future change in the GP magnitudes.
+            sign_match = np.all(
+                np.sign(gp_coords) == np.sign(target)[None, :], axis=1
+            )
+            matches = np.flatnonzero(sign_match)
+            if matches.size != 1:
+                raise RuntimeError(
+                    "Failed to pair hex8 VTK node {} with a unique 2x2x2 "
+                    "Gauss point (matches={}). Did the GP or node ordering "
+                    "convention change?".format(j, matches.tolist())
+                )
+            node_to_gp[j] = int(matches[0])
+
+        # Sanity check: mapping must be a permutation of 0..7.
+        if sorted(node_to_gp.tolist()) != list(range(8)):
+            raise RuntimeError(
+                "hex8 node->GP mapping is not a permutation: "
+                f"{node_to_gp.tolist()}"
+            )
+
+        # Build shape-function matrix: row i uses lex GP i, col j is VTK node j.
+        N_gp = np.empty((8, 8))
+        for i in range(8):
+            xi, eta, zeta = gp_coords[i]
+            N_gp[i] = Hex8Element.shape_functions(xi, eta, zeta)
+        N_inv = np.linalg.inv(N_gp)
+
+        cls._hex8_extrap_cache = (N_inv, node_to_gp)
+        return cls._hex8_extrap_cache
+
     def _extrapolate_to_nodes(self, gauss_values: np.ndarray) -> np.ndarray:
         """Extrapolate values from 2x2x2 Gauss points to 8 hex nodes.
 
         Uses the inverse of the shape function matrix evaluated at the
-        Gauss points.  For a hex8 element with 2x2x2 Gauss quadrature,
-        the 8 Gauss points and 8 nodes yield a square (8x8) interpolation
-        matrix whose inverse provides the extrapolation.
+        Gauss points.  For a hex8 element with 2x2x2 Gauss quadrature
+        this is exact for any tri-linear field.
 
-        .. math::
+        **Ordering contract** (see :meth:`_build_hex8_extrapolation` for
+        the full discussion of issue #51):
 
-            \\mathbf{N}_{gp} = [N_j(\\xi_{gp,i})]_{8 \\times 8}
+        - ``gauss_values`` is indexed by **lexicographic** Gauss-point
+          order — exactly what ``Hex8Element._gauss_points`` and
+          ``stress_at_gauss_points`` produce.
+        - The returned nodal array is indexed by **VTK / Abaqus** node
+          order — exactly what ``mesh.elements`` connectivity expects.
 
-            \\mathbf{f}_{nodes} = \\mathbf{N}_{gp}^{-1} \\, \\mathbf{f}_{gp}
+        These two orders are *not* the same; a naive "pair GP i with node
+        i" simplification would scramble the result spatially.
 
         Parameters
         ----------
         gauss_values : np.ndarray
-            Shape ``(8, n_components)`` values at the 8 Gauss points.
+            Shape ``(8,)`` or ``(8, n_components)`` values at the 8 Gauss
+            points, in lexicographic order.
 
         Returns
         -------
         np.ndarray
-            Shape ``(8, n_components)`` extrapolated nodal values.
+            Same shape as ``gauss_values`` — extrapolated nodal values in
+            VTK node order.
 
         Notes
         -----
-        The Gauss points for 2-point rule are at
+        The Gauss points for the 2-point rule are at
         ``xi = +/- 1/sqrt(3) ~ +/- 0.57735``.  The extrapolation matrix
-        is constant for all hex8 elements and can be cached.
+        is constant across all hex8 elements and is cached on the class.
         """
-        from wrinklefe.elements.hex8 import Hex8Element
-        from wrinklefe.elements.gauss import gauss_points_hex
-
         gauss_values = np.asarray(gauss_values, dtype=float)
+        squeeze = False
         if gauss_values.ndim == 1:
             gauss_values = gauss_values[:, np.newaxis]
+            squeeze = True
+        if gauss_values.shape[0] != 8:
+            raise ValueError(
+                "gauss_values must have 8 rows (one per 2x2x2 Gauss point), "
+                f"got shape {gauss_values.shape}."
+            )
 
-        # Build shape function matrix evaluated at Gauss points
-        gp_coords, _ = gauss_points_hex(order=2)
-        n_gp = gp_coords.shape[0]
-        N_gp = np.empty((n_gp, 8))
-        for i in range(n_gp):
-            xi, eta, zeta = gp_coords[i]
-            N_gp[i] = Hex8Element.shape_functions(xi, eta, zeta)
-
-        # Invert: N_gp is 8x8 for hex8 with 2x2x2 quadrature
-        N_inv = np.linalg.inv(N_gp)
-
-        return N_inv @ gauss_values
+        N_inv, _node_to_gp = self._build_hex8_extrapolation()
+        nodal = N_inv @ gauss_values
+        return nodal[:, 0] if squeeze else nodal

--- a/tests/test_solver/test_extrapolate.py
+++ b/tests/test_solver/test_extrapolate.py
@@ -1,0 +1,202 @@
+"""Regression tests for hex8 Gauss-point to nodal extrapolation (issue #51).
+
+The two orderings at play are:
+
+- ``gauss_points_hex(order=2)`` -> lexicographic in (xi, eta, zeta), with
+  zeta varying fastest (because of ``np.meshgrid(..., indexing="ij")``
+  followed by ``ravel``).
+- ``Hex8Element._NODE_COORDS`` -> VTK / Abaqus convention: bottom face
+  CCW (zeta=-1) followed by top face CCW (zeta=+1).
+
+The bug guarded against here is the silent assumption that "GP i pairs
+with node i" — that is wrong, and gives a spatially-permuted nodal field
+that is hard to detect after the fact.  These tests pin the correct
+nearest-neighbour mapping and verify exact recovery of a tri-linear
+field.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.mesh import WrinkleMesh
+from wrinklefe.elements.gauss import gauss_points_hex
+from wrinklefe.elements.hex8 import _NODE_COORDS
+from wrinklefe.solver.static import StaticSolver
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def single_elem_solver():
+    """A StaticSolver wrapping a single-hex8 mesh — only needed so that
+    :meth:`StaticSolver._extrapolate_to_nodes` (an instance method) can be
+    invoked.  The mesh itself is incidental to the extrapolation test.
+    """
+    material = OrthotropicMaterial()
+    laminate = Laminate.from_angles([0.0], material=material, ply_thickness=1.0)
+    mesh = WrinkleMesh(
+        laminate=laminate,
+        wrinkle_config=None,
+        Lx=1.0, Ly=1.0,
+        nx=1, ny=1, nz_per_ply=1,
+    ).generate()
+    return StaticSolver(mesh=mesh, laminate=laminate)
+
+
+# ---------------------------------------------------------------------------
+# Pinned ordering / mapping tests
+# ---------------------------------------------------------------------------
+
+class TestHex8Orderings:
+    """Sanity-check the two orderings the extrapolation depends on."""
+
+    def test_gauss_points_are_lex(self):
+        """``gauss_points_hex(2)`` returns GPs in lex order with zeta fastest.
+
+        This is the property that ``_extrapolate_to_nodes`` depends on; if
+        it ever changes, the extrapolation matrix must be rebuilt.
+        """
+        gp_coords, _ = gauss_points_hex(order=2)
+        g = 1.0 / np.sqrt(3.0)
+        expected = np.array(
+            [
+                [-g, -g, -g],
+                [-g, -g, +g],
+                [-g, +g, -g],
+                [-g, +g, +g],
+                [+g, -g, -g],
+                [+g, -g, +g],
+                [+g, +g, -g],
+                [+g, +g, +g],
+            ]
+        )
+        np.testing.assert_allclose(gp_coords, expected, atol=1e-12)
+
+    def test_node_coords_are_vtk(self):
+        """``_NODE_COORDS`` follows the VTK / Abaqus hex8 convention."""
+        expected = np.array(
+            [
+                [-1.0, -1.0, -1.0],
+                [+1.0, -1.0, -1.0],
+                [+1.0, +1.0, -1.0],
+                [-1.0, +1.0, -1.0],
+                [-1.0, -1.0, +1.0],
+                [+1.0, -1.0, +1.0],
+                [+1.0, +1.0, +1.0],
+                [-1.0, +1.0, +1.0],
+            ]
+        )
+        np.testing.assert_array_equal(_NODE_COORDS, expected)
+
+    def test_node_to_gp_mapping_is_pinned(self):
+        """The VTK-node -> lex-GP nearest mapping has a fixed permutation.
+
+        Hard-coding the expected permutation guards against either
+        ordering convention drifting silently.
+        """
+        _N_inv, node_to_gp = StaticSolver._build_hex8_extrapolation()
+        # Expected pairing (each VTK node paired to the lex GP at the
+        # same sign(xi, eta, zeta)):
+        #   Node 0 (-,-,-) <-> GP 0 (-,-,-)
+        #   Node 1 (+,-,-) <-> GP 4 (+,-,-)
+        #   Node 2 (+,+,-) <-> GP 6 (+,+,-)
+        #   Node 3 (-,+,-) <-> GP 2 (-,+,-)
+        #   Node 4 (-,-,+) <-> GP 1 (-,-,+)
+        #   Node 5 (+,-,+) <-> GP 5 (+,-,+)
+        #   Node 6 (+,+,+) <-> GP 7 (+,+,+)
+        #   Node 7 (-,+,+) <-> GP 3 (-,+,+)
+        np.testing.assert_array_equal(
+            node_to_gp, np.array([0, 4, 6, 2, 1, 5, 7, 3])
+        )
+
+    def test_node_to_gp_is_permutation(self):
+        """The mapping must be a bijection across all 8 nodes/GPs."""
+        _N_inv, node_to_gp = StaticSolver._build_hex8_extrapolation()
+        assert sorted(node_to_gp.tolist()) == list(range(8))
+
+
+# ---------------------------------------------------------------------------
+# Extrapolation correctness
+# ---------------------------------------------------------------------------
+
+class TestExtrapolateToNodes:
+    """Exercise :meth:`StaticSolver._extrapolate_to_nodes`."""
+
+    def test_constant_field_recovers_exactly(self, single_elem_solver):
+        """A constant Gauss-point field extrapolates to the same constant."""
+        gp_values = np.full((8, 6), 3.14)
+        nodal = single_elem_solver._extrapolate_to_nodes(gp_values)
+        np.testing.assert_allclose(nodal, 3.14, atol=1e-12)
+
+    def test_trilinear_field_recovers_exactly(self, single_elem_solver):
+        """A tri-linear nodal field is recovered exactly after a round trip.
+
+        Build a known nodal field, sample it at the lex Gauss points, then
+        run the extrapolator and confirm we get the original nodal field
+        back — verifying that GP-order / node-order alignment is correct
+        end-to-end (issue #51).
+        """
+        from wrinklefe.elements.hex8 import Hex8Element
+
+        gp_coords, _ = gauss_points_hex(order=2)
+        # Distinct value per VTK node (non-uniform, asymmetric):
+        f_nodes_true = np.arange(1.0, 9.0)  # [1, 2, ..., 8] in VTK order
+
+        # Sample the tri-linear field at each lex Gauss point.
+        f_gp = np.empty(8)
+        for i in range(8):
+            xi, eta, zeta = gp_coords[i]
+            N = Hex8Element.shape_functions(xi, eta, zeta)  # cols = VTK nodes
+            f_gp[i] = float(N @ f_nodes_true)
+
+        f_nodes_back = single_elem_solver._extrapolate_to_nodes(f_gp)
+        np.testing.assert_allclose(f_nodes_back, f_nodes_true, atol=1e-10)
+
+    def test_gp_indicator_dominates_nearest_node(self, single_elem_solver):
+        """A "delta" GP field — one GP at 1, others at 0 — yields the
+        largest extrapolated nodal value at the **nearest** VTK node.
+
+        The 2x2x2 extrapolation matrix is a true tri-linear extrapolant
+        (it amplifies outward from the GP grid to the element corners),
+        so the nodal value at the nearest corner is positive and larger
+        in magnitude than at any other node — which is exactly the
+        guarantee a caller relying on the node<->GP pairing needs.
+
+        Wrong pairing (issue #51) would put the maximum at a different,
+        spatially incorrect node.
+        """
+        _N_inv, node_to_gp = StaticSolver._build_hex8_extrapolation()
+        for gp_idx in range(8):
+            f_gp = np.zeros(8)
+            f_gp[gp_idx] = 1.0
+            nodal = single_elem_solver._extrapolate_to_nodes(f_gp)
+            # The VTK node nearest to this GP must have the maximum
+            # extrapolated value.
+            nearest_node = int(np.flatnonzero(node_to_gp == gp_idx)[0])
+            assert int(np.argmax(nodal)) == nearest_node, (
+                f"GP {gp_idx}: expected max at node {nearest_node}, "
+                f"got max at node {int(np.argmax(nodal))}; nodal={nodal}"
+            )
+
+    def test_input_shape_1d(self, single_elem_solver):
+        """1-D input of shape (8,) returns 1-D output of shape (8,)."""
+        f_gp = np.linspace(0.0, 1.0, 8)
+        out = single_elem_solver._extrapolate_to_nodes(f_gp)
+        assert out.shape == (8,)
+
+    def test_input_shape_2d(self, single_elem_solver):
+        """2-D input of shape (8, k) returns 2-D output of shape (8, k)."""
+        f_gp = np.random.default_rng(0).standard_normal((8, 6))
+        out = single_elem_solver._extrapolate_to_nodes(f_gp)
+        assert out.shape == (8, 6)
+
+    def test_wrong_input_length_raises(self, single_elem_solver):
+        """Inputs with the wrong number of Gauss points are rejected."""
+        with pytest.raises(ValueError, match="8 rows"):
+            single_elem_solver._extrapolate_to_nodes(np.zeros((4, 6)))


### PR DESCRIPTION
## Summary

Closes #51.

`StaticSolver._extrapolate_to_nodes` (hex8, 2x2x2) was a quiet trap: two distinct orderings — **lexicographic** Gauss points from `gauss_points_hex` (via `np.meshgrid(..., indexing="ij")`, zeta fastest) and **VTK / Abaqus** node order in `_NODE_COORDS` — are *not* the same, and "pair GP i with node i" would scramble the nodal field.

The math the function actually performs (`f_nodes = N_inv @ f_gp` with `N_gp[i, j] = N_j(gp_i)`) is in fact correct, because column *j* of `N_gp` uses VTK node order and row *i* uses lex GP order. But that fact was undocumented, the function was dead code, and the next caller was guaranteed to mis-align inputs. This PR:

- Extracts the matrix build into a cached classmethod `_build_hex8_extrapolation`, which **explicitly** constructs the VTK-node → lex-GP nearest-neighbour permutation by sign-matching and asserts it is a bijection. If either ordering convention drifts, this raises immediately.
- Documents the input/output ordering contract on `_extrapolate_to_nodes` and rejects wrongly-shaped inputs.
- Adds a regression test module `tests/test_solver/test_extrapolate.py` covering ordering invariants, exact tri-linear recovery, and nearest-node dominance.

## Mapping (Gauss-point lex index -> nearest VTK node)

| Lex GP | (sign xi, eta, zeta) | VTK node | Node coord |
|--------|----------------------|----------|------------|
| 0 | (-, -, -) | 0 | (-1, -1, -1) |
| 1 | (-, -, +) | 4 | (-1, -1, +1) |
| 2 | (-, +, -) | 3 | (-1, +1, -1) |
| 3 | (-, +, +) | 7 | (-1, +1, +1) |
| 4 | (+, -, -) | 1 | (+1, -1, -1) |
| 5 | (+, -, +) | 5 | (+1, -1, +1) |
| 6 | (+, +, -) | 2 | (+1, +1, -1) |
| 7 | (+, +, +) | 6 | (+1, +1, +1) |

Equivalently, `node_to_gp = [0, 4, 6, 2, 1, 5, 7, 3]` (VTK node j -> lex GP index).

## Test plan

- [x] `pytest -k "extrapolate or gauss or hex8"` — 146 passed
- [x] `pytest tests/test_io/ tests/test_solver/` — 86 passed (VTK / export untouched)
- [x] Full suite `pytest -q` — 617 passed, 1 xfailed (pre-existing)
- [x] New `tests/test_solver/test_extrapolate.py` — 10 / 10 pass; covers:
  - lex GP order pin
  - VTK node coord pin
  - hard-coded `node_to_gp = [0, 4, 6, 2, 1, 5, 7, 3]`
  - bijection check
  - constant-field exact recovery
  - tri-linear field exact round-trip (the canonical "did you align orders" test)
  - per-GP "delta" field max at the nearest node
  - 1-D and 2-D input shape handling
  - bad input shape raises `ValueError`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_