### PR TITLE
Fix test_pressure_bc_wrinkled_mesh_equilibrium: lower wrinkle amplitude to 0.2 (closes #137 regression from #136 interaction)

### DIFF
--- a/tests/test_solver/test_static.py
+++ b/tests/test_solver/test_static.py
@@ -451,7 +451,7 @@ class TestBoundaryHandler:
             material=x850_material, ply_thickness=0.183,
         )
         wrinkle = GaussianSinusoidal(
-            amplitude=0.4, wavelength=8.0, width=6.0, center=0.0,
+            amplitude=0.2, wavelength=8.0, width=6.0, center=0.0,
         )
         cfg = WrinkleConfiguration.dual_wrinkle(
             profile=wrinkle, interface1=1, interface2=2, phase=0.0,


### PR DESCRIPTION
## Summary

PRs #136 and #137 were each green in isolation but interact once both land on `main`. #137 added `test_pressure_bc_wrinkled_mesh_equilibrium`, whose mesh uses `amplitude=0.4`, which generates 12 inverted hex8 elements at this mesh resolution. #136 independently added a Jacobian-sign check to `MeshData.validate()` (invoked inside `WrinkleMesh.generate()`), which now correctly raises `MeshValidationError` on that inverted mesh — so the test fails on `main` even though neither PR was wrong on its own. This mirrors the remediation #136 itself applied to the `wrinkled_mesh` fixture in `tests/test_mesh.py`, where it likewise reduced the amplitude.

## Change

One line in `tests/test_solver/test_static.py`, inside `test_pressure_bc_wrinkled_mesh_equilibrium`: the `GaussianSinusoidal(...)` call's `amplitude=0.4` is lowered to `amplitude=0.2`. At `0.2` the mesh is valid (non-inverted) for this resolution while still exercising a genuinely wrinkled, unequal-area face, preserving the regression intent for issue #50. No source files, assertions, or other tests were touched.

## Verification

- `python -m pytest -q -k "pressure_bc or face_force or wrinkled" tests/test_solver/test_static.py`: 6 selected tests pass.
- `python -m pytest -q`: full suite green — **673 passed, 4 xfailed, 0 failed**.

https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_