### PR TITLE
Fix viz figure leak: close internally-created figures in batch paths

### DIFF
--- a/src/wrinklefe/viz/__init__.py
+++ b/src/wrinklefe/viz/__init__.py
@@ -28,7 +28,9 @@ from wrinklefe.viz.style import (
     MORPHOLOGY_MARKERS,
     colorbar_setup,
     ensure_axes,
+    figure_context,
     get_morphology_style,
+    save_figure,
     set_publication_style,
 )
 
@@ -67,6 +69,8 @@ __all__ = [
     "FIGSIZE_DOUBLE_WIDE",
     "colorbar_setup",
     "ensure_axes",
+    "save_figure",
+    "figure_context",
     "get_morphology_style",
     # 2D plots
     "plot_wrinkle_profile",

--- a/src/wrinklefe/viz/plots_2d.py
+++ b/src/wrinklefe/viz/plots_2d.py
@@ -11,6 +11,14 @@ All plot functions follow a consistent interface:
 - Return the :class:`~matplotlib.axes.Axes` object for further customization.
 - Apply publication styling from :mod:`wrinklefe.viz.style`.
 
+.. note::
+   When ``ax=None`` the returned ``Axes`` has a *new* parent ``Figure`` that
+   the caller owns. Interactive / Streamlit callers keep it (e.g.
+   ``st.pyplot(ax.figure)``). Batch / sweep / headless code that calls these
+   in a loop **must** close the figure to avoid leaking it; use
+   :func:`wrinklefe.viz.save_figure` (saves then closes by default) or
+   :func:`wrinklefe.viz.figure_context`.
+
 References
 ----------
 Jin, L. et al. (2026). Thin-Walled Structures, 219, 114237.

--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -11,6 +11,11 @@ All plot functions follow the same interface as :mod:`wrinklefe.viz.plots_2d`:
 - Return the :class:`~matplotlib.axes.Axes` object.
 - Apply publication styling from :mod:`wrinklefe.viz.style`.
 
+.. note::
+   As with :mod:`wrinklefe.viz.plots_2d`, batch / sweep / headless loops must
+   close internally-created figures; use :func:`wrinklefe.viz.save_figure`
+   or :func:`wrinklefe.viz.figure_context`. Interactive callers are unaffected.
+
 Colormap convention
 -------------------
 Use perceptually uniform colormaps (``jet`` is deprecated for scientific viz):

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -16,13 +16,16 @@ Elhajjar, R. (2025). Scientific Reports, 15, 25977.
 
 from __future__ import annotations
 
-from typing import Optional
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional, Union
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
+from matplotlib.figure import Figure
 from matplotlib.image import AxesImage
 
 
@@ -237,3 +240,77 @@ def ensure_axes(
     if projection is not None:
         return fig.add_subplot(111, projection=projection)
     return fig.add_subplot(111)
+
+
+def save_figure(
+    ax_or_fig: Union[Axes, Figure],
+    path: Union[str, "os.PathLike[str]"],
+    *,
+    close: bool = True,
+    dpi: int = 300,
+    **savefig_kwargs: Any,
+) -> None:
+    """Save the figure backing ``ax_or_fig`` to ``path`` and (by default) close it.
+
+    This is the recommended way to persist plots produced by the ``plot_*``
+    functions in batch / sweep / CLI / headless code. Those functions return an
+    :class:`~matplotlib.axes.Axes` whose parent :class:`~matplotlib.figure.Figure`
+    is created internally by :func:`ensure_axes`; if such loops never call
+    :func:`matplotlib.pyplot.close`, the figures accumulate (memory leak and the
+    ``More than 20 figures have been opened`` warning).
+
+    Parameters
+    ----------
+    ax_or_fig : Axes or Figure
+        The object returned by a ``plot_*`` function (an ``Axes``), or a
+        ``Figure`` directly.
+    path : str or os.PathLike
+        Destination file path for :meth:`~matplotlib.figure.Figure.savefig`.
+    close : bool, optional
+        If ``True`` (default), close the figure after writing so it does not
+        leak. Pass ``False`` only if the caller still needs the live figure
+        (e.g. to display it interactively afterwards).
+    dpi : int, optional
+        Resolution passed to ``savefig``. Default is 300.
+    **savefig_kwargs
+        Extra keyword arguments forwarded to
+        :meth:`~matplotlib.figure.Figure.savefig` (e.g. ``bbox_inches='tight'``).
+    """
+    fig = ax_or_fig if isinstance(ax_or_fig, Figure) else ax_or_fig.figure
+    savefig_kwargs.setdefault("bbox_inches", "tight")
+    fig.savefig(path, dpi=dpi, **savefig_kwargs)
+    if close:
+        plt.close(fig)
+
+
+@contextmanager
+def figure_context(ax_or_fig: Union[Axes, Figure]) -> Iterator[Figure]:
+    """Context manager that closes an internally-created figure on exit.
+
+    Use this to wrap a ``plot_*`` call in leak-prone batch loops when you are
+    not going through :func:`save_figure`::
+
+        for case in cases:
+            with figure_context(plot_wrinkle_profile(case.profile)) as fig:
+                fig.savefig(case.out_path)
+        # every figure is closed; plt.get_fignums() does not grow
+
+    Interactive / Streamlit callers should simply not use this helper (and not
+    pass ``close=True`` to :func:`save_figure`); the figure they receive stays
+    alive exactly as before.
+
+    Parameters
+    ----------
+    ax_or_fig : Axes or Figure
+        The object returned by a ``plot_*`` function, or a ``Figure``.
+
+    Yields
+    ------
+    Figure
+        The parent figure, guaranteed closed when the ``with`` block exits.
+    """
+    fig = ax_or_fig if isinstance(ax_or_fig, Figure) else ax_or_fig.figure
+    try:
+        yield fig
+    finally:
+        plt.close(fig)

--- a/tests/test_viz/test_no_figure_leak.py
+++ b/tests/test_viz/test_no_figure_leak.py
@@ -1,0 +1,115 @@
+"""Regression tests for the matplotlib figure leak (issues #38 / #30).
+
+``ensure_axes`` creates a new ``Figure`` when ``ax=None`` but the ``plot_*``
+functions only return the ``Axes``. In batch / sweep / headless loops nothing
+closed those figures, so they accumulated until matplotlib emitted the
+``More than 20 figures have been opened`` warning (a real memory leak).
+
+The fix adds opt-in :func:`wrinklefe.viz.save_figure` /
+:func:`wrinklefe.viz.figure_context` helpers that close internally-created
+figures. These tests assert that the number of open matplotlib figures stays
+bounded across many iterations when those helpers are used, while the
+interactive contract (the returned ``Axes`` keeps its live figure) is
+preserved when they are not.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless; no display required
+
+import matplotlib.pyplot as plt
+import pytest
+
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+from wrinklefe.viz import figure_context, plot_wrinkle_profile, save_figure
+
+N_ITERATIONS = 30
+
+
+@pytest.fixture
+def profile() -> GaussianSinusoidal:
+    return GaussianSinusoidal(amplitude=0.5, wavelength=10.0, width=5.0)
+
+
+@pytest.fixture(autouse=True)
+def _clean_figures():
+    """Start and end each test with no open figures."""
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def test_save_figure_does_not_leak_in_loop(profile, tmp_path):
+    """The save-to-disk path must close figures: fignums stay bounded at ~0."""
+    assert len(plt.get_fignums()) == 0
+
+    for i in range(N_ITERATIONS):
+        ax = plot_wrinkle_profile(profile)
+        save_figure(ax, tmp_path / f"profile_{i}.png")
+        # After each save+close exactly zero figures should remain open.
+        assert len(plt.get_fignums()) == 0, (
+            f"figure leaked at iteration {i}: "
+            f"{len(plt.get_fignums())} open figures"
+        )
+
+    assert len(plt.get_fignums()) == 0
+    # Sanity: files were actually written.
+    assert len(list(tmp_path.glob("profile_*.png"))) == N_ITERATIONS
+
+
+def test_figure_context_does_not_leak_in_loop(profile, tmp_path):
+    """figure_context closes the internally-created figure on block exit."""
+    assert len(plt.get_fignums()) == 0
+
+    for i in range(N_ITERATIONS):
+        with figure_context(plot_wrinkle_profile(profile)) as fig:
+            fig.savefig(tmp_path / f"ctx_{i}.png")
+        assert len(plt.get_fignums()) == 0, (
+            f"figure leaked at iteration {i}"
+        )
+
+    assert len(plt.get_fignums()) == 0
+
+
+@pytest.mark.filterwarnings("ignore:More than 20 figures:RuntimeWarning")
+def test_plain_loop_without_helper_does_leak(profile):
+    """Documents the original bug: without a helper, figures accumulate.
+
+    This guards against a regression where ``ensure_axes`` stopped creating
+    a figure at all (which would silently break the interactive contract).
+    """
+    for _ in range(N_ITERATIONS):
+        plot_wrinkle_profile(profile)
+    # Without an explicit close the leak is real and unbounded.
+    assert len(plt.get_fignums()) == N_ITERATIONS
+
+
+def test_save_figure_keeps_figure_when_close_false(profile, tmp_path):
+    """Interactive contract: close=False leaves the live figure open."""
+    ax = plot_wrinkle_profile(profile)
+    fig = ax.figure
+    save_figure(ax, tmp_path / "keep.png", close=False)
+    assert fig.number in plt.get_fignums()
+    plt.close(fig)
+
+
+def test_returned_axes_still_has_live_figure(profile):
+    """Non-breaking: plot_* still returns an Axes whose Figure is alive.
+
+    Streamlit / interactive callers rely on ``ax.figure`` being a usable,
+    not-yet-closed figure (e.g. ``st.pyplot(ax.figure)``).
+    """
+    ax = plot_wrinkle_profile(profile)
+    assert ax.figure is not None
+    assert ax.figure.number in plt.get_fignums()
+    plt.close(ax.figure)
+
+
+def test_save_figure_accepts_figure_directly(profile, tmp_path):
+    """save_figure works whether handed an Axes or a Figure."""
+    ax = plot_wrinkle_profile(profile)
+    save_figure(ax.figure, tmp_path / "fig.png")
+    assert len(plt.get_fignums()) == 0
+    assert (tmp_path / "fig.png").exists()


### PR DESCRIPTION
Closes #38, closes #30 (duplicate — same matplotlib figure-leak problem).

## The leak mechanism

`ensure_axes(ax=None)` in `src/wrinklefe/viz/style.py` calls `plt.figure(...)` and returns only the child `Axes`. Every public `plot_*` function in `plots_2d.py` / `plots_3d.py` follows this pattern and returns just the `Axes`. In batch/sweep/headless loops nothing ever calls `plt.close()`, so pyplot retains every `Figure`, leaking memory and eventually emitting `RuntimeWarning: More than 20 figures have been opened`.

## Design choice (interactive callers unaffected)

The `plot_*` return contract is **unchanged** — they still return an `Axes` whose parent `Figure` is alive. Streamlit / interactive callers (`st.pyplot(ax.figure)`) keep working exactly as before. The fix is **opt-in** for the leak-prone side:

- `wrinklefe.viz.save_figure(ax_or_fig, path, *, close=True, dpi=300, **savefig_kwargs)` — the recommended side-effecting save-to-disk path: writes the figure and closes it by default (`close=False` available for callers that still need it).
- `wrinklefe.viz.figure_context(ax_or_fig)` — context manager that guarantees the internally-created figure is closed on block exit.

Both accept either an `Axes` or a `Figure`. Module docstrings now direct batch users to these helpers.

## Batch callers

No in-repo production code calls `wrinklefe.viz.plot_*` in a loop — the sweep module (`parametric_sweep.py`) and the Streamlit `app.py` build their own figures and already `plt.close()` them correctly. The leak is on the public API surface used by external sweep/notebook/CLI scripts; `save_figure`/`figure_context` give them a clean, non-breaking way to avoid it.

## Tests

New `tests/test_viz/test_no_figure_leak.py` (Agg backend):
- `save_figure` and `figure_context` over 30 iterations: assert `len(plt.get_fignums()) == 0` after every iteration (bounded, no growth).
- Plain loop without a helper still leaks `N` figures — guards against `ensure_axes` regressing and silently breaking the interactive contract.
- `close=False` keeps the live figure; `plot_*` still returns an `Axes` with a live `.figure`; `save_figure` accepts a `Figure` directly.

Targeted (`-k "viz or plot or figure"`): 6 passed. Full suite: **682 passed, 1 xfailed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_