### PR TITLE
Add AnalysisConfig.__post_init__ input validation

### DIFF
--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -36,6 +36,7 @@ References
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field, fields, replace
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -408,6 +409,164 @@ class AnalysisConfig:
             # Quasi-isotropic [0/45/-45/90]_3s → 24 plies
             base = [0, 45, -45, 90]
             self.angles = (base * 3) + list(reversed(base * 3))
+
+        self._validate()
+
+    def _validate(self) -> None:
+        """Fail fast on physically invalid configuration.
+
+        Called from :meth:`__post_init__` after defaults (``domain_length``,
+        ``material``, ``angles``) have been resolved.  Each check raises a
+        :class:`ValueError` naming the offending field and value so that
+        misconfiguration surfaces at construction time rather than as an
+        obscure traceback deep in the solver/mesh path.
+        """
+        # --- Wrinkle geometry -----------------------------------------
+        # amplitude == 0 is a legitimate "no wrinkle" (flat) case: the
+        # mid-surface profile z(x) = A * envelope reduces to 0, so the
+        # closed-form misalignment angle arctan(2*pi*A/lambda) is 0.
+        # Only a negative amplitude is physically meaningless.
+        if self.amplitude < 0:
+            raise ValueError(
+                f"AnalysisConfig.amplitude must be >= 0 "
+                f"(0 = flat / no wrinkle), got {self.amplitude}"
+            )
+        if not (self.wavelength > 0):
+            # Strictly positive: lambda divides into the closed-form
+            # slope (2*pi*A/lambda) and the auto-derived domain_length.
+            raise ValueError(
+                f"AnalysisConfig.wavelength must be > 0, "
+                f"got {self.wavelength}"
+            )
+        if not (self.width > 0):
+            raise ValueError(
+                f"AnalysisConfig.width must be > 0, got {self.width}"
+            )
+        if not (self.domain_length > 0):
+            raise ValueError(
+                f"AnalysisConfig.domain_length must be > 0, "
+                f"got {self.domain_length}"
+            )
+        if not (self.domain_width > 0):
+            raise ValueError(
+                f"AnalysisConfig.domain_width must be > 0, "
+                f"got {self.domain_width}"
+            )
+        if not (self.ply_thickness > 0):
+            raise ValueError(
+                f"AnalysisConfig.ply_thickness must be > 0, "
+                f"got {self.ply_thickness}"
+            )
+
+        # --- Morphology / phase ---------------------------------------
+        # run() resolves morphology by name (possibly lower/strip'd) via
+        # WrinkleConfiguration.from_morphology_name; an explicit numeric
+        # ``phase`` overrides the named-morphology phase for dual-wrinkle
+        # modes but the name is still consumed (single-wrinkle modes and
+        # the from_morphology_name fallback both require a known name).
+        valid_morphologies = sorted(
+            set(MORPHOLOGY_PHASES) | set(SINGLE_WRINKLE_MODES)
+        )
+        if (
+            not isinstance(self.morphology, str)
+            or self.morphology.lower().strip() not in valid_morphologies
+        ):
+            raise ValueError(
+                f"AnalysisConfig.morphology must be one of "
+                f"{valid_morphologies}, got {self.morphology!r}"
+            )
+        if self.phase is not None and not math.isfinite(float(self.phase)):
+            raise ValueError(
+                f"AnalysisConfig.phase must be finite when set, "
+                f"got {self.phase}"
+            )
+        if not (0.0 <= self.decay_floor <= 1.0):
+            raise ValueError(
+                f"AnalysisConfig.decay_floor must be in [0, 1], "
+                f"got {self.decay_floor}"
+            )
+
+        # --- Loading --------------------------------------------------
+        valid_loadings = ("compression", "tension")
+        if (
+            not isinstance(self.loading, str)
+            or self.loading.lower().strip() not in valid_loadings
+        ):
+            raise ValueError(
+                f"AnalysisConfig.loading must be one of "
+                f"{list(valid_loadings)}, got {self.loading!r}"
+            )
+        if not math.isfinite(self.applied_strain):
+            raise ValueError(
+                f"AnalysisConfig.applied_strain must be finite, "
+                f"got {self.applied_strain}"
+            )
+
+        # --- Wrinkle placement (interface indices) --------------------
+        n_plies = len(self.angles)
+        for name in ("interface_1", "interface_2"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(
+                    f"AnalysisConfig.{name} must be an int, got {value!r}"
+                )
+            if not (0 <= value < n_plies):
+                raise ValueError(
+                    f"AnalysisConfig.{name} must be in [0, {n_plies}) "
+                    f"(0 <= interface < number of plies), got {value}"
+                )
+
+        # --- Mesh resolution (structural integers) --------------------
+        for name in ("nx", "ny", "nz_per_ply"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(
+                    f"AnalysisConfig.{name} must be an int, got {value!r}"
+                )
+            if value < 1:
+                raise ValueError(
+                    f"AnalysisConfig.{name} must be >= 1, got {value}"
+                )
+
+        # --- Solver ---------------------------------------------------
+        valid_solvers = ("direct", "iterative")
+        if (
+            not isinstance(self.solver, str)
+            or self.solver.lower().strip() not in valid_solvers
+        ):
+            raise ValueError(
+                f"AnalysisConfig.solver must be one of "
+                f"{list(valid_solvers)}, got {self.solver!r}"
+            )
+
+        # --- Optional analyses ---------------------------------------
+        if not isinstance(self.n_buckling_modes, int) or isinstance(
+            self.n_buckling_modes, bool
+        ):
+            raise ValueError(
+                f"AnalysisConfig.n_buckling_modes must be an int, "
+                f"got {self.n_buckling_modes!r}"
+            )
+        if self.n_buckling_modes < 1:
+            raise ValueError(
+                f"AnalysisConfig.n_buckling_modes must be >= 1, "
+                f"got {self.n_buckling_modes}"
+            )
+        # mc_samples must be a usable sample count.  Both issues ask for
+        # mc_samples >= 1; reject <= 0 unconditionally (a clearly-invalid
+        # value) and require a valid int whenever Monte Carlo will run.
+        if not isinstance(self.mc_samples, int) or isinstance(
+            self.mc_samples, bool
+        ):
+            raise ValueError(
+                f"AnalysisConfig.mc_samples must be an int, "
+                f"got {self.mc_samples!r}"
+            )
+        if self.mc_samples < 1:
+            raise ValueError(
+                f"AnalysisConfig.mc_samples must be >= 1, "
+                f"got {self.mc_samples}"
+            )
 
 
 # ======================================================================

--- a/tests/test_analysis_config.py
+++ b/tests/test_analysis_config.py
@@ -1,0 +1,165 @@
+"""Regression tests for AnalysisConfig.__post_init__ input validation.
+
+Verifies the fix for issues #39 / #29: ``AnalysisConfig.__post_init__``
+previously performed zero validation, so physically invalid inputs
+(negative amplitude, non-positive wavelength/width, unknown morphology,
+non-positive ``mc_samples``, etc.) were silently accepted and surfaced
+only as obscure tracebacks deep in the solver/mesh path.  Construction
+must now fail fast with a clear :class:`ValueError` naming the field and
+the offending value, while every valid configuration (including boundary
+values) still constructs unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig
+from wrinklefe.core.material import MaterialLibrary
+
+
+# ----------------------------------------------------------------------
+# Valid configurations must still construct unchanged
+# ----------------------------------------------------------------------
+
+def test_default_config_constructs():
+    """A default AnalysisConfig must construct without error."""
+    cfg = AnalysisConfig()
+    # __post_init__ side effects preserved (valid-input behaviour unchanged).
+    assert cfg.domain_length == pytest.approx(3.0 * cfg.wavelength)
+    assert cfg.material is not None
+    assert cfg.angles is not None and len(cfg.angles) == 24
+
+
+def test_fully_specified_valid_config_constructs():
+    """A realistic fully-specified valid config must construct."""
+    cfg = AnalysisConfig(
+        amplitude=0.366,
+        wavelength=16.0,
+        width=12.0,
+        morphology="concave",
+        loading="tension",
+        material=MaterialLibrary().get("IM7_8552"),
+        angles=[0, 90, 0, 90, 0, 90, 90, 0, 90, 0, 90, 0],
+        interface_1=5,
+        interface_2=6,
+        nx=4,
+        ny=2,
+        nz_per_ply=1,
+        domain_width=10.0,
+        applied_strain=-0.005,
+        run_montecarlo=True,
+        mc_samples=100,
+    )
+    assert cfg.morphology == "concave"
+
+
+def test_nonpositive_domain_length_is_auto_derived_not_rejected():
+    """Existing behaviour preserved: domain_length <= 0 is a sentinel
+    meaning "auto = 3 * wavelength", not an invalid value."""
+    cfg = AnalysisConfig(domain_length=-5.0, wavelength=10.0)
+    assert cfg.domain_length == pytest.approx(30.0)
+    cfg2 = AnalysisConfig(domain_length=0.0, wavelength=8.0)
+    assert cfg2.domain_length == pytest.approx(24.0)
+
+
+@pytest.mark.parametrize("morphology", ["stack", "convex", "concave",
+                                        "uniform", "graded"])
+def test_all_named_morphologies_accepted(morphology):
+    """Every canonical morphology name must be accepted."""
+    assert AnalysisConfig(morphology=morphology).morphology == morphology
+
+
+@pytest.mark.parametrize("morphology", ["STACK", " Convex ", "Concave"])
+def test_morphology_case_and_whitespace_tolerated(morphology):
+    """run() lower/strip's the name, so validation must too."""
+    assert AnalysisConfig(morphology=morphology) is not None
+
+
+@pytest.mark.parametrize("loading", ["compression", "tension"])
+def test_valid_loadings_accepted(loading):
+    assert AnalysisConfig(loading=loading).loading == loading
+
+
+def test_boundary_valid_values_accepted():
+    """Smallest/edge values that are still valid must be accepted."""
+    # amplitude == 0 is the legitimate "no wrinkle" (flat) case.
+    AnalysisConfig(amplitude=0.0)
+    # Strictly-positive fields at a small positive value.
+    AnalysisConfig(wavelength=1e-6, width=1e-6, domain_width=1e-6,
+                   ply_thickness=1e-6)
+    # decay_floor inclusive bounds.
+    AnalysisConfig(decay_floor=0.0)
+    AnalysisConfig(decay_floor=1.0)
+    # Smallest valid structural integers / counts.
+    AnalysisConfig(nx=1, ny=1, nz_per_ply=1, n_buckling_modes=1,
+                   mc_samples=1)
+    # interface indices at the inclusive lower / exclusive upper bound.
+    AnalysisConfig(angles=[0, 90, 0, 90], interface_1=0, interface_2=3)
+    # explicit numeric phase must not require a dual-wrinkle name and
+    # must coexist with a single-wrinkle morphology.
+    AnalysisConfig(phase=0.7, morphology="graded")
+
+
+# ----------------------------------------------------------------------
+# Invalid configurations must raise ValueError naming field + value
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"amplitude": -0.1}, r"amplitude must be >= 0.*got -0\.1"),
+        ({"wavelength": 0.0}, r"wavelength must be > 0.*got 0\.0"),
+        ({"wavelength": -16.0}, r"wavelength must be > 0.*got -16\.0"),
+        ({"width": 0.0}, r"width must be > 0.*got 0\.0"),
+        ({"width": -1.0}, r"width must be > 0.*got -1\.0"),
+        ({"domain_width": 0.0}, r"domain_width must be > 0.*got 0\.0"),
+        ({"ply_thickness": 0.0}, r"ply_thickness must be > 0.*got 0\.0"),
+        ({"ply_thickness": -0.183}, r"ply_thickness must be > 0"),
+        ({"morphology": "spiral"},
+         r"morphology must be one of.*got 'spiral'"),
+        ({"morphology": "unknown"}, r"morphology must be one of"),
+        ({"morphology": 5}, r"morphology must be one of"),
+        ({"loading": "shear"}, r"loading must be one of.*got 'shear'"),
+        ({"loading": None}, r"loading must be one of"),
+        ({"decay_floor": -0.1}, r"decay_floor must be in \[0, 1\]"),
+        ({"decay_floor": 1.5}, r"decay_floor must be in \[0, 1\]"),
+        ({"applied_strain": float("nan")},
+         r"applied_strain must be finite"),
+        ({"applied_strain": float("inf")},
+         r"applied_strain must be finite"),
+        ({"phase": float("inf")}, r"phase must be finite"),
+        ({"angles": [0, 90, 0, 90], "interface_1": 4},
+         r"interface_1 must be in \[0, 4\).*got 4"),
+        ({"angles": [0, 90, 0, 90], "interface_1": -1},
+         r"interface_1 must be in \[0, 4\)"),
+        ({"angles": [0, 90, 0, 90], "interface_1": 1, "interface_2": 10},
+         r"interface_2 must be in \[0, 4\)"),
+        ({"nx": 0}, r"nx must be >= 1.*got 0"),
+        ({"ny": 0}, r"ny must be >= 1.*got 0"),
+        ({"nz_per_ply": -2}, r"nz_per_ply must be >= 1.*got -2"),
+        ({"n_buckling_modes": 0}, r"n_buckling_modes must be >= 1.*got 0"),
+        ({"mc_samples": 0}, r"mc_samples must be >= 1.*got 0"),
+        ({"mc_samples": -10}, r"mc_samples must be >= 1.*got -10"),
+    ],
+)
+def test_invalid_config_raises_value_error(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        AnalysisConfig(**kwargs)
+
+
+def test_negative_mc_samples_rejected_even_when_montecarlo_off():
+    """A clearly-invalid mc_samples (<= 0) is rejected regardless of
+    whether Monte Carlo will actually run (matches the issue ask)."""
+    with pytest.raises(ValueError, match=r"mc_samples must be >= 1"):
+        AnalysisConfig(run_montecarlo=False, mc_samples=0)
+
+
+def test_explicit_phase_does_not_require_dual_wrinkle_name():
+    """A numeric ``phase`` must not force ``morphology`` to be a known
+    dual-wrinkle name, but the name must still be a valid morphology
+    (run() always consumes it via from_morphology_name)."""
+    AnalysisConfig(phase=1.0, morphology="stack")
+    AnalysisConfig(phase=1.0, morphology="uniform")
+    with pytest.raises(ValueError, match=r"morphology must be one of"):
+        AnalysisConfig(phase=1.0, morphology="bogus")


### PR DESCRIPTION
## Summary

Closes #39, closes #29 (duplicate request).

`AnalysisConfig.__post_init__` previously performed zero input validation: physically invalid inputs (negative amplitude, non-positive wavelength/width, unknown morphology, non-positive `mc_samples`, etc.) were silently accepted and surfaced only as obscure tracebacks deep in the solver/mesh path. A new `_validate()` helper is called from `__post_init__` **after** the existing defaulting logic (`domain_length`, `material`, `angles`) so it can validate resolved values.

Valid-input behaviour and the class API are unchanged. The `domain_length <= 0` sentinel ("auto = 3 * wavelength") is preserved and is **not** treated as invalid.

## Validated fields, rules, and messages

| Field | Rule | Message form |
|---|---|---|
| `amplitude` | `>= 0` (0 = legitimate "no wrinkle"/flat case; only `< 0` rejected, documented inline) | `AnalysisConfig.amplitude must be >= 0 (0 = flat / no wrinkle), got <v>` |
| `wavelength` | `> 0` (divides into slope `2*pi*A/lambda` and auto `domain_length`) | `AnalysisConfig.wavelength must be > 0, got <v>` |
| `width` | `> 0` | `AnalysisConfig.width must be > 0, got <v>` |
| `domain_length` | `> 0` (after sentinel re-derivation) | `AnalysisConfig.domain_length must be > 0, got <v>` |
| `domain_width` | `> 0` | `AnalysisConfig.domain_width must be > 0, got <v>` |
| `ply_thickness` | `> 0` | `AnalysisConfig.ply_thickness must be > 0, got <v>` |
| `morphology` | one of `{concave, convex, graded, stack, uniform}` (canonical set = `MORPHOLOGY_PHASES` ∪ `SINGLE_WRINKLE_MODES`); case/whitespace tolerated to mirror `run()` | `AnalysisConfig.morphology must be one of [...], got <v>` |
| `phase` | finite when set; explicit numeric phase does **not** require a dual-wrinkle name (mirrors `run()`), but the name must still be a valid morphology since `run()` always consumes it via `from_morphology_name` | `AnalysisConfig.phase must be finite when set, got <v>` |
| `decay_floor` | in `[0, 1]` | `AnalysisConfig.decay_floor must be in [0, 1], got <v>` |
| `loading` | one of `{compression, tension}` | `AnalysisConfig.loading must be one of [...], got <v>` |
| `applied_strain` | finite | `AnalysisConfig.applied_strain must be finite, got <v>` |
| `interface_1`, `interface_2` | int, in `[0, len(angles))` | `AnalysisConfig.interface_1 must be in [0, N) (0 <= interface < number of plies), got <v>` |
| `nx`, `ny`, `nz_per_ply` | int, `>= 1` | `AnalysisConfig.nx must be >= 1, got <v>` |
| `n_buckling_modes` | int, `>= 1` | `AnalysisConfig.n_buckling_modes must be >= 1, got <v>` |
| `mc_samples` | int, `>= 1` (rejected `<= 0` unconditionally, even when `run_montecarlo` is False, per the issue ask) | `AnalysisConfig.mc_samples must be >= 1, got <v>` |

`bool` is explicitly rejected where an `int` is required (since `bool` is an `int` subclass).

## Tests

New `tests/test_analysis_config.py` (matches the existing `tests/test_analysis*.py` convention; #29 explicitly asked for this file):
- Parametrized over every invalid field → `pytest.raises(ValueError, match=...)`.
- Default and a fully-specified valid config still construct.
- Boundary-valid values accepted (`amplitude=0`, smallest positive geometry, `decay_floor` 0 and 1, smallest valid integers/counts, interface indices at inclusive lower / exclusive upper bound, explicit `phase` with single-wrinkle morphology).
- Asserts the `domain_length <= 0` sentinel is still auto-derived (valid-input behaviour preserved).

## Existing test adjustments

None. No existing test constructed an invalid config; no pre-existing test was modified.

## Test results

- Targeted (`-k "config or validation or analysis"`): **121 passed**.
- Full suite (`python -m pytest -q`): **770 passed**, 0 failures.

https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_