### PR TITLE
Fix MaxStrainCriterion: consistent strain basis so uniaxial allowables give FI=1

### DIFF
--- a/src/wrinklefe/failure/max_strain.py
+++ b/src/wrinklefe/failure/max_strain.py
@@ -8,11 +8,24 @@ all six strain components.
 Mathematical Formulation
 ------------------------
 Given stress vector ``sigma`` in Voigt notation (11, 22, 33, 23, 13, 12),
-compute the strain vector::
+the working strains are the *uncoupled engineering strains* obtained by
+dividing each stress component by its corresponding direct modulus::
 
-    epsilon = [S] @ sigma
+    epsilon = [sigma_11/E1, sigma_22/E2, sigma_33/E3,
+               tau_23/G23,  tau_13/G13,  tau_12/G12]
 
-where ``[S]`` is the 6x6 compliance matrix.
+This deliberately omits the Poisson-coupling off-diagonal terms of the
+full compliance matrix ``[S]``.  It is the standard engineering
+"maximum strain" convention (Jones, *Mechanics of Composite Materials*;
+Daniel & Ishai; Tsai), and it is the *only* basis on which the working
+strains are consistent with the uniaxial-test allowables below: each
+uniaxial strength then maps exactly to a failure index of 1.0.
+
+Using the coupled compliance path (``epsilon = [S] @ sigma``) instead
+breaks this self-calibration -- e.g. pure transverse compression
+``sigma_22 = -Yc`` induces a Poisson strain ``eps_33 = nu23*Yc/E2`` that
+is compared against the unrelated allowable ``Zt/E3``, spuriously firing
+a through-thickness tension failure (FI ~ 1.38 instead of 1.0).
 
 Ultimate strains are derived from uniaxial strengths::
 
@@ -92,8 +105,20 @@ class MaxStrainCriterion(FailureCriterion):
             Failure index, dominant mode, reserve factor, and criterion name.
         """
         stress_local = np.asarray(stress_local, dtype=np.float64)
-        S = material.compliance_matrix
-        strain = S @ stress_local
+
+        # Uncoupled engineering strains (no Poisson off-diagonal coupling).
+        # This is the basis on which the uniaxial-test allowables below are
+        # defined, so each uniaxial strength maps exactly to FI = 1.0.
+        # Using the full compliance matrix would introduce Poisson-coupled
+        # strains that are inconsistent with the uniaxial allowables.
+        strain = np.array([
+            stress_local[0] / material.E1,
+            stress_local[1] / material.E2,
+            stress_local[2] / material.E3,
+            stress_local[3] / material.G23,
+            stress_local[4] / material.G13,
+            stress_local[5] / material.G12,
+        ])
 
         # Ultimate strains (all positive magnitudes)
         eps1t = material.Xt / material.E1

--- a/tests/test_failure/test_max_strain.py
+++ b/tests/test_failure/test_max_strain.py
@@ -44,11 +44,14 @@ class TestMaxStrainUniaxial:
         assert result.index == pytest.approx(1.0, rel=1e-6)
         assert result.mode == "matrix_transverse_tension"
 
-    @pytest.mark.xfail(
-        reason="max_strain.py over-predicts FI ~1.379 under pure σ22=-Yc; tracked in #24",
-        strict=True,
-    )
     def test_pure_transverse_compression_at_Yc(self, criterion, material):
+        """Regression for #34/#25/#24.
+
+        Pure sigma_22 = -Yc must give FI = 1.0 (failure exactly at the
+        transverse compressive allowable).  The previous compliance-based
+        implementation returned ~1.379 because Poisson-induced eps_33 was
+        compared against the unrelated Zt/E3 allowable.
+        """
         stress = np.array([0.0, -material.Yc, 0.0, 0.0, 0.0, 0.0])
         result = criterion.evaluate(stress, material)
         assert result.index == pytest.approx(1.0, rel=1e-6)
@@ -65,3 +68,79 @@ class TestMaxStrainUniaxial:
         stress = np.array([0.5 * material.Xt, 0.0, 0.0, 0.0, 0.0, 0.0])
         result = criterion.evaluate(stress, material)
         assert result.reserve_factor == pytest.approx(1.0 / result.index, rel=1e-12)
+
+
+class TestMaxStrainConsistentBasisRegression:
+    """Regression suite for #34 / #25 / #24.
+
+    The correctness contract for the engineering max-strain criterion is
+    that every uniaxial allowable self-calibrates to FI = 1.0, because the
+    working strains and the allowable strains are computed on the *same*
+    uncoupled engineering basis (sigma_i / E_i), with no Poisson coupling.
+    """
+
+    # (label, stress vector, expected dominant mode)
+    UNIAXIAL_CASES = [
+        ("sigma11=+Xt", lambda m: [m.Xt, 0, 0, 0, 0, 0], "fiber_tension"),
+        ("sigma11=-Xc", lambda m: [-m.Xc, 0, 0, 0, 0, 0], "fiber_compression"),
+        ("sigma22=+Yt", lambda m: [0, m.Yt, 0, 0, 0, 0],
+         "matrix_transverse_tension"),
+        ("sigma22=-Yc", lambda m: [0, -m.Yc, 0, 0, 0, 0],
+         "matrix_transverse_compression"),
+        ("tau12=+S12", lambda m: [0, 0, 0, 0, 0, m.S12], "shear_12"),
+    ]
+
+    @pytest.mark.parametrize(
+        "label,build,mode",
+        UNIAXIAL_CASES,
+        ids=[c[0] for c in UNIAXIAL_CASES],
+    )
+    def test_every_uniaxial_allowable_maps_to_fi_one(
+        self, criterion, material, label, build, mode
+    ):
+        stress = np.array(build(material), dtype=float)
+        result = criterion.evaluate(stress, material)
+        assert result.index == pytest.approx(1.0, rel=1e-6), label
+        assert result.mode == mode, label
+
+    def test_zero_stress_gives_fi_zero(self, criterion, material):
+        result = criterion.evaluate(np.zeros(6), material)
+        assert result.index == pytest.approx(0.0, abs=1e-12)
+
+    def test_transverse_compression_does_not_fire_thickness_tension(
+        self, criterion, material
+    ):
+        """Core bug: pure sigma_22 = -Yc must NOT spuriously fail in the
+        through-thickness tension mode via Poisson-coupled eps_33."""
+        stress = np.array([0.0, -material.Yc, 0.0, 0.0, 0.0, 0.0])
+        result = criterion.evaluate(stress, material)
+        assert result.mode == "matrix_transverse_compression"
+        assert result.index == pytest.approx(1.0, rel=1e-6)
+        # The old compliance path returned ~1.379 here.
+        assert result.index < 1.05
+
+    @pytest.mark.parametrize(
+        "build", [c[1] for c in UNIAXIAL_CASES], ids=[c[0] for c in UNIAXIAL_CASES]
+    )
+    def test_proportional_loading_is_linear(self, criterion, material, build):
+        """Max-strain is linear in stress: doubling the stress state
+        doubles FI, and the reserve factor scales the load to first
+        failure (RF * stress -> FI = 1)."""
+        stress = np.array(build(material), dtype=float)
+        base = criterion.evaluate(stress, material)
+        doubled = criterion.evaluate(2.0 * stress, material)
+        assert doubled.index == pytest.approx(2.0 * base.index, rel=1e-9)
+        assert base.reserve_factor == pytest.approx(1.0 / base.index, rel=1e-12)
+        scaled = criterion.evaluate(base.reserve_factor * stress, material)
+        assert scaled.index == pytest.approx(1.0, rel=1e-6)
+
+    def test_working_strain_uses_uncoupled_engineering_basis(
+        self, criterion, material
+    ):
+        """The working strain must be sigma_i/E_i with no Poisson terms.
+        Half the transverse compressive allowable -> FI exactly 0.5 and
+        no other component (notably eps_33) contributes."""
+        stress = np.array([0.0, -0.5 * material.Yc, 0.0, 0.0, 0.0, 0.0])
+        result = criterion.evaluate(stress, material)
+        assert result.index == pytest.approx(0.5, rel=1e-9)
+        assert result.mode == "matrix_transverse_compression"


### PR DESCRIPTION
## Root cause

`MaxStrainCriterion.evaluate` computed the **working strains** via the full 3D
compliance matrix (`strain = S @ stress`), which introduces Poisson-coupled
off-diagonal terms. But the **allowable strains** are the uncoupled
uniaxial-test ratios (`eps2c = Yc/E2`, `eps3t = Zt/E3`, ...). The two sides
were on inconsistent bases. Under pure transverse compression
`sigma22 = -Yc`, the compliance path produces a Poisson-induced
`eps33 = nu23*Yc/E2 = 0.009463`, which exceeds the unrelated allowable
`Zt/E3 = 0.006861` (ratio **1.379**) and spuriously fires a through-thickness
tension failure. The **working-strain side used the wrong basis**.

## Fix

Switch the working strains to the **uncoupled engineering basis**
(`epsilon = [sigma11/E1, sigma22/E2, sigma33/E3, tau23/G23, tau13/G13, tau12/G12]`),
which is the standard engineering max-strain convention
(Jones / Daniel & Ishai / Tsai) and the *same* basis the allowables already
use. With both sides consistent, every uniaxial strength self-calibrates to
FI = 1.0. Docstring updated to remove the `epsilon = [S] @ sigma` claim and
explain why coupling is omitted. Class API unchanged; one-line strain
expression swapped.

## Uniaxial verification (IM7/8552, `OrthotropicMaterial()`)

| Stress state | FI before | FI after | Dominant mode |
|---|---|---|---|
| sigma11 = +Xt | 1.000 | **1.000** | fiber_tension |
| sigma11 = -Xc | 1.000 | **1.000** | fiber_compression |
| sigma22 = +Yt | 1.000 | **1.000** | matrix_transverse_tension |
| sigma22 = -Yc | **1.379** | **1.000** | matrix_transverse_compression |
| tau12 = +S12 | 1.000 | **1.000** | shear_12 |
| zero stress | 0.000 | **0.000** | - |

Proportional loading confirmed linear: doubling the stress doubles FI;
`reserve_factor = 1/FI` scales the load to first failure.

## Regression tests (`tests/test_failure/test_max_strain.py`)

- Removed the `@pytest.mark.xfail(strict=True)` on
  `test_pure_transverse_compression_at_Yc` (now genuinely passing).
- New `TestMaxStrainConsistentBasisRegression`:
  - parametrized: all 5 uniaxial allowables -> FI = 1.0 with correct mode
  - zero stress -> FI = 0
  - transverse compression does **not** fire thickness tension (FI < 1.05)
  - proportional loading linear + reserve-factor scaling (parametrized over all 5)
  - working strain uses the uncoupled engineering basis (half-allowable -> FI = 0.5)

## Suite status

Full suite green: **727 passed** (0 failed). No downstream shifts — no other
code consumed a coupled-strain value from this criterion.

closes #34
closes #25
closes #24

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_