### PR TITLE
Fix parametric_sweep: handle phase parameter (closes #49)

### DIFF
--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -51,6 +51,7 @@ from wrinklefe.core.morphology import (
     WrinkleConfiguration,
     WrinklePlacement,
     MORPHOLOGY_PHASES,
+    SINGLE_WRINKLE_MODES,
 )
 from wrinklefe.core.mesh import WrinkleMesh, MeshData
 from wrinklefe.solver.static import StaticSolver
@@ -295,6 +296,14 @@ class AnalysisConfig:
     morphology : str
         Morphology name: ``'stack'``, ``'convex'``, or ``'concave'``.
         Default is ``'stack'``.
+    phase : float or None
+        Explicit dual-wrinkle phase offset phi [radians] between the two
+        wrinkles.  When ``None`` (default), the phase is derived from
+        ``morphology`` via :data:`MORPHOLOGY_PHASES` (stack=0,
+        convex=+pi/2, concave=-pi/2).  When set to a float, it overrides
+        the named-morphology phase, allowing arbitrary dual-wrinkle phase
+        offsets to be analysed or swept (e.g. between 0 and pi).  Ignored
+        for single-wrinkle morphologies (``'uniform'``, ``'graded'``).
     loading : str
         Loading mode: ``'compression'`` or ``'tension'``.
         Default is ``'compression'``.
@@ -343,6 +352,11 @@ class AnalysisConfig:
 
     # Morphology
     morphology: str = "stack"
+    # Explicit dual-wrinkle phase offset phi [rad]. None → derive from
+    # `morphology` (stack=0, convex=+pi/2, concave=-pi/2). A float
+    # overrides the named-morphology phase so arbitrary phases can be
+    # analysed/swept. Ignored for single-wrinkle modes (uniform/graded).
+    phase: Optional[float] = None
     decay_floor: float = 0.0  # graded mode: min amplitude fraction at surfaces (0–1)
 
     # Loading
@@ -595,12 +609,25 @@ class WrinkleAnalysis:
             width=cfg.width,
             center=wrinkle_center,
         )
-        wrinkle_config = WrinkleConfiguration.from_morphology_name(
-            cfg.morphology, profile,
-            interface1=cfg.interface_1,
-            interface2=cfg.interface_2,
-            decay_floor=cfg.decay_floor,
-        )
+        if cfg.phase is not None and (
+            cfg.morphology.lower().strip() not in SINGLE_WRINKLE_MODES
+        ):
+            # Explicit phase overrides the named-morphology phase so
+            # arbitrary dual-wrinkle phase offsets can be analysed/swept.
+            wrinkle_config = WrinkleConfiguration.dual_wrinkle(
+                profile,
+                interface1=cfg.interface_1,
+                interface2=cfg.interface_2,
+                phase=float(cfg.phase),
+            )
+            wrinkle_config.decay_floor = max(0.0, min(1.0, cfg.decay_floor))
+        else:
+            wrinkle_config = WrinkleConfiguration.from_morphology_name(
+                cfg.morphology, profile,
+                interface1=cfg.interface_1,
+                interface2=cfg.interface_2,
+                decay_floor=cfg.decay_floor,
+            )
         results.wrinkle_config = wrinkle_config
 
         # 3. Analytical predictions

--- a/src/wrinklefe/sweep/parametric_sweep.py
+++ b/src/wrinklefe/sweep/parametric_sweep.py
@@ -85,13 +85,20 @@ def validate_args(sweep_params, ranges):
 
 
 def _make_config(params, fine_mesh=False):
-    """Build an AnalysisConfig from a parameter dict."""
+    """Build an AnalysisConfig from a parameter dict.
+
+    A ``phase`` entry (when not ``None``) is plumbed through to
+    ``AnalysisConfig.phase`` so phase sweeps actually change the
+    dual-wrinkle geometry instead of being silently dropped (issue #49).
+    """
     nx, ny = (50, 20) if fine_mesh else (30, 15)
+    phase = params.get('phase')
     return AnalysisConfig(
         amplitude=params['amplitude'],
         wavelength=params['wavelength'],
         width=params.get('width', DEFAULTS['width']),
         morphology=params.get('morphology', 'stack'),
+        phase=None if phase is None else float(phase),
         nx=nx,
         ny=ny,
     )
@@ -173,15 +180,14 @@ def run_sweep(sweep_config, fine_mesh=False):
         print(f"  [{idx+1}/{total}] {param_str} ...", end='', flush=True)
 
         if is_phase_sweep:
-            # Phase sweep: use the phase value directly as morphology offset
-            phase = params['phase']
-            base_cfg = _make_config(params, fine_mesh)
-            # Create a stack config and override morphology via phase
-            base_cfg.morphology = 'stack'
-            ar_list = WrinkleAnalysis.parametric_sweep(base_cfg, 'amplitude',
-                                                        [params['amplitude']])
-            # For phase sweeps we do a single run with custom phase
-            ar = ar_list[0]
+            # Phase sweep: the swept phase value is plumbed straight into
+            # AnalysisConfig.phase (issue #49), which overrides the
+            # named-morphology phase so each point uses a distinct
+            # dual-wrinkle geometry instead of an identical 'stack' one.
+            phase = float(params['phase'])
+            params['morphology'] = 'stack'  # named phase is overridden anyway
+            cfg = _make_config(params, fine_mesh)
+            ar = WrinkleAnalysis(cfg).run()
             point_results = {
                 'custom': {
                     **_result_to_metrics(ar),

--- a/tests/test_analysis_sweep.py
+++ b/tests/test_analysis_sweep.py
@@ -9,6 +9,7 @@ and only override the swept parameters.
 
 from __future__ import annotations
 
+import math
 from dataclasses import fields, replace
 from unittest.mock import patch
 
@@ -219,3 +220,116 @@ class TestSweepDomainLengthDerivation:
         # but is not a field; the stricter check must reject it.
         with pytest.raises(AttributeError, match="has no field"):
             WrinkleAnalysis.parametric_sweep(base, "__post_init__", [1.0])
+
+
+class TestPhaseSweep:
+    """Issue #49: sweeping ``phase`` must change the dual-wrinkle geometry.
+
+    Previously ``AnalysisConfig`` had no ``phase`` field, so a phase
+    sweep silently produced N identical configurations (every point used
+    the same named-morphology phase).  ``phase`` is now a real numeric
+    field that overrides the named-morphology phase and is threaded into
+    the wrinkle profile via ``WrinkleConfiguration.dual_wrinkle``.
+    """
+
+    def _phase_base(self):
+        return AnalysisConfig(
+            amplitude=0.366,
+            wavelength=16.0,
+            width=12.0,
+            morphology="stack",
+            loading="compression",
+            material=MaterialLibrary().get("IM7_8552"),
+            angles=[0, 90, 0, 90, 0, 90, 90, 0, 90, 0, 90, 0],
+            interface_1=5,
+            interface_2=6,
+            nx=4,
+            ny=2,
+            nz_per_ply=1,
+            domain_width=10.0,
+            applied_strain=-0.005,
+            analytical_only=True,
+            verbose=False,
+        )
+
+    def test_phase_is_a_sweepable_field(self):
+        """``phase`` must be a real AnalysisConfig field (no AttributeError)."""
+        assert any(f.name == "phase" for f in fields(AnalysisConfig))
+        # Default leaves phase unset so named morphology still governs.
+        assert AnalysisConfig().phase is None
+
+    def test_parametric_sweep_phase_produces_distinct_configs(self):
+        """Each swept phase must reach AnalysisConfig.phase as a distinct value."""
+        captured = []
+
+        def fake_run(self, analytical_only=None):
+            captured.append(self.config)
+            return _make_stub_result(self.config)
+
+        phases = [0.0, math.pi / 4, math.pi / 2, 3 * math.pi / 4]
+        with patch.object(WrinkleAnalysis, "run", fake_run):
+            results = WrinkleAnalysis.parametric_sweep(
+                self._phase_base(), "phase", phases
+            )
+
+        assert len(results) == len(phases)
+        for cfg, expected in zip(captured, phases):
+            assert cfg.phase == pytest.approx(expected)
+        # All swept phase values are distinct (no silent collapse).
+        assert len({round(c.phase, 9) for c in captured}) == len(phases)
+
+    def test_parametric_sweep_phase_changes_knockdown(self):
+        """Distinct phases must yield distinct morphology factors / knockdowns."""
+        base = self._phase_base()
+        # Phases chosen so sin(phi) is strictly increasing (the morphology
+        # factor is exp(-alpha*sin(phi) - ...)); avoid points that share a
+        # sin value, e.g. phi=0/pi or phi=pi/4 vs 3pi/4, which are
+        # *physically* identical (this is correct morphology physics, not
+        # a no-op).  Within [0, pi/2] sin is monotonic.
+        phases = [0.0, math.pi / 6, math.pi / 3, math.pi / 2]
+        results = WrinkleAnalysis.parametric_sweep(
+            base, "phase", phases, analytical_only=True
+        )
+
+        mfs = [r.morphology_factor for r in results]
+        kds = [r.analytical_knockdown for r in results]
+        # N distinct morphology factors and knockdowns — not a no-op.
+        assert len({round(m, 8) for m in mfs}) == len(phases), (
+            f"phase sweep produced non-distinct morphology factors: {mfs}"
+        )
+        assert len({round(k, 8) for k in kds}) == len(phases), (
+            f"phase sweep produced non-distinct knockdowns (silent no-op): {kds}"
+        )
+
+    def test_explicit_phase_matches_named_morphology(self):
+        """phase=+pi/2 must reproduce the named 'convex' morphology exactly."""
+        base = self._phase_base()
+        named_convex = WrinkleAnalysis(
+            replace(base, morphology="convex")
+        ).run(analytical_only=True)
+        explicit = WrinkleAnalysis(
+            replace(base, morphology="stack", phase=math.pi / 2)
+        ).run(analytical_only=True)
+        assert explicit.analytical_knockdown == pytest.approx(
+            named_convex.analytical_knockdown
+        )
+        assert explicit.morphology_factor == pytest.approx(
+            named_convex.morphology_factor
+        )
+
+    def test_phase_none_preserves_named_morphology(self):
+        """phase=None (default) must keep using the named-morphology phase."""
+        base = self._phase_base()
+        concave = WrinkleAnalysis(
+            replace(base, morphology="concave", phase=None)
+        ).run(analytical_only=True)
+        stack = WrinkleAnalysis(
+            replace(base, morphology="stack", phase=None)
+        ).run(analytical_only=True)
+        # Named morphologies still differentiate when phase is unset.
+        assert concave.morphology_factor != pytest.approx(
+            stack.morphology_factor
+        )
+        # concave amplifies (M_f > 1), stack is baseline (M_f == 1).
+        assert concave.morphology_factor > 1.0
+        assert stack.morphology_factor == pytest.approx(1.0)


### PR DESCRIPTION
## Fix chosen: option (a) — `phase` is a real parameter, plumb it through

`phase` IS a well-defined dual-wrinkle physics parameter. `WrinkleConfiguration.dual_wrinkle(..., phase=...)` already accepts an arbitrary phase offset (radians) and threads it through `apply_to_nodes`, `fiber_angles_at_nodes`, and `aggregate_morphology_factor`. The named morphologies (`stack`/`convex`/`concave`) are just presets of `MORPHOLOGY_PHASES` (0, +pi/2, -pi/2). The bug was that `AnalysisConfig` had **no `phase` field**, so:

- `WrinkleAnalysis.run()` only ever called `from_morphology_name`, making arbitrary phases unreachable.
- The standalone `sweep/parametric_sweep.py` computed `params['phase']` but `_make_config` never passed it to `AnalysisConfig`, so every swept point used the same `stack` geometry — a silent no-op (the exact symptom reported).

Option (b) was rejected because the wrinkle pipeline fully supports arbitrary phase; rejecting it would discard real functionality.

## Files changed
- `src/wrinklefe/analysis.py`: add `phase: Optional[float] = None` field (documented); in `run()`, when `phase` is set and morphology is not single-wrinkle, build the config via `dual_wrinkle(..., phase=...)` (preserving `decay_floor`). `phase=None` keeps the named-morphology path — fully backward compatible.
- `src/wrinklefe/sweep/parametric_sweep.py`: `_make_config` now plumbs `phase` into `AnalysisConfig`; the phase-sweep branch simplified to run with the real swept phase instead of discarding it.
- `tests/test_analysis_sweep.py`: new `TestPhaseSweep` class.

## Test coverage
New tests verify: `phase` is a sweepable field; `parametric_sweep` produces N distinct configs/knockdowns per phase (no silent no-op); explicit `phase=+pi/2` reproduces the named `convex` morphology exactly; `phase=None` preserves named-morphology behavior.

- Targeted: `pytest -k "sweep or phase or parametric"` — 29 passed
- Full suite: 681 passed, 1 xfailed (pre-existing, unrelated) — no regressions

https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_