### PR TITLE
Fix face-force application: consistent nodal forces from face integration (closes #50)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -220,6 +220,90 @@ class MeshData:
         target_grid = 0 if side == "min" else (self.nx, self.ny, self.nz)[axis]
         return np.flatnonzero(grid_idx == target_grid)
 
+    def face_elements(self, face: str) -> np.ndarray:
+        """Return Q4 face-element connectivity on a boundary face.
+
+        For consistent face-load integration (issue #50) we need to know
+        which 4 corner nodes form each surface quadrilateral on a face,
+        not just the unordered set of face nodes.  Each row gives the
+        four global node indices of one face quad, counter-clockwise when
+        viewed from outside the domain.
+
+        The quads are enumerated topologically from the structured ``(i,
+        j, k)`` grid (same convention as :meth:`nodes_on_face`), so the
+        result is correct for both flat and wrinkled meshes — only the
+        geometric node coordinates change, never the connectivity.
+
+        Parameters
+        ----------
+        face : str
+            One of ``'x_min'``, ``'x_max'``, ``'y_min'``, ``'y_max'``,
+            ``'z_min'``, ``'z_max'``.
+
+        Returns
+        -------
+        np.ndarray
+            Shape ``(n_face_elements, 4)`` array of node indices
+            (0-based).  ``n_face_elements`` is ``ny*nz`` for x-faces,
+            ``nx*nz`` for y-faces, and ``nx*ny`` for z-faces.
+
+        Raises
+        ------
+        ValueError
+            If *face* is not a recognised name.
+        """
+        valid = {"x_min", "x_max", "y_min", "y_max", "z_min", "z_max"}
+        if face not in valid:
+            raise ValueError(
+                f"Unknown face '{face}'. Must be one of {sorted(valid)}"
+            )
+
+        nxp = self.nx + 1
+        nyp = self.ny + 1
+
+        def node_id(i: np.ndarray, j: np.ndarray, k: np.ndarray) -> np.ndarray:
+            return k * (nyp * nxp) + j * nxp + i
+
+        if face in ("x_min", "x_max"):
+            i_fix = 0 if face == "x_min" else self.nx
+            ej = np.arange(self.ny)
+            ek = np.arange(self.nz)
+            kk, jj = np.meshgrid(ek, ej, indexing="ij")
+            kk = kk.ravel()
+            jj = jj.ravel()
+            ii = np.full_like(jj, i_fix)
+            # CCW viewed from outside (+x or -x normal)
+            n0 = node_id(ii, jj, kk)
+            n1 = node_id(ii, jj + 1, kk)
+            n2 = node_id(ii, jj + 1, kk + 1)
+            n3 = node_id(ii, jj, kk + 1)
+        elif face in ("y_min", "y_max"):
+            j_fix = 0 if face == "y_min" else self.ny
+            ei = np.arange(self.nx)
+            ek = np.arange(self.nz)
+            kk, ii = np.meshgrid(ek, ei, indexing="ij")
+            kk = kk.ravel()
+            ii = ii.ravel()
+            jj = np.full_like(ii, j_fix)
+            n0 = node_id(ii, jj, kk)
+            n1 = node_id(ii + 1, jj, kk)
+            n2 = node_id(ii + 1, jj, kk + 1)
+            n3 = node_id(ii, jj, kk + 1)
+        else:  # z_min, z_max
+            k_fix = 0 if face == "z_min" else self.nz
+            ei = np.arange(self.nx)
+            ej = np.arange(self.ny)
+            jj, ii = np.meshgrid(ej, ei, indexing="ij")
+            jj = jj.ravel()
+            ii = ii.ravel()
+            kk = np.full_like(ii, k_fix)
+            n0 = node_id(ii, jj, kk)
+            n1 = node_id(ii + 1, jj, kk)
+            n2 = node_id(ii + 1, jj + 1, kk)
+            n3 = node_id(ii, jj + 1, kk)
+
+        return np.column_stack([n0, n1, n2, n3]).astype(np.intp)
+
     def elements_in_ply(self, ply_idx: int) -> np.ndarray:
         """Return element indices belonging to a given ply.
 

--- a/src/wrinklefe/solver/boundary.py
+++ b/src/wrinklefe/solver/boundary.py
@@ -30,6 +30,43 @@ from wrinklefe.core.laminate import LoadState
 
 
 # ======================================================================
+# Internal helpers
+# ======================================================================
+
+def _quad_areas(nodes: np.ndarray, quads: np.ndarray) -> np.ndarray:
+    """Return the area of each Q4 quadrilateral, by triangle split.
+
+    Splits each quad ``(n0, n1, n2, n3)`` along the ``n0-n2`` diagonal
+    into two triangles and sums ``|d1 x d2| / 2`` for each.  This is
+    exact for planar quads and a sensible bilinear approximation for
+    mildly non-planar (e.g. wrinkled) faces.
+
+    Parameters
+    ----------
+    nodes : np.ndarray
+        Shape ``(n_nodes, 3)`` coordinate array.
+    quads : np.ndarray
+        Shape ``(n_quads, 4)`` corner-node-index array.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n_quads,)`` array of areas.
+    """
+    p0 = nodes[quads[:, 0]]
+    p1 = nodes[quads[:, 1]]
+    p2 = nodes[quads[:, 2]]
+    p3 = nodes[quads[:, 3]]
+    # Triangle 0-1-2
+    cross1 = np.cross(p1 - p0, p2 - p0)
+    # Triangle 0-2-3
+    cross2 = np.cross(p2 - p0, p3 - p0)
+    a1 = 0.5 * np.linalg.norm(cross1, axis=1)
+    a2 = 0.5 * np.linalg.norm(cross2, axis=1)
+    return a1 + a2
+
+
+# ======================================================================
 # BoundaryCondition dataclass
 # ======================================================================
 
@@ -222,9 +259,23 @@ class BoundaryHandler:
         For ``"force"`` BCs, the value is applied directly to each
         specified node in the specified DOFs.
 
-        For ``"pressure"`` BCs, the total force (``bc.value``) is
-        distributed equally among all nodes on the specified face
-        in the specified DOFs.
+        For ``"pressure"`` BCs the value is the *total* force over the
+        face and is distributed via **consistent face integration**
+        (issue #50).  For each face quad with area :math:`A_e` we
+        contribute :math:`t \\cdot A_e / 4` to each of its four corner
+        nodes, where the traction :math:`t = \\text{value} / A_\\text{face}`
+        is uniform over the face:
+
+        .. math::
+
+            F_i = \\int_\\Gamma N_i(\\xi, \\eta)\\, t\\, dA
+                = t \\sum_{e \\ni i} \\frac{A_e}{4}.
+
+        On a uniform grid this reproduces the corner-1/4, edge-1/2,
+        interior-1 tributary-area weights; on a wrinkled mesh the
+        per-quad areas vary so the weights are area-correct.  When a
+        pressure BC is supplied via explicit ``node_ids`` (no face
+        topology available) we fall back to equal per-node distribution.
 
         Parameters
         ----------
@@ -248,16 +299,59 @@ class BoundaryHandler:
                         F[3 * int(nid) + d] += bc.value
 
             elif bc.bc_type == "pressure":
+                self._apply_pressure_bc(bc, F)
+
+        return F
+
+    def _apply_pressure_bc(
+        self, bc: BoundaryCondition, F: np.ndarray,
+    ) -> None:
+        """Accumulate consistent nodal forces from a pressure BC.
+
+        See :meth:`get_force_dofs` for the underlying math.  This method
+        mutates ``F`` in place.
+        """
+        if bc.face is not None:
+            face_elems = self.mesh.face_elements(bc.face)
+            if face_elems.shape[0] == 0:
+                return
+            quad_areas = _quad_areas(self.mesh.nodes, face_elems)
+            total_area = float(quad_areas.sum())
+            if total_area <= 0.0:
+                # Degenerate face — fall back to equal split to stay
+                # consistent with the legacy behaviour.
                 nodes = bc.resolve_nodes(self.mesh)
                 n_nodes = len(nodes)
                 if n_nodes == 0:
-                    continue
-                force_per_node = bc.value / n_nodes
+                    return
+                share = bc.value / n_nodes
                 for nid in nodes:
                     for d in bc.dofs:
-                        F[3 * int(nid) + d] += force_per_node
+                        F[3 * int(nid) + d] += share
+                return
 
-        return F
+            traction = bc.value / total_area
+            # Each face quad contributes t * A_e / 4 to each of its
+            # 4 corner nodes (Q4 bilinear shape functions, uniform t).
+            contrib = traction * quad_areas * 0.25  # shape (n_face_e,)
+            for d in bc.dofs:
+                # Scatter-add into F[3*nid + d] for each corner.
+                np.add.at(
+                    F, 3 * face_elems.ravel() + d,
+                    np.repeat(contrib, 4),
+                )
+            return
+
+        # No face topology — explicit node list.  Fall back to equal
+        # division (legacy behaviour for ``node_ids``-based pressure).
+        nodes = bc.resolve_nodes(self.mesh)
+        n_nodes = len(nodes)
+        if n_nodes == 0:
+            return
+        share = bc.value / n_nodes
+        for nid in nodes:
+            for d in bc.dofs:
+                F[3 * int(nid) + d] += share
 
     # ------------------------------------------------------------------
     # Penalty method

--- a/src/wrinklefe/solver/static.py
+++ b/src/wrinklefe/solver/static.py
@@ -440,35 +440,33 @@ class StaticSolver:
             )
         )
 
-        # Apply traction on x_max face from Nx
-        # Traction = Nx / Ly  (N/mm per unit width, distributed over face)
-        x_max_nodes = self.mesh.nodes_on_face("x_max")
+        # Apply traction on x_max face from Nx via a pressure BC so the
+        # total face force is distributed by consistent face integration
+        # (see boundary.BoundaryHandler.get_force_dofs and issue #50).
+        # CLT Nx has units of force per unit width (N/mm), so the total
+        # nodal force across the face is Nx * Ly.
         _, Ly, Lz = self.mesh.domain_size
-        n_face_nodes = len(x_max_nodes)
+        x_max_has_elements = self.mesh.nx > 0 and self.mesh.ny > 0 and self.mesh.nz > 0
 
-        if n_face_nodes > 0 and not np.isclose(load.Nx, 0.0):
-            # Total force = Nx * Ly (since Nx is per unit width)
-            # Distribute equally to face nodes
+        if x_max_has_elements and not np.isclose(load.Nx, 0.0):
             total_force_x = load.Nx * Ly
-            force_per_node = total_force_x / n_face_nodes
             bcs.append(
                 BoundaryCondition(
-                    bc_type="force",
-                    node_ids=x_max_nodes,
+                    bc_type="pressure",
+                    face="x_max",
                     dofs=[0],
-                    value=force_per_node,
+                    value=total_force_x,
                 )
             )
 
-        if n_face_nodes > 0 and not np.isclose(load.Nxy, 0.0):
+        if x_max_has_elements and not np.isclose(load.Nxy, 0.0):
             total_force_y = load.Nxy * Ly
-            force_per_node = total_force_y / n_face_nodes
             bcs.append(
                 BoundaryCondition(
-                    bc_type="force",
-                    node_ids=x_max_nodes,
+                    bc_type="pressure",
+                    face="x_max",
                     dofs=[1],
-                    value=force_per_node,
+                    value=total_force_y,
                 )
             )
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -174,6 +174,49 @@ class TestNodesOnFace:
         npt.assert_allclose(x_values, 0.0, atol=1e-10)
 
 
+class TestFaceElements:
+    """Tests for ``MeshData.face_elements`` (issue #50)."""
+
+    def test_face_elements_shape_x_max(self, small_mesh_generator, small_mesh):
+        gen = small_mesh_generator
+        quads = small_mesh.face_elements("x_max")
+        assert quads.shape == (gen.ny * gen.nz, 4)
+
+    def test_face_elements_shape_z_max(self, small_mesh_generator, small_mesh):
+        gen = small_mesh_generator
+        quads = small_mesh.face_elements("z_max")
+        assert quads.shape == (gen.nx * gen.ny, 4)
+
+    def test_face_elements_corners_on_face(self, small_mesh):
+        """Every corner of every face quad must belong to the face's node set."""
+        for face in ("x_min", "x_max", "y_min", "y_max", "z_min", "z_max"):
+            quads = small_mesh.face_elements(face)
+            face_nodes = set(small_mesh.nodes_on_face(face).tolist())
+            for q in quads:
+                for nid in q:
+                    assert int(nid) in face_nodes
+
+    def test_face_elements_quad_area_sums_to_face_area(self, small_mesh):
+        """Sum of Q4 quad areas equals the rectangular face area on flat mesh."""
+        from wrinklefe.solver.boundary import _quad_areas
+        Lx, Ly, Lz = small_mesh.domain_size
+        face_to_area = {
+            "x_min": Ly * Lz, "x_max": Ly * Lz,
+            "y_min": Lx * Lz, "y_max": Lx * Lz,
+            "z_min": Lx * Ly, "z_max": Lx * Ly,
+        }
+        for face, expected_area in face_to_area.items():
+            quads = small_mesh.face_elements(face)
+            total = float(_quad_areas(small_mesh.nodes, quads).sum())
+            assert np.isclose(total, expected_area, rtol=1e-10), (
+                f"{face}: total area {total} != expected {expected_area}"
+            )
+
+    def test_face_elements_invalid_face_raises(self, small_mesh):
+        with pytest.raises(ValueError, match="Unknown face"):
+            small_mesh.face_elements("top")
+
+
 class TestElementConnectivity:
     """Test element connectivity and adjacency."""
 

--- a/tests/test_solver/test_static.py
+++ b/tests/test_solver/test_static.py
@@ -303,8 +303,14 @@ class TestBoundaryHandler:
         # Force at node 0, DOF 0
         assert np.isclose(F[0], 100.0)
 
-    def test_pressure_bc_distribution(self, small_mesh):
-        """Pressure BC distributes total force equally among face nodes."""
+    def test_pressure_bc_distribution_total_force(self, small_mesh):
+        """Pressure BC: summed nodal forces equal the prescribed total.
+
+        Regression for issue #50: the distribution is *not* equal per
+        node (corners, edges, and interior face nodes get different
+        weights), but the global sum must match the prescribed total
+        force on the face.
+        """
         handler = BoundaryHandler(small_mesh)
         total_force = 600.0
         bcs = [
@@ -314,10 +320,201 @@ class TestBoundaryHandler:
         ]
         F = handler.get_force_dofs(bcs)
         xmax_nodes = small_mesh.nodes_on_face("x_max")
-        n_face = len(xmax_nodes)
-        force_per_node = total_force / n_face
+        # Global equilibrium: sum of nodal Fx equals the total prescribed
+        applied_x = F[3 * xmax_nodes].sum()
+        assert np.isclose(applied_x, total_force, rtol=1e-12, atol=1e-9)
+        # And no Fx force leaks elsewhere
+        other = np.ones(small_mesh.n_dof, dtype=bool)
+        other[3 * xmax_nodes] = False
+        assert np.allclose(F[other], 0.0)
+
+    def test_pressure_bc_consistent_tributary_weights(self, small_mesh):
+        """Pressure BC distribution follows corner-1/4, edge-1/2, interior-1.
+
+        On a flat structured mesh with uniform face quads of area ``A``,
+        consistent face integration produces nodal forces:
+
+        - corner face nodes (in 1 quad): ``t * A / 4``
+        - edge face nodes  (in 2 quads): ``t * A / 2``
+        - interior nodes   (in 4 quads): ``t * A``
+
+        where ``t = total_force / total_face_area``.
+        """
+        handler = BoundaryHandler(small_mesh)
+        total_force = 600.0
+        bcs = [
+            BoundaryCondition(
+                bc_type="pressure", face="x_max", dofs=[0], value=total_force
+            ),
+        ]
+        F = handler.get_force_dofs(bcs)
+
+        face_quads = small_mesh.face_elements("x_max")
+        # Total face area (sum of quad areas)
+        from wrinklefe.solver.boundary import _quad_areas
+        areas = _quad_areas(small_mesh.nodes, face_quads)
+        A_total = float(areas.sum())
+        traction = total_force / A_total
+        # Number of face quads each node belongs to
+        from collections import Counter
+        share_count = Counter(face_quads.ravel().tolist())
+
+        # Each face node's expected Fx = traction * sum(quad_area)/4 over
+        # all quads that touch it.  For a regular grid quads have equal
+        # area so this reduces to traction * A_e * (n_quads_touching)/4.
+        for nid in small_mesh.nodes_on_face("x_max"):
+            mask = (face_quads == nid).any(axis=1)
+            expected = traction * areas[mask].sum() / 4.0
+            assert np.isclose(F[3 * nid], expected, rtol=1e-10, atol=1e-12), (
+                f"node {nid} (n_quads={share_count[int(nid)]}): "
+                f"F={F[3 * nid]}, expected={expected}"
+            )
+
+    def test_pressure_bc_uniform_face_buckets(self, small_mesh):
+        """On a flat uniform grid, face nodes group into corner/edge/interior buckets.
+
+        Verifies the canonical 1:2:4 ratio of consistent nodal forces.
+        """
+        # small_mesh is 3x2x1 (Lx=3, Ly=2), so x_max face has
+        # (ny+1)*(nz+1) = 3*2 = 6 nodes and ny*nz = 2 quads.
+        # With only 2 quads (one row in z, two columns in y), every
+        # face node is either at a quad corner (touched by 1 quad) or
+        # at the shared edge (touched by 2 quads).  Use a denser face
+        # by inflating ny, nz.
+        from wrinklefe.core.mesh import WrinkleMesh
+        from wrinklefe.core.material import OrthotropicMaterial
+        from wrinklefe.core.laminate import Laminate
+
+        mat = OrthotropicMaterial()
+        lam = Laminate.from_angles([0.0], material=mat, ply_thickness=1.0)
+        gen = WrinkleMesh(
+            laminate=lam, wrinkle_config=None,
+            Lx=3.0, Ly=3.0, nx=3, ny=3, nz_per_ply=3,
+        )
+        mesh = gen.generate()
+
+        handler = BoundaryHandler(mesh)
+        total_force = 90.0  # nice round number with Lx not in the load
+        bcs = [
+            BoundaryCondition(
+                bc_type="pressure", face="x_max", dofs=[0], value=total_force,
+            ),
+        ]
+        F = handler.get_force_dofs(bcs)
+
+        face_quads = mesh.face_elements("x_max")
+        face_nodes = mesh.nodes_on_face("x_max")
+        # On a regular grid all face quads have equal area:
+        from wrinklefe.solver.boundary import _quad_areas
+        areas = _quad_areas(mesh.nodes, face_quads)
+        np.testing.assert_allclose(areas, areas[0], rtol=1e-12)
+        A_total = float(areas.sum())
+        A_e = float(areas[0])
+        traction = total_force / A_total
+
+        # Tally how many quads each face node belongs to and check the
+        # nodal force matches t * A_e * count / 4.
+        from collections import Counter
+        counts = Counter(face_quads.ravel().tolist())
+
+        # Sanity: we should see counts {1, 2, 4} for a uniform interior face
+        unique_counts = set(counts[int(nid)] for nid in face_nodes)
+        assert unique_counts == {1, 2, 4}, unique_counts
+
+        for nid in face_nodes:
+            expected = traction * A_e * counts[int(nid)] / 4.0
+            assert np.isclose(F[3 * nid], expected, rtol=1e-10), (
+                f"node {nid} (count={counts[int(nid)]}): "
+                f"F={F[3 * nid]}, expected={expected}"
+            )
+
+        # Global equilibrium
+        assert np.isclose(F[3 * face_nodes].sum(), total_force, rtol=1e-12)
+
+    def test_pressure_bc_wrinkled_mesh_equilibrium(self, x850_material):
+        """Consistent face integration preserves total force on a wrinkled mesh.
+
+        Regression for issue #50: on a wrinkled mesh, face quads have
+        unequal areas; the legacy equal-per-node distribution gave the
+        wrong tributary weighting (corner over-loading).  With the
+        consistent-integration fix, the *summed* face force still equals
+        the prescribed total, and corners now get less than the
+        legacy 1/N share.
+        """
+        from wrinklefe.core.mesh import WrinkleMesh
+        from wrinklefe.core.laminate import Laminate
+        from wrinklefe.core.wrinkle import GaussianSinusoidal
+        from wrinklefe.core.morphology import WrinkleConfiguration
+
+        lam = Laminate.from_angles(
+            [0.0, 0.0, 0.0, 0.0],
+            material=x850_material, ply_thickness=0.183,
+        )
+        wrinkle = GaussianSinusoidal(
+            amplitude=0.4, wavelength=8.0, width=6.0, center=0.0,
+        )
+        cfg = WrinkleConfiguration.dual_wrinkle(
+            profile=wrinkle, interface1=1, interface2=2, phase=0.0,
+        )
+        gen = WrinkleMesh(
+            laminate=lam, wrinkle_config=cfg,
+            Lx=10.0, Ly=6.0, nx=8, ny=4, nz_per_ply=1,
+        )
+        mesh = gen.generate()
+
+        handler = BoundaryHandler(mesh)
+        total_force = 1234.5
+        bcs = [
+            BoundaryCondition(
+                bc_type="pressure", face="z_max", dofs=[2],
+                value=total_force,
+            ),
+        ]
+        F = handler.get_force_dofs(bcs)
+
+        face_nodes = mesh.nodes_on_face("z_max")
+        # Equilibrium: the integrated normal force matches the
+        # prescribed total to numerical tolerance.
+        assert np.isclose(F[3 * face_nodes + 2].sum(), total_force, rtol=1e-10)
+
+        # On a wrinkled face the corner nodes should receive *less*
+        # than the legacy equal-share value because they sit in one
+        # quad (1/4 area weight) while interior nodes accumulate area
+        # from four neighbouring quads.
+        face_quads = mesh.face_elements("z_max")
+        from collections import Counter
+        counts = Counter(face_quads.ravel().tolist())
+        corner_nodes = [n for n in face_nodes if counts[int(n)] == 1]
+        interior_nodes = [n for n in face_nodes if counts[int(n)] == 4]
+        assert corner_nodes and interior_nodes
+        legacy_share = total_force / len(face_nodes)
+        for n in corner_nodes:
+            assert F[3 * n + 2] < legacy_share
+        for n in interior_nodes:
+            assert F[3 * n + 2] > legacy_share
+
+    def test_pressure_bc_nodeid_fallback_legacy(self, small_mesh):
+        """Pressure BC with explicit ``node_ids`` falls back to equal split.
+
+        Without face topology there is no way to integrate over surface
+        shape functions, so we keep the legacy equal-per-node behaviour
+        as a documented fallback.
+        """
+        handler = BoundaryHandler(small_mesh)
+        xmax_nodes = small_mesh.nodes_on_face("x_max")
+        total_force = 1000.0
+        bcs = [
+            BoundaryCondition(
+                bc_type="pressure",
+                node_ids=xmax_nodes,
+                dofs=[0],
+                value=total_force,
+            ),
+        ]
+        F = handler.get_force_dofs(bcs)
+        per_node = total_force / len(xmax_nodes)
         for nid in xmax_nodes:
-            assert np.isclose(F[3 * nid], force_per_node)
+            assert np.isclose(F[3 * nid], per_node)
 
     def test_apply_penalty(self, small_mesh, single_ply_laminate):
         """Penalty method modifies diagonal and force vector."""


### PR DESCRIPTION
## Summary

Closes #50.

The previous face-load distribution divided a face's total force equally among all face nodes (`F / n_face_nodes`). That treats corner, edge, and interior face nodes as if they had equal tributary area, which over-loads corners and under-loads interior nodes — and is *especially* wrong on wrinkled meshes where surface quads have unequal areas.

This PR switches to **consistent face integration** through the surface (Q4 bilinear) shape functions.

## Math

For a face under traction `t`, the consistent nodal force at node `i` is

```
F_i = ∫_Γ N_i(ξ, η) · t  dA
```

For a uniform traction this reduces to a sum over the face quads that touch node `i`:

```
F_i = t · Σ_{e ∋ i} A_e / 4
```

i.e. each face quad contributes `t · A_e / 4` to each of its 4 corner nodes (bilinear Q4 weights). We keep the public `BoundaryCondition(bc_type="pressure", face=..., value=total_force)` API: `value` remains the *total* face force; the traction is recovered internally as `value / Σ A_e`.

## Before / after distribution

On a uniform `nx × ny` grid face with N face nodes, the legacy code gave every node `total/N`. The corrected distribution gives:

| Face-node kind         | Quads touching | Consistent share          |
|------------------------|----------------|---------------------------|
| Corner (4 of them)     | 1              | `t · A_e / 4`             |
| Edge                   | 2              | `t · A_e / 2`             |
| Interior               | 4              | `t · A_e`                 |

Sum of all shares equals `total_force` to numerical tolerance. On a wrinkled mesh the per-quad `A_e` vary, so corners (which sit in only one quad — typically a small one near a wrinkle crest) get less than the legacy `1/N`, and interior nodes accordingly more — that is the bug fix.

## Implementation

- `MeshData.face_elements(face)` — new helper returning Q4 corner-node connectivity per face quad, enumerated topologically from the structured `(i, j, k)` grid (same convention as `nodes_on_face`, so it's correct on wrinkled meshes).
- `boundary._quad_areas` — Q4 area via two-triangle split along the `0-2` diagonal; exact for planar quads, bilinear approximation for curved ones.
- `BoundaryHandler.get_force_dofs` — `"pressure"` BCs with `face=` now use consistent integration. `"pressure"` BCs with explicit `node_ids` (no face topology) keep the legacy equal split as a documented fallback.
- `StaticSolver._load_state_to_bcs` — converted `Nx`/`Nxy` from `bc_type="force"` (which silently divided by N) to `bc_type="pressure"` on the `x_max` face, so this path also benefits.

## Tests

New regression tests (`tests/test_solver/test_static.py`):

- `test_pressure_bc_distribution_total_force` — sum of nodal `Fx` on `x_max` equals the prescribed total to machine precision; no leakage to other DOFs.
- `test_pressure_bc_consistent_tributary_weights` — per-node `F_i = t · Σ A_e / 4` for every face node on the `small_mesh` (`3 × 2 × 1`).
- `test_pressure_bc_uniform_face_buckets` — on a dense flat face (`3 × 3 × 3`) the canonical 1-quad / 2-quad / 4-quad bucket pattern emerges, and force shares respect the 1 : 2 : 4 ratio.
- `test_pressure_bc_wrinkled_mesh_equilibrium` — on a wrinkled (`8 × 4 × 4` with `dual_wrinkle`) face, the integrated normal force matches the prescribed total to `1e-10`, **and** corner nodes receive *less* than the legacy `total/N` share while interior nodes receive more.
- `test_pressure_bc_nodeid_fallback_legacy` — documents the explicit-`node_ids` fallback.

New mesh tests (`tests/test_mesh.py::TestFaceElements`) cover `face_elements` shape, corner membership, and area accounting for every face.

## Tests whose numerical values shifted

- `tests/test_solver/test_static.py::test_pressure_bc_distribution` (old) asserted equal-per-node distribution, which was the bug. Replaced with `test_pressure_bc_distribution_total_force` plus the new consistent-weight tests above. The summed face force is unchanged; only the per-node split changed.
- No solver-residual tests shifted: `compression_bcs` and related displacement-driven tests do not touch `"pressure"` BCs, and the only `solve_load_state` test asserts only that the result is a `FieldResults` instance.

Full suite: **645 passed, 1 xfailed** (pre-existing).

## Test plan

- [x] `python -m pytest -x -q -k "boundary or face_force or static"` — 60 passed
- [x] `python -m pytest --tb=short` — 645 passed, 1 xfailed (pre-existing)
- [x] Equilibrium check: total applied force = `traction · face_area` to `~1e-10` on wrinkled mesh
- [x] Corner / edge / interior 1:2:4 ratio verified on flat regular grids


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_