### PR TITLE
Fix Laminate.midplane_strains thermal sign (+= not -=) (closes #133)

### DIFF
--- a/src/wrinklefe/core/laminate.py
+++ b/src/wrinklefe/core/laminate.py
@@ -506,7 +506,7 @@ class Laminate:
             \\begin{bmatrix} \\varepsilon^0 \\\\ \\kappa \\end{bmatrix}
             = [ABD]^{-1} \\left(
               \\begin{bmatrix} N \\\\ M \\end{bmatrix}
-              - \\begin{bmatrix} N^T \\\\ M^T \\end{bmatrix}
+              + \\begin{bmatrix} N^T \\\\ M^T \\end{bmatrix}
             \\right)
 
         Parameters
@@ -522,11 +522,13 @@ class Laminate:
         """
         NM = load.to_vector()
 
-        # Subtract thermal resultants if temperature change is present
+        # Add thermal resultants if temperature change is present.
+        # Standard CLT solves [A B; B D]{eps0; kappa} = {N + N^T; M + M^T},
+        # so the effective RHS load ADDS the thermal resultants.
         if not np.isclose(load.delta_T, 0.0):
             NT, MT = self.thermal_resultants(load.delta_T)
-            NM[0:3] -= NT
-            NM[3:6] -= MT
+            NM[0:3] += NT
+            NM[3:6] += MT
 
         return self.abd_inverse() @ NM
 

--- a/tests/test_laminate.py
+++ b/tests/test_laminate.py
@@ -477,14 +477,6 @@ class TestLaminateThermal:
         expected = lam.abd_inverse() @ load.to_vector()
         npt.assert_array_equal(observed, expected)
 
-    @pytest.mark.xfail(
-        reason=(
-            "Sign-flip bug in Laminate.midplane_strains: subtracts thermal "
-            "resultants when it should add them (see issue #133). The hand "
-            "reference here is the correct CLT free-thermal-expansion result."
-        ),
-        strict=True,
-    )
     def test_free_thermal_expansion_single_ply(self, x850_material):
         """Single unidirectional 0° ply, N = M = 0, ΔT > 0 → ε⁰ = α·ΔT, κ = 0.
 
@@ -500,13 +492,6 @@ class TestLaminateThermal:
         npt.assert_allclose(observed[0:3], expected_eps0, rtol=1e-12, atol=1e-14)
         npt.assert_allclose(observed[3:6], np.zeros(3), atol=1e-14)
 
-    @pytest.mark.xfail(
-        reason=(
-            "Sign-flip bug in Laminate.midplane_strains: subtracts thermal "
-            "resultants when it should add them (see issue #133)."
-        ),
-        strict=True,
-    )
     def test_midplane_strains_symmetric_free_thermal_recovers_alpha_eff(
         self, x850_material
     ):
@@ -528,13 +513,6 @@ class TestLaminateThermal:
         npt.assert_allclose(observed[0:3], eps0_expected, rtol=1e-12, atol=1e-12)
         npt.assert_allclose(observed[3:6], np.zeros(3), atol=1e-12)
 
-    @pytest.mark.xfail(
-        reason=(
-            "Sign-flip bug in Laminate.midplane_strains: subtracts thermal "
-            "resultants when it should add them (see issue #133)."
-        ),
-        strict=True,
-    )
     def test_midplane_strains_thermal_coupling_unsymmetric(self, x850_material):
         """Unsymmetric ``[0/90]`` with ΔT only:
         ``(ε⁰; κ) = ABD⁻¹ · [N^T; M^T]``. Couples in-plane and bending.


### PR DESCRIPTION
## Root cause
`Laminate.midplane_strains` subtracted the thermal resultants from the RHS load vector. Standard CLT solves `[A B; B D]{ε⁰; κ} = {N + Nᵀ; M + Mᵀ}`, so for a pure-thermal free-expansion problem the effective load must **add** `(Nᵀ, Mᵀ)`. Subtracting flipped the sign of the entire thermal response (a 0° IM7/8552 ply at ΔT=+100 °C gave `ε⁰_y = −2.6e−3` instead of `α₂·ΔT = +2.6e−3`).

## Fix (`src/wrinklefe/core/laminate.py`, `midplane_strains`, ~526-529)
Before:
```python
NM[0:3] -= NT
NM[3:6] -= MT
```
After:
```python
NM[0:3] += NT
NM[3:6] += MT
```
Also updated the docstring CLT formula (`- [Nᵀ; Mᵀ]` → `+ [Nᵀ; Mᵀ]`). `thermal_resultants` returns `Nᵀ` with the conventional positive sign and is **unchanged** — its #135 tests already pass; only `midplane_strains` consumed it with the wrong sign.

## Tests (`tests/test_laminate.py`, `TestLaminateThermal`)
Removed the 3 `@pytest.mark.xfail(strict=True, …)` markers that pinned this bug:
- `test_free_thermal_expansion_single_ply`
- `test_midplane_strains_symmetric_free_thermal_recovers_alpha_eff`
- `test_midplane_strains_thermal_coupling_unsymmetric`

All 3 now pass as regular tests; assertions unchanged.

## Verification
- `tests/test_laminate.py`: **52 passed**, 0 xfail/xpass.
- Full suite: **675 passed, 1 xfailed** (an unrelated pre-existing xfail), plus 1 pre-existing unrelated failure `test_pressure_bc_wrinkled_mesh_equilibrium` (inverted hex8 mesh elements). That failure reproduces on clean `origin/main` with this fix stashed, so it is **not a regression** from this change and has no thermal/laminate code path.
- Issue reproduction now yields the correct `[-5.0e-05, +2.6e-03, 0.0]`.

No remaining xfail/xpass for this bug.

closes #133

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_