### PR TITLE
Fix CLI analyze: honor --buckling and --montecarlo flags (closes #81)

### DIFF
--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -102,15 +102,30 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_analyze.add_argument(
         "--buckling", action="store_true", default=False,
-        help="Run linear buckling analysis",
+        help="Run linear buckling analysis (implies full FE solve)",
     )
     p_analyze.add_argument(
         "--montecarlo", action="store_true", default=False,
-        help="Run Monte Carlo simulation",
+        help="Run Monte Carlo simulation (implies full FE solve)",
     )
     p_analyze.add_argument(
         "--mc-samples", type=int, default=5000,
         help="Number of Monte Carlo samples (default: 5000)",
+    )
+    p_analyze.add_argument(
+        "--fe", action=argparse.BooleanOptionalAction, default=None,
+        help=(
+            "Force a full FE solve (--fe) or skip it (--no-fe). "
+            "Default: FE on unless overridden. --buckling/--montecarlo "
+            "imply --fe."
+        ),
+    )
+    p_analyze.add_argument(
+        "--analytical-only", action="store_true", default=False,
+        help=(
+            "Run analytical predictions only, skipping the FE solve, "
+            "buckling, and Monte Carlo branches."
+        ),
     )
     p_analyze.add_argument(
         "--verbose", action="store_true", default=False,
@@ -142,8 +157,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Gaussian envelope half-width in mm (default: 12.0)",
     )
     p_compare.add_argument(
-        "--analytical-only", action="store_true", default=True,
-        help="Run analytical predictions only, no FE (default: True)",
+        "--analytical-only", action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "Run analytical predictions only and skip the FE solve "
+            "(default). Use --no-analytical-only to run the full FE "
+            "comparison for all three morphologies."
+        ),
     )
     p_compare.add_argument(
         "--verbose", action="store_true", default=False,
@@ -178,6 +197,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "--morphology", type=str, default="stack",
         choices=["stack", "convex", "concave"],
         help="Morphology for the sweep (default: stack)",
+    )
+    p_sweep.add_argument(
+        "--analytical-only", action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "Run analytical predictions only for each sweep value "
+            "(default). Use --no-analytical-only to run a full FE "
+            "sweep (slow)."
+        ),
     )
     p_sweep.add_argument(
         "--verbose", action="store_true", default=False,
@@ -220,6 +247,30 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
 
     angles = _parse_angles(args.angles)
 
+    # Resolve analytical-only vs. full FE intent.
+    #
+    # Precedence (highest first):
+    #   1. --analytical-only       -> skip FE / buckling / MC
+    #   2. --buckling / --montecarlo / --fe -> full FE solve
+    #   3. --no-fe                 -> analytical-only
+    #   4. default                 -> full FE solve
+    if args.analytical_only:
+        if args.buckling or args.montecarlo:
+            print(
+                "error: --analytical-only is incompatible with "
+                "--buckling/--montecarlo (those flags require a full "
+                "FE solve).",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        analytical_only = True
+    elif args.buckling or args.montecarlo or args.fe is True:
+        analytical_only = False
+    elif args.fe is False:
+        analytical_only = True
+    else:
+        analytical_only = False
+
     config = AnalysisConfig(
         amplitude=args.amplitude,
         wavelength=args.wavelength,
@@ -235,11 +286,16 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         run_buckling=args.buckling,
         run_montecarlo=args.montecarlo,
         mc_samples=args.mc_samples,
+        analytical_only=analytical_only,
         verbose=args.verbose,
     )
 
     analysis = WrinkleAnalysis(config)
-    result = analysis.run(analytical_only=True)
+    try:
+        result = analysis.run(analytical_only=analytical_only)
+    except Exception as exc:  # pragma: no cover - exercised via tests/CLI
+        print(f"error: analysis failed: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(result.summary())
 
@@ -317,7 +373,7 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
         config,
         parameter=args.parameter,
         values=values,
-        analytical_only=True,
+        analytical_only=args.analytical_only,
     )
 
     print("=" * 60)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,278 @@
+"""Tests for the ``wrinklefe`` command-line interface.
+
+These tests focus on how CLI flags map into :class:`AnalysisConfig` and how
+they propagate into :meth:`WrinkleAnalysis.run` and the comparison/sweep
+helpers. To keep them cheap, we patch the engine entry points and capture
+the configs/kwargs the CLI hands them.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wrinklefe.cli import main as cli_main
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _stub_analysis_run():
+    """Build a context manager that stubs ``WrinkleAnalysis.run``.
+
+    Returns a tuple ``(patcher, captured)`` where ``captured`` is a dict
+    that, after the CLI call, holds ``"config"`` (the AnalysisConfig the
+    handler built) and ``"analytical_only"`` (the kwarg passed to
+    :meth:`WrinkleAnalysis.run`).
+    """
+    captured: dict = {}
+
+    real_init = None  # filled in below
+
+    def fake_run(self, analytical_only=None):
+        captured["analytical_only"] = analytical_only
+        captured["config"] = self.config
+        result = MagicMock()
+        result.summary.return_value = "<stubbed summary>"
+        return result
+
+    return captured, patch(
+        "wrinklefe.analysis.WrinkleAnalysis.run", new=fake_run
+    )
+
+
+# --------------------------------------------------------------------------- #
+# analyze: flag -> config plumbing
+# --------------------------------------------------------------------------- #
+
+
+def test_analyze_default_runs_full_fe_solve():
+    """No flags should run a full FE solve, not analytical-only."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze"])
+
+    cfg = captured["config"]
+    assert cfg.run_buckling is False
+    assert cfg.run_montecarlo is False
+    # The CLI used to hard-code analytical_only=True. Default is now
+    # full FE.
+    assert captured["analytical_only"] is False
+    assert cfg.analytical_only is False
+
+
+def test_analyze_buckling_flag_propagates():
+    """--buckling must set run_buckling and force a full FE solve."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--buckling"])
+
+    cfg = captured["config"]
+    assert cfg.run_buckling is True
+    assert cfg.run_montecarlo is False
+    assert captured["analytical_only"] is False
+    assert cfg.analytical_only is False
+
+
+def test_analyze_montecarlo_flag_propagates():
+    """--montecarlo must set run_montecarlo + mc_samples and run full FE."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--montecarlo", "--mc-samples", "37"])
+
+    cfg = captured["config"]
+    assert cfg.run_buckling is False
+    assert cfg.run_montecarlo is True
+    assert cfg.mc_samples == 37
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_buckling_and_montecarlo_together():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--buckling", "--montecarlo"])
+
+    cfg = captured["config"]
+    assert cfg.run_buckling is True
+    assert cfg.run_montecarlo is True
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_analytical_only_flag_skips_fe():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--analytical-only"])
+
+    cfg = captured["config"]
+    assert cfg.run_buckling is False
+    assert cfg.run_montecarlo is False
+    assert captured["analytical_only"] is True
+    assert cfg.analytical_only is True
+
+
+def test_analyze_no_fe_flag_skips_fe():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--no-fe"])
+
+    assert captured["analytical_only"] is True
+
+
+def test_analyze_fe_flag_runs_full_fe():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--fe"])
+
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_analytical_only_with_buckling_errors(capsys):
+    """--analytical-only conflicts with --buckling and must exit 2."""
+    captured, patcher = _stub_analysis_run()
+    with patcher, pytest.raises(SystemExit) as exc_info:
+        cli_main(["analyze", "--analytical-only", "--buckling"])
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "analytical-only" in err.lower()
+
+
+def test_analyze_passes_solver_and_mesh_options():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze",
+            "--nx", "8",
+            "--ny", "4",
+            "--strain", "-0.005",
+            "--solver", "iterative",
+        ])
+
+    cfg = captured["config"]
+    assert cfg.nx == 8
+    assert cfg.ny == 4
+    assert cfg.applied_strain == pytest.approx(-0.005)
+    assert cfg.solver == "iterative"
+
+
+# --------------------------------------------------------------------------- #
+# compare: --analytical-only / --no-analytical-only
+# --------------------------------------------------------------------------- #
+
+
+def _make_fake_result():
+    r = MagicMock()
+    r.morphology_factor = 1.0
+    r.max_angle_rad = 0.0
+    r.effective_angle_rad = 0.0
+    r.damage_index = 0.0
+    r.analytical_knockdown = 1.0
+    r.analytical_strength_MPa = 100.0
+    return r
+
+
+def test_compare_default_is_analytical_only():
+    captured: dict = {}
+
+    def fake_compare(base_config, morphologies, analytical_only):
+        captured["analytical_only"] = analytical_only
+        return {m: _make_fake_result() for m in morphologies}
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.compare_morphologies",
+        new=staticmethod(fake_compare),
+    ):
+        cli_main(["compare"])
+
+    assert captured["analytical_only"] is True
+
+
+def test_compare_no_analytical_only_runs_full_fe():
+    captured: dict = {}
+
+    def fake_compare(base_config, morphologies, analytical_only):
+        captured["analytical_only"] = analytical_only
+        return {m: _make_fake_result() for m in morphologies}
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.compare_morphologies",
+        new=staticmethod(fake_compare),
+    ):
+        cli_main(["compare", "--no-analytical-only"])
+
+    assert captured["analytical_only"] is False
+
+
+# --------------------------------------------------------------------------- #
+# sweep: --analytical-only / --no-analytical-only
+# --------------------------------------------------------------------------- #
+
+
+def test_sweep_default_is_analytical_only():
+    captured: dict = {}
+
+    def fake_sweep(base_config, parameter, values, analytical_only):
+        captured["analytical_only"] = analytical_only
+        captured["parameter"] = parameter
+        captured["values"] = list(values)
+        return [_make_fake_result() for _ in values]
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.parametric_sweep",
+        new=staticmethod(fake_sweep),
+    ):
+        cli_main([
+            "sweep",
+            "--parameter", "amplitude",
+            "--min", "0.1",
+            "--max", "0.3",
+            "--steps", "3",
+        ])
+
+    assert captured["analytical_only"] is True
+    assert captured["parameter"] == "amplitude"
+    assert len(captured["values"]) == 3
+
+
+def test_sweep_no_analytical_only_runs_full_fe():
+    captured: dict = {}
+
+    def fake_sweep(base_config, parameter, values, analytical_only):
+        captured["analytical_only"] = analytical_only
+        return [_make_fake_result() for _ in values]
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.parametric_sweep",
+        new=staticmethod(fake_sweep),
+    ):
+        cli_main([
+            "sweep",
+            "--parameter", "amplitude",
+            "--min", "0.1",
+            "--max", "0.3",
+            "--steps", "2",
+            "--no-analytical-only",
+        ])
+
+    assert captured["analytical_only"] is False
+
+
+# --------------------------------------------------------------------------- #
+# argparse exit codes for invalid input
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_morphology_exits_with_code_2():
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["analyze", "--morphology", "bogus"])
+    assert exc_info.value.code == 2
+
+
+def test_invalid_numeric_value_exits_with_code_2():
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["analyze", "--amplitude", "not-a-number"])
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Root cause

`src/wrinklefe/cli.py:_cmd_analyze` forwarded `--buckling` / `--montecarlo` / `--mc-samples` into `AnalysisConfig` correctly, but then called:

```python
result = analysis.run(analytical_only=True)
```

unconditionally. `WrinkleAnalysis.run` short-circuits before mesh / static solve / failure / buckling / Monte Carlo whenever `analytical_only=True`, so every one of those CLI flags was a no-op. `_cmd_sweep` had the same hard-coded `analytical_only=True`. `_cmd_compare` declared `--analytical-only` as `store_true` with `default=True`, leaving no CLI path to run the full FE comparison.

## Before / after flow

**Before:** `analyze --buckling` -> `AnalysisConfig(run_buckling=True)` -> `run(analytical_only=True)` -> returns analytical-only results, buckling branch never executed.

**After:** `analyze --buckling` -> `analytical_only=False` derived from intent -> `AnalysisConfig(run_buckling=True, analytical_only=False)` -> `run(analytical_only=False)` -> full FE + buckling.

## Changes

- `analyze`: derives `analytical_only` from `--analytical-only` / `--fe` / `--no-fe` / `--buckling` / `--montecarlo` with documented precedence. Default is now a full FE solve. Conflicting `--analytical-only --buckling` exits with code 2 and a clear stderr message. Runtime errors from `analysis.run()` exit with code 1.
- `compare`: `--analytical-only` upgraded to `argparse.BooleanOptionalAction`; users can now invoke `--no-analytical-only` for a full FE comparison.
- `sweep`: adds `--analytical-only / --no-analytical-only` and forwards the resolved value to `WrinkleAnalysis.parametric_sweep` instead of pinning `True`.

## Tests

- New `tests/test_cli.py` adds 15 tests covering flag-to-config plumbing for `analyze`, the default-is-full-FE behavior, the `--analytical-only` vs. `--buckling` conflict, mesh/solver option forwarding, and the `compare` / `sweep` analytical-only matrix. `WrinkleAnalysis.run`, `compare_morphologies`, and `parametric_sweep` are patched so the assertions check the config/kwargs the CLI builds without running an expensive analysis.
- `pytest -x -q -k "cli or analyze"` -> 15 passed, 637 deselected.
- Full fast suite (`pytest -q --ignore=tests/test_integration`) -> 605 passed, 1 xfailed.

Closes #81.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_