### PR TITLE
CLI: support contracted layup notation and uniform/graded morphologies

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,12 +15,10 @@ from __future__ import annotations
 import csv
 import io
 import json
-import re
 import sys
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import List
 
 import matplotlib
 
@@ -37,6 +35,7 @@ if _SRC.is_dir() and str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 
@@ -642,78 +641,6 @@ with st.sidebar:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_PLY_TOKEN_RE = re.compile(
-    r"""\s*
-        (?P<sign>±)?\s*
-        (?P<angle>[+-]?\d+(?:\.\d+)?)\s*
-        (?:_(?P<rep>\d+))?\s*
-    """,
-    re.VERBOSE,
-)
-
-
-def _expand_ply_token(token: str) -> List[float]:
-    """Expand a single ply entry like ``0``, ``45_2``, ``±45``, or ``±30_2``."""
-    token = token.strip()
-    if not token:
-        return []
-    m = _PLY_TOKEN_RE.fullmatch(token)
-    if not m:
-        raise ValueError(f"Could not parse ply token: {token!r}")
-    angle = float(m.group("angle"))
-    rep = int(m.group("rep")) if m.group("rep") else 1
-    if m.group("sign") == "±":
-        return [angle, -angle] * rep
-    return [angle] * rep
-
-
-def _parse_contracted_layup(s: str) -> List[float]:
-    """Parse contracted notation like ``[0/45/-45/90]_3s`` or ``[0/±45/90]s``."""
-    m = re.fullmatch(
-        r"\s*\[\s*(?P<inner>[^\[\]]*)\]\s*_?\s*(?P<rep>\d+)?\s*(?P<sym>[sS])?\s*",
-        s,
-    )
-    if not m:
-        raise ValueError(
-            f"Could not parse contracted layup {s!r}. "
-            "Expected a form like '[0/45/-45/90]_3s'."
-        )
-    plies: List[float] = []
-    for tok in m.group("inner").split("/"):
-        plies.extend(_expand_ply_token(tok))
-    if not plies:
-        raise ValueError("Contracted layup contains no plies.")
-    repeat = int(m.group("rep")) if m.group("rep") else 1
-    plies = plies * repeat
-    if m.group("sym"):
-        plies = plies + plies[::-1]
-    return plies
-
-
-def parse_layup(s: str) -> List[float]:
-    """Parse a layup string into a flat list of ply angles (degrees).
-
-    Two notations are accepted:
-
-    * **Contracted** — ``[0/45/-45/90]_3s`` (sublaminate in brackets, optional
-      repeat count, trailing ``s`` for symmetry). ``±`` and ``_n`` ply-level
-      modifiers are also supported, e.g. ``[0/±45/90_2]s``.
-    * **Explicit list** — comma-, semicolon-, or newline-separated angles,
-      e.g. ``0, 45, -45, 90, ...``.
-    """
-    s = s.strip()
-    if not s:
-        raise ValueError("Layup is empty.")
-    if "[" in s or "]" in s:
-        return _parse_contracted_layup(s)
-    out: List[float] = []
-    for tok in s.replace(";", ",").replace("\n", ",").split(","):
-        out.extend(_expand_ply_token(tok))
-    if not out:
-        raise ValueError("Layup is empty.")
-    return out
-
 
 @st.cache_data(show_spinner=False)
 def run_analysis_cached(cfg_payload: tuple) -> dict:

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -24,6 +24,14 @@ from typing import List, Optional, Sequence
 
 import numpy as np
 
+from wrinklefe.core.layup import parse_layup
+from wrinklefe.core.morphology import MORPHOLOGY_PHASES, SINGLE_WRINKLE_MODES
+
+# Single source of truth for the morphology names the CLI accepts. Pulled
+# straight from ``core.morphology`` so the CLI can never drift from the
+# engine / Streamlit app (see issue #83).
+MORPHOLOGY_CHOICES = sorted(set(MORPHOLOGY_PHASES.keys()) | SINGLE_WRINKLE_MODES)
+
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser with subcommands."""
@@ -64,8 +72,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_analyze.add_argument(
         "--morphology", type=str, default="stack",
-        choices=["stack", "convex", "concave"],
-        help="Wrinkle morphology type (default: stack)",
+        choices=MORPHOLOGY_CHOICES,
+        help=(
+            "Wrinkle morphology type (default: stack). "
+            f"One of: {', '.join(MORPHOLOGY_CHOICES)}."
+        ),
     )
     p_analyze.add_argument(
         "--loading", type=str, default="compression",
@@ -77,9 +88,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Material name from MaterialLibrary (default: IM7_8552)",
     )
     p_analyze.add_argument(
-        "--angles", type=str, default=None,
+        "--angles", "--layup", type=str, default=None, dest="angles",
         help=(
-            "Ply angles as comma-separated values, e.g. '0,45,-45,90'. "
+            "Ply layup. Accepts an explicit comma-separated list "
+            "(e.g. '0,45,-45,90') or contracted notation "
+            "(e.g. '[0/45/-45/90]_3s', '[0/±45/90]s'). "
             "Default: quasi-isotropic [0/45/-45/90]_3s"
         ),
     )
@@ -195,8 +208,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_sweep.add_argument(
         "--morphology", type=str, default="stack",
-        choices=["stack", "convex", "concave"],
-        help="Morphology for the sweep (default: stack)",
+        choices=MORPHOLOGY_CHOICES,
+        help=(
+            "Morphology for the sweep (default: stack). "
+            f"One of: {', '.join(MORPHOLOGY_CHOICES)}."
+        ),
     )
     p_sweep.add_argument(
         "--analytical-only", action=argparse.BooleanOptionalAction, default=True,
@@ -228,10 +244,21 @@ def _build_parser() -> argparse.ArgumentParser:
 # ====================================================================== #
 
 def _parse_angles(angles_str: Optional[str]) -> Optional[List[float]]:
-    """Parse a comma-separated angle string into a list of floats."""
+    """Parse a layup string into a list of ply angles (degrees).
+
+    Accepts both an explicit comma/semicolon/newline-separated list
+    (e.g. ``0,45,-45,90``) and contracted notation
+    (e.g. ``[0/45/-45/90]_3s``) via the shared
+    :func:`wrinklefe.core.layup.parse_layup` parser. On a malformed
+    layup, prints a clear error and exits with a non-zero status.
+    """
     if angles_str is None:
         return None
-    return [float(a.strip()) for a in angles_str.split(",")]
+    try:
+        return parse_layup(angles_str)
+    except ValueError as exc:
+        print(f"error: invalid layup: {exc}", file=sys.stderr)
+        sys.exit(2)
 
 
 def _cmd_analyze(args: argparse.Namespace) -> None:

--- a/src/wrinklefe/core/layup.py
+++ b/src/wrinklefe/core/layup.py
@@ -1,0 +1,97 @@
+"""Layup notation parsing shared across the WrinkleFE UIs and CLI.
+
+This module is the single source of truth for turning a human-written
+layup string into a flat list of ply angles (degrees). Both the
+Streamlit app (``app.py``) and the command-line interface
+(``wrinklefe.cli``) import :func:`parse_layup` from here so the two
+front-ends can never drift apart.
+
+Two notations are accepted:
+
+* **Contracted** -- ``[0/45/-45/90]_3s`` (sublaminate in brackets,
+  optional repeat count, trailing ``s`` for symmetry). ``+/-`` (written
+  ``±``) and ``_n`` ply-level modifiers are also supported, e.g.
+  ``[0/±45/90_2]s``.
+* **Explicit list** -- comma-, semicolon-, or newline-separated angles,
+  e.g. ``0, 45, -45, 90, ...``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+__all__ = ["parse_layup"]
+
+
+_PLY_TOKEN_RE = re.compile(
+    r"""\s*
+        (?P<sign>±)?\s*
+        (?P<angle>[+-]?\d+(?:\.\d+)?)\s*
+        (?:_(?P<rep>\d+))?\s*
+    """,
+    re.VERBOSE,
+)
+
+
+def _expand_ply_token(token: str) -> List[float]:
+    """Expand a single ply entry like ``0``, ``45_2``, ``±45``, or ``±30_2``."""
+    token = token.strip()
+    if not token:
+        return []
+    m = _PLY_TOKEN_RE.fullmatch(token)
+    if not m:
+        raise ValueError(f"Could not parse ply token: {token!r}")
+    angle = float(m.group("angle"))
+    rep = int(m.group("rep")) if m.group("rep") else 1
+    if m.group("sign") == "±":
+        return [angle, -angle] * rep
+    return [angle] * rep
+
+
+def _parse_contracted_layup(s: str) -> List[float]:
+    """Parse contracted notation like ``[0/45/-45/90]_3s`` or ``[0/±45/90]s``."""
+    m = re.fullmatch(
+        r"\s*\[\s*(?P<inner>[^\[\]]*)\]\s*_?\s*(?P<rep>\d+)?\s*(?P<sym>[sS])?\s*",
+        s,
+    )
+    if not m:
+        raise ValueError(
+            f"Could not parse contracted layup {s!r}. "
+            "Expected a form like '[0/45/-45/90]_3s'."
+        )
+    plies: List[float] = []
+    for tok in m.group("inner").split("/"):
+        plies.extend(_expand_ply_token(tok))
+    if not plies:
+        raise ValueError("Contracted layup contains no plies.")
+    repeat = int(m.group("rep")) if m.group("rep") else 1
+    plies = plies * repeat
+    if m.group("sym"):
+        plies = plies + plies[::-1]
+    return plies
+
+
+def parse_layup(s: str) -> List[float]:
+    """Parse a layup string into a flat list of ply angles (degrees).
+
+    Two notations are accepted:
+
+    * **Contracted** -- ``[0/45/-45/90]_3s`` (sublaminate in brackets,
+      optional repeat count, trailing ``s`` for symmetry). ``±`` and
+      ``_n`` ply-level modifiers are also supported, e.g.
+      ``[0/±45/90_2]s``.
+    * **Explicit list** -- comma-, semicolon-, or newline-separated
+      angles, e.g. ``0, 45, -45, 90, ...``.
+    """
+    s = s.strip()
+    if not s:
+        raise ValueError("Layup is empty.")
+    if "[" in s or "]" in s:
+        return _parse_contracted_layup(s)
+    out: List[float] = []
+    for tok in s.replace(";", ",").replace("\n", ",").split(","):
+        out.extend(_expand_ply_token(tok))
+    if not out:
+        raise ValueError("Layup is empty.")
+    return out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,3 +276,119 @@ def test_invalid_numeric_value_exits_with_code_2():
     with pytest.raises(SystemExit) as exc_info:
         cli_main(["analyze", "--amplitude", "not-a-number"])
     assert exc_info.value.code == 2
+
+
+# --------------------------------------------------------------------------- #
+# issue #83: contracted layup notation + uniform/graded morphologies
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_morphology_choices_sourced_from_core():
+    """CLI choices must equal the canonical core.morphology set, not a
+    hard-coded literal (acceptance criterion of issue #83)."""
+    from wrinklefe.cli import MORPHOLOGY_CHOICES
+    from wrinklefe.core.morphology import (
+        MORPHOLOGY_PHASES,
+        SINGLE_WRINKLE_MODES,
+    )
+
+    expected = sorted(set(MORPHOLOGY_PHASES.keys()) | SINGLE_WRINKLE_MODES)
+    assert MORPHOLOGY_CHOICES == expected
+    # The two formerly-unreachable modes are now present.
+    assert "uniform" in MORPHOLOGY_CHOICES
+    assert "graded" in MORPHOLOGY_CHOICES
+
+
+@pytest.mark.parametrize("morph", ["uniform", "graded"])
+def test_analyze_accepts_uniform_and_graded(morph):
+    """--morphology uniform/graded are accepted and plumbed into the
+    AnalysisConfig the engine receives."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--morphology", morph, "--analytical-only"])
+
+    cfg = captured["config"]
+    assert cfg.morphology == morph
+
+
+def test_analyze_contracted_layup_expands_to_24_plies():
+    """'[0/45/-45/90]_3s' must reach AnalysisConfig as the same 24-ply
+    list the Streamlit app produces."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze",
+            "--layup", "[0/45/-45/90]_3s",
+            "--analytical-only",
+        ])
+
+    cfg = captured["config"]
+    quarter = [0.0, 45.0, -45.0, 90.0]
+    expected = quarter * 3
+    expected = expected + expected[::-1]
+    assert cfg.angles == expected
+    assert len(cfg.angles) == 24
+
+
+def test_analyze_contracted_layup_matches_shared_parser():
+    """The CLI path must agree exactly with the shared parser used by
+    app.py for the same input."""
+    from wrinklefe.core.layup import parse_layup
+
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze",
+            "--layup", "[0/±45/90]s",
+            "--analytical-only",
+        ])
+
+    assert captured["config"].angles == parse_layup("[0/±45/90]s")
+
+
+def test_analyze_explicit_comma_list_still_works():
+    """Backwards compatibility: the original comma-separated form."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze",
+            "--angles", "0, 45, -45, 90",
+            "--analytical-only",
+        ])
+
+    assert captured["config"].angles == [0.0, 45.0, -45.0, 90.0]
+
+
+def test_analyze_invalid_layup_exits_nonzero_with_message(capsys):
+    """A malformed layup must produce a clear error and a non-zero exit."""
+    captured, patcher = _stub_analysis_run()
+    with patcher, pytest.raises(SystemExit) as exc_info:
+        cli_main(["analyze", "--layup", "[0/45/", "--analytical-only"])
+
+    assert exc_info.value.code != 0
+    err = capsys.readouterr().err
+    assert "layup" in err.lower()
+
+
+def test_sweep_accepts_graded_morphology():
+    """sweep --morphology graded must be accepted (was argparse-rejected)."""
+    captured: dict = {}
+
+    def fake_sweep(base_config, parameter, values, analytical_only):
+        captured["config"] = base_config
+        return [_make_fake_result() for _ in values]
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.parametric_sweep",
+        new=staticmethod(fake_sweep),
+    ):
+        cli_main([
+            "sweep",
+            "--parameter", "amplitude",
+            "--min", "0.1",
+            "--max", "0.3",
+            "--steps", "2",
+            "--morphology", "graded",
+        ])
+
+    assert captured["config"].morphology == "graded"

--- a/tests/test_layup.py
+++ b/tests/test_layup.py
@@ -1,0 +1,108 @@
+"""Tests for the shared layup parser :mod:`wrinklefe.core.layup`.
+
+This parser is the single source of truth for both the Streamlit app
+(``app.py``) and the CLI (``wrinklefe.cli``); see issue #83. These tests
+cover the parser directly and assert that ``app.py`` imports it rather
+than defining its own copy.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from wrinklefe.core.layup import parse_layup
+
+
+# --------------------------------------------------------------------------- #
+# Contracted notation
+# --------------------------------------------------------------------------- #
+
+
+def test_contracted_quasi_iso_3s_expands_to_24():
+    quarter = [0.0, 45.0, -45.0, 90.0]
+    expected = quarter * 3
+    expected = expected + expected[::-1]
+    assert parse_layup("[0/45/-45/90]_3s") == expected
+    assert len(parse_layup("[0/45/-45/90]_3s")) == 24
+
+
+def test_contracted_symmetry_only():
+    assert parse_layup("[0/90]s") == [0.0, 90.0, 90.0, 0.0]
+
+
+def test_contracted_plus_minus_token():
+    assert parse_layup("[0/±45/90]s") == [
+        0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0
+    ]
+
+
+def test_contracted_ply_level_repeat():
+    assert parse_layup("[0_2/90]") == [0.0, 0.0, 90.0]
+
+
+def test_contracted_repeat_without_symmetry():
+    assert parse_layup("[0/90]_2") == [0.0, 90.0, 0.0, 90.0]
+
+
+# --------------------------------------------------------------------------- #
+# Explicit list notation
+# --------------------------------------------------------------------------- #
+
+
+def test_explicit_comma_list():
+    assert parse_layup("0, 45, -45, 90") == [0.0, 45.0, -45.0, 90.0]
+
+
+def test_explicit_semicolon_and_newline_separators():
+    assert parse_layup("0; 45\n-45;90") == [0.0, 45.0, -45.0, 90.0]
+
+
+def test_explicit_plus_minus_token():
+    assert parse_layup("0, ±45, 90") == [0.0, 45.0, -45.0, 90.0]
+
+
+# --------------------------------------------------------------------------- #
+# Error handling
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "[0/45/", "[]", "[abc]"])
+def test_malformed_layup_raises_value_error(bad):
+    with pytest.raises(ValueError):
+        parse_layup(bad)
+
+
+# --------------------------------------------------------------------------- #
+# app.py must consume the shared parser (no duplicate definition)
+# --------------------------------------------------------------------------- #
+
+
+def _app_py_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "app.py"
+
+
+def test_app_py_imports_shared_parser():
+    """app.py imports parse_layup from the package, not a local copy."""
+    src = _app_py_path().read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    imports_shared = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "wrinklefe.core.layup"
+        and any(alias.name == "parse_layup" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert imports_shared, "app.py must import parse_layup from wrinklefe.core.layup"
+
+    # And it must NOT redefine the parser locally anymore.
+    local_defs = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    assert "parse_layup" not in local_defs
+    assert "_parse_contracted_layup" not in local_defs
+    assert "_expand_ply_token" not in local_defs


### PR DESCRIPTION
Closes #83.

## Parser sharing (refactor)
The contracted-layup parser previously lived only in `app.py`
(`_PLY_TOKEN_RE`, `_expand_ply_token`, `_parse_contracted_layup`,
`parse_layup`). It was self-contained (only `re` + `typing`), so it was
**moved verbatim** into a new package module `src/wrinklefe/core/layup.py`
as the single source of truth.

- `app.py` now does `from wrinklefe.core.layup import parse_layup` and the
  local definitions were deleted. Behavior is byte-identical (same regex,
  same expansion rules), so every Streamlit-path test still passes. The
  now-unused `import re` / `from typing import List` were dropped from
  `app.py`.
- The CLI imports the same `parse_layup`, so `[0/45/-45/90]_3s`,
  `[0/±45/90]s`, ply-level `_n` repeats, symmetry, and explicit
  comma/semicolon/newline lists all behave identically across UI and CLI.

## Morphology plumbing
`cli.py` no longer hard-codes `choices=["stack","convex","concave"]`.
A module-level `MORPHOLOGY_CHOICES = sorted(MORPHOLOGY_PHASES.keys() |
SINGLE_WRINKLE_MODES)` is pulled from `core.morphology` and used for both
`analyze` and `sweep`, so the CLI can't drift. `uniform` and `graded` are
now accepted and verified end-to-end to reach `AnalysisConfig.morphology`.
`--angles` gained a `--layup` alias; malformed layups exit non-zero with a
clear `error: invalid layup: ...` message.

`compare` (a deliberately 3-morphology comparison) was left unchanged.

## Tests
- `tests/test_cli.py` (extended): choices sourced from core; `--morphology
  uniform/graded` reach the config; `[0/45/-45/90]_3s` -> 24 plies via CLI;
  CLI agrees with shared parser; explicit comma list still works; invalid
  layup exits non-zero with message; `sweep --morphology graded` accepted.
- `tests/test_layup.py` (new): direct unit tests for `parse_layup`
  (contracted, ±, ply repeat, symmetry, explicit separators, error cases)
  plus an AST-level check that `app.py` imports the shared parser and no
  longer defines its own copy.

## Test results
- Targeted (`-k "cli or layup or morphology"`): 83 passed.
- Full suite: **749 passed**, 0 failures (~198s).

https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_