### PR TITLE
Fix VTK export: stress fields now true element averages (closes #52)

### DIFF
--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -225,8 +225,12 @@ def export_vtk(
 
     - ``ply_id`` (integer)
     - ``ply_angle`` (degrees)
-    - ``stress_11`` (MPa, element average at first Gauss point) if
-      *field_results* is provided
+    - ``stress_11``, ``stress_22``, ``stress_33``, ``stress_23``,
+      ``stress_13``, ``stress_12`` (MPa, true element average over the
+      element's Gauss points) if *field_results* is provided.  Each value
+      is the mean of the corresponding global-frame stress component over
+      all Gauss points in the element, so the field is a genuine
+      per-element representative value rather than a single sampled point.
 
     Parameters
     ----------
@@ -301,10 +305,23 @@ def export_vtk(
         for eid in range(n_elem):
             f.write(f"{mesh.ply_angles[eid]:.4f}\n")
 
-        # Stress sigma_11 (if available) -- element average at first Gauss point
-        if field_results is not None:
-            f.write("SCALARS stress_11 double 1\n")
-            f.write("LOOKUP_TABLE default\n")
-            for eid in range(n_elem):
-                s11 = field_results.stress_global[eid, 0, 0]
-                f.write(f"{s11:.6e}\n")
+        # Stress components (if available) -- true element average over the
+        # element's Gauss points.  Voigt ordering of stress_global is
+        # [sigma_11, sigma_22, sigma_33, tau_23, tau_13, tau_12].
+        if field_results is not None and field_results.stress_global.size > 0:
+            stress = field_results.stress_global  # (n_elem, n_gauss, 6)
+            # Mean over Gauss-point axis -> (n_elem, 6)
+            elem_avg = stress.mean(axis=1)
+            component_names = (
+                "stress_11",
+                "stress_22",
+                "stress_33",
+                "stress_23",
+                "stress_13",
+                "stress_12",
+            )
+            for comp_idx, name in enumerate(component_names):
+                f.write(f"SCALARS {name} double 1\n")
+                f.write("LOOKUP_TABLE default\n")
+                for eid in range(n_elem):
+                    f.write(f"{elem_avg[eid, comp_idx]:.6e}\n")

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -295,3 +295,97 @@ class TestVTKExport:
         assert "SCALARS fiber_angle" in content
         # Should not have displacement vectors
         assert "displacement" not in content
+
+    def test_stress_fields_are_true_element_averages(self, tmp_path):
+        """Regression for #52: exported stress_* is the mean over the
+        element's Gauss points, not the first Gauss point only.
+
+        Builds a tiny synthetic mesh + FieldResults where the Gauss-point
+        stresses differ within each element, then parses the VTK cell-data
+        block and asserts every exported component equals the per-element
+        Gauss-point mean (not stress_global[eid, 0, comp]).
+        """
+        from wrinklefe.solver.results import FieldResults
+
+        n_nodes = 8
+        n_elem = 1
+        n_gauss = 8
+
+        class _Mesh:
+            pass
+
+        mesh = _Mesh()
+        # Unit cube hex8
+        mesh.nodes = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 1.0],
+                [1.0, 1.0, 1.0],
+                [0.0, 1.0, 1.0],
+            ],
+            dtype=float,
+        )
+        mesh.elements = np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=int)
+        mesh.n_nodes = n_nodes
+        mesh.n_elements = n_elem
+        mesh.fiber_angles = np.zeros(n_nodes)
+        mesh.ply_ids = np.zeros(n_elem, dtype=int)
+        mesh.ply_angles = np.zeros(n_elem)
+
+        rng = np.random.default_rng(52)
+        # Deliberately distinct stresses at every Gauss point/component so
+        # the mean differs from the first Gauss point's value.
+        stress_global = rng.normal(scale=100.0, size=(n_elem, n_gauss, 6))
+        # Make GP0 a clear outlier so a "first GP" bug would be obvious.
+        stress_global[0, 0, :] += 5000.0
+
+        zeros = np.zeros((n_elem, n_gauss, 6))
+        field = FieldResults(
+            displacement=np.zeros((n_nodes, 3)),
+            stress_global=stress_global,
+            stress_local=zeros.copy(),
+            strain_global=zeros.copy(),
+            strain_local=zeros.copy(),
+            mesh=mesh,
+            laminate=None,
+        )
+
+        out = tmp_path / "synthetic.vtk"
+        export_vtk(mesh, field, out)
+        lines = out.read_text().splitlines()
+
+        # Parse each "SCALARS <name> double 1" block (one value, n_elem==1).
+        exported: dict[str, float] = {}
+        for i, line in enumerate(lines):
+            if line.startswith("SCALARS stress_"):
+                name = line.split()[1]
+                # line i+1 is LOOKUP_TABLE, line i+2 is the value
+                exported[name] = float(lines[i + 2])
+
+        # Voigt order of stress_global columns.
+        comp_index = {
+            "stress_11": 0,
+            "stress_22": 1,
+            "stress_33": 2,
+            "stress_23": 3,
+            "stress_13": 4,
+            "stress_12": 5,
+        }
+        assert set(exported) == set(comp_index), (
+            f"Expected all 6 stress components, got {sorted(exported)}"
+        )
+
+        for name, col in comp_index.items():
+            expected_mean = stress_global[0, :, col].mean()
+            first_gp = stress_global[0, 0, col]
+            assert exported[name] == pytest.approx(expected_mean, rel=1e-6), (
+                f"{name}: exported {exported[name]} != element mean "
+                f"{expected_mean}"
+            )
+            # Guard: the mean must be distinguishable from the old
+            # first-Gauss-point behaviour for this fixture.
+            assert abs(expected_mean - first_gp) > 1.0


### PR DESCRIPTION
## Problem (issue #52)

`export_vtk` in `src/wrinklefe/io/export.py` documented the `stress_11` cell-data field as the **"element average"**, but the code wrote `field_results.stress_global[eid, 0, 0]` — the value at the **first Gauss point only**. Which Gauss point that is depends on element-local orientation, so the exported field varied discontinuously between adjacent elements and silently misled ParaView users who read it as "the element's stress". Only `stress_11` was exported at all.

## Fix chosen: change the data (issue option 1, the preferred direction)

Compute the genuine per-element average as the mean over the element's Gauss points (`stress_global.mean(axis=1)`), making the data match the documented contract. Visualization-oriented exports want a smooth representative value, so correcting the data (not weakening the docs) is the right call.

Applied consistently to **all six** global-frame Voigt components, not just `stress_11`:

- `stress_11`, `stress_22`, `stress_33`, `stress_23`, `stress_13`, `stress_12`

(Voigt ordering of `stress_global` is `[σ11, σ22, σ33, τ23, τ13, τ12]`.) Previously the other five components were not exported at all; they are now, with the same true-average semantics. Added a `stress_global.size > 0` guard so an empty field array does not produce NaNs. The docstring now states the precise semantics.

## What was exported vs documented

| | Before | After |
|---|---|---|
| Documented | "element average at first Gauss point" (contradictory) | true element average over Gauss points |
| Actually written | `stress_global[eid, 0, 0]` (1st GP, σ11 only) | mean over GPs, all 6 components |

## Test

Added `TestVTKExport::test_stress_fields_are_true_element_averages`: builds a synthetic single-hex model with deliberately distinct per-Gauss-point stresses (GP0 a large outlier), exports to VTK, parses every `SCALARS stress_*` block, and asserts each exported component equals the per-element Gauss-point mean within `rel=1e-6` — and that the mean is distinguishable from the old first-Gauss-point value.

Targeted suite (`-k "vtk or export or stress"`): 64 passed. Changes are confined to `export.py` and the new test.

closes #52

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_