### PR TITLE
Mesh: validate() now rejects inverted hex8 elements (closes #94)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -33,11 +33,26 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from wrinklefe.core.laminate import Laminate
+from wrinklefe.elements.hex8 import _detJ_at_centroid_batch
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from wrinklefe.core.morphology import WrinkleConfiguration
+
+
+# Below this absolute tolerance, a centroid det(J) is treated as zero
+# (degenerate element); strictly non-positive values are always rejected.
+_DETJ_TOL: float = 1.0e-12
+
+
+class MeshValidationError(ValueError):
+    """Raised by :meth:`MeshData.validate` when the mesh contains
+    inverted or degenerate hex8 elements (det(J) <= 0 at the element
+    centroid).  Catching ``ValueError`` also catches this exception
+    for backwards compatibility with callers that previously relied on
+    ``WrinkleMesh.generate()`` only ever raising ``ValueError``.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -305,11 +320,26 @@ class MeshData:
         * Element connectivity indices are within ``[0, n_nodes)``.
         * Element aspect ratios (bounding-box based) do not exceed 10:1.
         * No degenerate elements (all 8 nodes collapsed to a single point).
+        * Element Jacobian determinant ``det(J)`` at the centroid is
+          strictly positive for every hex8 element.  This is the upstream
+          analogue of the strict per-Gauss-point check in
+          ``Hex8Element._check_detJ`` (issue #45, PR #120) and ensures
+          inverted / tangled elements are rejected during mesh
+          construction rather than mid-solve.  When any element fails this
+          check, ``validate()`` raises :class:`MeshValidationError`
+          listing the offending indices.
 
         Returns
         -------
         list[str]
-            Warning messages for any failed checks.
+            Warning messages for any failed checks (excluding the
+            Jacobian check, which raises on failure).
+
+        Raises
+        ------
+        MeshValidationError
+            If one or more hex8 elements have non-positive Jacobian
+            determinant at the centroid (inverted or degenerate).
         """
         warnings: list[str] = []
 
@@ -364,6 +394,35 @@ class MeshData:
                     f"{n_degen}/{n_check} sampled elements are degenerate "
                     f"(all nodes at same point)"
                 )
+
+        # 5. Jacobian-sign check at the element centroid (every element).
+        #    Cheap (one (3,3) determinant per element) and catches gross
+        #    inversion / tangling that the bounding-box-based checks above
+        #    cannot see.  Failure here raises rather than warns: an
+        #    inverted hex8 element produces non-physical stiffness in the
+        #    solver and there is no useful work to do downstream.
+        if self.elements.size > 0 and connectivity_ok and np.all(np.isfinite(self.nodes)):
+            elem_coords = self.nodes[self.elements]  # (n_elem, 8, 3)
+            detJ = _detJ_at_centroid_batch(elem_coords)  # (n_elem,)
+            bad_mask = detJ <= _DETJ_TOL
+            n_bad = int(bad_mask.sum())
+            if n_bad > 0:
+                bad_indices = np.flatnonzero(bad_mask)
+                worst_idx = int(bad_indices[np.argmin(detJ[bad_indices])])
+                # Show up to 10 indices in the message; full list still
+                # available on the ``inverted_element_indices`` attribute
+                # of the exception.
+                shown = bad_indices[:10].tolist()
+                tail = "" if n_bad <= 10 else f", ... ({n_bad - 10} more)"
+                err = MeshValidationError(
+                    f"{n_bad} inverted hex8 elements at indices "
+                    f"{shown}{tail} (worst: element {worst_idx}, "
+                    f"det(J)={detJ[worst_idx]:.3e} at centroid). "
+                    "Check node ordering / wrinkle amplitude vs element size."
+                )
+                err.inverted_element_indices = bad_indices
+                err.detJ = detJ
+                raise err
 
         return warnings
 

--- a/src/wrinklefe/elements/hex8.py
+++ b/src/wrinklefe/elements/hex8.py
@@ -52,6 +52,71 @@ _NODE_COORDS = np.array([
 ], dtype=float)
 
 
+# Shape-function derivatives at the element centroid (xi=eta=zeta=0).
+# For trilinear shape functions, every (1 + xi_i * 0) factor reduces to 1,
+# so dN_j/d(xi_i) at the centroid simplifies to 0.125 * xi_i_j, where
+# xi_i_j is the i-th natural coordinate of node j.  Pre-computed here as a
+# (3, 8) array so the centroid Jacobian can be evaluated with a single
+# matmul ``_DN_CENTROID @ coords`` — used by :func:`_detJ_at_centroid` and
+# by ``MeshData.validate()`` to flag inverted elements before assembly.
+_DN_CENTROID = 0.125 * _NODE_COORDS.T  # (3, 8)
+
+
+def _detJ_at_centroid(coords: np.ndarray) -> float:
+    """Determinant of the hex8 Jacobian evaluated at the element centroid.
+
+    The centroid is ``(xi, eta, zeta) = (0, 0, 0)`` in natural coordinates.
+    A non-positive value indicates an inverted or degenerate element; this
+    helper is the cheap detector used by ``MeshData.validate()`` (issue
+    #94) and shares its shape-function math with the strict element-level
+    check (``Hex8Element._check_detJ``, issue #45 / PR #120).
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Shape ``(8, 3)`` — physical (x, y, z) coordinates of the 8 nodes
+        in the standard VTK / Abaqus ordering.
+
+    Returns
+    -------
+    float
+        Determinant of the 3x3 Jacobian ``dx/d(xi)`` at the centroid.
+    """
+    coords = np.asarray(coords, dtype=float)
+    if coords.shape != (8, 3):
+        raise ValueError(
+            f"coords must have shape (8, 3), got {coords.shape}."
+        )
+    J = _DN_CENTROID @ coords  # (3, 3)
+    return float(np.linalg.det(J))
+
+
+def _detJ_at_centroid_batch(elem_coords: np.ndarray) -> np.ndarray:
+    """Vectorised centroid det(J) for an array of hex8 elements.
+
+    Parameters
+    ----------
+    elem_coords : np.ndarray
+        Shape ``(n_elem, 8, 3)`` — node coordinates for each element in
+        the standard VTK / Abaqus ordering.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n_elem,)`` array of Jacobian determinants at each
+        element's centroid.
+    """
+    elem_coords = np.asarray(elem_coords, dtype=float)
+    if elem_coords.ndim != 3 or elem_coords.shape[1:] != (8, 3):
+        raise ValueError(
+            "elem_coords must have shape (n_elem, 8, 3), got "
+            f"{elem_coords.shape}."
+        )
+    # J has shape (n_elem, 3, 3); broadcast _DN_CENTROID across n_elem.
+    J = np.einsum("ij,njk->nik", _DN_CENTROID, elem_coords)
+    return np.linalg.det(J)
+
+
 class Hex8Element:
     """8-node isoparametric hexahedral element for 3-D composite analysis.
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -8,7 +8,7 @@ from wrinklefe.core.material import OrthotropicMaterial
 from wrinklefe.core.laminate import Laminate
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 from wrinklefe.core.morphology import WrinkleConfiguration
-from wrinklefe.core.mesh import MeshData, WrinkleMesh
+from wrinklefe.core.mesh import MeshData, MeshValidationError, WrinkleMesh
 
 
 @pytest.fixture
@@ -210,7 +210,13 @@ class TestWrinkledMesh:
 
     @pytest.fixture
     def wrinkled_mesh(self, small_laminate):
-        profile = GaussianSinusoidal(amplitude=0.366, wavelength=16.0, width=12.0, center=5.0)
+        # Mild-wrinkle parameters: amplitude small enough that no hex8
+        # element inverts at this resolution (4x3x4).  The previous
+        # amplitude (0.366) produced 6 genuinely inverted elements that
+        # the old validate() silently let through (issue #94); validate()
+        # now refuses such a mesh, so the fixture uses a physically valid
+        # configuration.
+        profile = GaussianSinusoidal(amplitude=0.1, wavelength=16.0, width=12.0, center=5.0)
         config = WrinkleConfiguration.dual_wrinkle(
             profile, interface1=1, interface2=2, phase=0.0
         )
@@ -349,3 +355,110 @@ class TestMultipleElementsPerPly:
         nz = small_laminate.n_plies * 2
         expected = 2 * 2 * nz
         assert mesh.n_elements == expected
+
+
+class TestValidateJacobianSign:
+    """Regression tests for issue #94 — MeshData.validate() must reject
+    inverted hex8 elements via the centroid det(J) check."""
+
+    def test_clean_mesh_validate_does_not_raise(self, small_mesh):
+        """A freshly generated flat mesh has all det(J) > 0."""
+        warnings = small_mesh.validate()
+        # No inverted-element error, and no Jacobian-related warning text
+        for w in warnings:
+            assert "inverted" not in w.lower()
+
+    def test_inverted_element_raises(self, small_mesh):
+        """Flipping an element's bottom/top faces inverts det(J) and must
+        be caught by validate() with a descriptive message."""
+        # Copy to avoid mutating the fixture for other tests
+        nodes = small_mesh.nodes.copy()
+        elements = small_mesh.elements.copy()
+
+        # Swap bottom (nodes 0..3) and top (nodes 4..7) of element 0 in
+        # the connectivity table.  This reverses the zeta-direction and
+        # makes det(J) at the centroid negative.
+        bad_id = 0
+        bottom = elements[bad_id, 0:4].copy()
+        top = elements[bad_id, 4:8].copy()
+        elements[bad_id, 0:4] = top
+        elements[bad_id, 4:8] = bottom
+
+        bad_mesh = MeshData(
+            nodes=nodes,
+            elements=elements,
+            ply_ids=small_mesh.ply_ids.copy(),
+            fiber_angles=small_mesh.fiber_angles.copy(),
+            ply_angles=small_mesh.ply_angles.copy(),
+            nx=small_mesh.nx,
+            ny=small_mesh.ny,
+            nz=small_mesh.nz,
+        )
+
+        with pytest.raises(MeshValidationError) as exc_info:
+            bad_mesh.validate()
+
+        msg = str(exc_info.value)
+        assert "inverted" in msg
+        assert "hex8" in msg
+        assert str(bad_id) in msg
+        # Exception carries the full list of bad indices for callers.
+        assert bad_id in exc_info.value.inverted_element_indices.tolist()
+
+    def test_multiple_inverted_elements_reported(self, small_mesh):
+        """validate() reports all inverted elements, not just the first."""
+        nodes = small_mesh.nodes.copy()
+        elements = small_mesh.elements.copy()
+
+        bad_ids = [0, 2, 5]
+        for bad_id in bad_ids:
+            bottom = elements[bad_id, 0:4].copy()
+            top = elements[bad_id, 4:8].copy()
+            elements[bad_id, 0:4] = top
+            elements[bad_id, 4:8] = bottom
+
+        bad_mesh = MeshData(
+            nodes=nodes,
+            elements=elements,
+            ply_ids=small_mesh.ply_ids.copy(),
+            fiber_angles=small_mesh.fiber_angles.copy(),
+            ply_angles=small_mesh.ply_angles.copy(),
+            nx=small_mesh.nx,
+            ny=small_mesh.ny,
+            nz=small_mesh.nz,
+        )
+
+        with pytest.raises(MeshValidationError) as exc_info:
+            bad_mesh.validate()
+
+        msg = str(exc_info.value)
+        assert f"{len(bad_ids)} inverted" in msg
+        reported = set(exc_info.value.inverted_element_indices.tolist())
+        assert set(bad_ids).issubset(reported)
+
+    def test_generate_raises_on_inverted_mesh(self, small_laminate):
+        """End-to-end: a manually corrupted MeshData through validate()
+        surfaces during construction-time quality gating."""
+        gen = WrinkleMesh(
+            laminate=small_laminate,
+            wrinkle_config=None,
+            Lx=10.0, Ly=5.0,
+            nx=4, ny=3, nz_per_ply=1,
+        )
+        mesh = gen.generate()
+        # Corrupt and re-validate to confirm the error path.
+        elements = mesh.elements.copy()
+        elements[1, 0:4], elements[1, 4:8] = (
+            elements[1, 4:8].copy(),
+            elements[1, 0:4].copy(),
+        )
+        bad = MeshData(
+            nodes=mesh.nodes,
+            elements=elements,
+            ply_ids=mesh.ply_ids,
+            fiber_angles=mesh.fiber_angles,
+            ply_angles=mesh.ply_angles,
+            nx=mesh.nx, ny=mesh.ny, nz=mesh.nz,
+        )
+        with pytest.raises(MeshValidationError, match=r"inverted hex8"):
+            bad.validate()


### PR DESCRIPTION
## Summary

`MeshData.validate()` previously checked only NaN/Inf coords, connectivity bounds, AABB-based aspect ratio, and fully-collapsed elements (all 8 nodes at one point). Inverted / tangled hex8 elements — which have a positive AABB volume and non-zero span on every axis — passed every check and surfaced only mid-solve (or silently produced wrong stresses, since the element stiffness routine uses `|det J|`).

This PR adds a per-element Jacobian-sign check to `validate()`:

- **Where the check runs:** at the element centroid (`xi = eta = zeta = 0`). This is the cheap default — one 3x3 determinant per element, vectorised across the whole connectivity table — and catches all gross inversions seen in practice (the failure mode the issue describes is a "top face dropping below the bottom face" topology, which always shows up at the centroid). Per-Gauss-point coverage remains in `Hex8Element` at assembly time (PR #120 / issue #45), so anything subtler is still caught there.
- **Reuse with PR #120:** factored a pure `_detJ_at_centroid(coords)` helper (plus a vectorised `_detJ_at_centroid_batch(elem_coords)`) in `src/wrinklefe/elements/hex8.py` and pre-computed the centroid shape-function derivatives once. `MeshData.validate()` imports the batched form. `Hex8Element._check_detJ` (the strict per-GP guard added in PR #120) is unchanged.
- **Error format:** raises a new `MeshValidationError(ValueError)` with a message like
  `3 inverted hex8 elements at indices [42, 117, 203] (worst: element 42, det(J)=-5.070e-02 at centroid). Check node ordering / wrinkle amplitude vs element size.`
  The full index array is also attached as `exc.inverted_element_indices` for programmatic access. The first 10 indices are shown inline; the count of suppressed indices follows.
- **Tolerance:** `det(J) <= 1e-12` is rejected (strictly non-positive is always rejected; the tolerance only adds a guard against denormalised "zero-volume" elements that slip past `<= 0`).

## Test plan

- [x] New regression test `TestValidateJacobianSign` in `tests/test_mesh.py`:
  - Clean `small_mesh` fixture: `validate()` returns without raising and emits no "inverted" warning.
  - Manually swap bottom and top faces of element 0 -> `MeshValidationError` with "inverted", "hex8", and the element index in the message; `inverted_element_indices` carries the correct id.
  - Same trick on three elements (0, 2, 5) -> error message reports `3 inverted` and the index set is a superset of the planted indices.
  - End-to-end: build a real mesh through `WrinkleMesh.generate()`, corrupt one element, re-`validate()` and assert it raises.
- [x] Updated the pre-existing `TestWrinkledMesh.wrinkled_mesh` fixture: its `amplitude=0.366` against a 0.732 mm laminate was physically invalid (6 elements with `det(J) ~ -0.05`), but the old `validate()` silently let it through. Lowered to `amplitude=0.1`, which preserves the wrinkle topology the existing assertions check while keeping the mesh well-formed.
- [x] `python -m pytest -x -q -k "mesh or validate"` -> 45 passed
- [x] Full suite `python -m pytest -q` -> 640 passed, 1 xfailed (unchanged from main)

Closes #94.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_