### PR TITLE
Docs: define wrinkle geometry parameters and units (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ measured wrinkle (e.g. from a cross-section micrograph or CT slice),
 `θ_max ≈ arctan(2πA/λ)`, which drives the Budiansky-Fleck compressive
 knockdown.
 
+### Wrinkle geometry parameters
+
+All wrinkle length parameters use a single, consistent unit:
+**millimetres (mm)** — the same unit as `ply_thickness` and
+`domain_length` (the default `amplitude=0.366` mm is exactly two ply
+thicknesses of 0.183 mm). Lengths are **not** normalized by thickness.
+The longitudinal coordinate `x` runs along the laminate in the fibre
+direction; out-of-plane displacement `z(x)` is measured from the flat
+(undeformed) mid-surface. Angles are in **radians**.
+
+| Parameter | Symbol | Definition | Units |
+|-----------|--------|------------|-------|
+| `amplitude` | A | Peak crest height from the flat mid-surface to the wrinkle crest (peak-to-midplane, **not** peak-to-peak; `A = (z_max − z_min)/2` for a measured wrinkle). Must be ≥ 0. | mm |
+| `wavelength` | λ | Period of the `cos(2πx/λ)` carrier along the longitudinal x-direction (crest-to-crest distance). Must be > 0. Wavenumber `k = 2π/λ`. | mm |
+| `width` | w | Longitudinal envelope decay length about the centre. Exact meaning is profile-dependent: Gaussian length scale `exp(−(x−x₀)²/w²)`, tapered flat-top extent (`\|x−x₀\| < w/2`), or triangular half-base (`\|x−x₀\| < w`). Must be > 0. | mm |
+| `center` | x₀ | Longitudinal position of the wrinkle crest / envelope peak, in the global x coordinate. Default 0.0. | mm |
+| `phase_offset` | φ | Phase of one wrinkle relative to a reference, mapping to a geometric offset `Δx = φλ/(2π)`. Stack φ=0, convex φ=+π/2, concave φ=−π/2. | rad |
+| `decay_floor` | — | Fraction of amplitude retained at the surface plies in `graded` mode (0 = full decay to zero, 1 = no decay). Clamped to [0, 1]. | dimensionless |
+
+Peak fibre misalignment: `θ_max ≈ arctan(2πA/λ)` (exact for a pure
+cosine; dimensionless because A and λ share the mm length unit). See the
+`WrinkleProfile` class docstring in `src/wrinklefe/core/wrinkle.py` for
+the full per-profile geometric definitions.
+
 ### Tension analysis
 
 ```python

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -98,20 +98,27 @@ class WrinklePlacement:
         a :class:`WrinkleSurface3D` extends this to z(x, y).
     ply_interface : int
         Interface index between ply *i* and ply *i+1* where the wrinkle
-        is located. For a laminate with *N* plies, valid indices are
-        0 through N-2 (inclusive).
+        is located (dimensionless integer). For a laminate with *N*
+        plies, valid indices are 0 through N-2 (inclusive).
     phase_offset : float
-        Phase offset phi in radians relative to a reference wrinkle.
-        The first wrinkle in a configuration typically uses phi = 0.
+        Phase offset phi in **radians** relative to a reference wrinkle,
+        in the range that maps naturally to ``[-pi, pi]``. The first
+        wrinkle in a configuration typically uses phi = 0. Canonical
+        dual-wrinkle morphologies: phi = 0 (stack, aligned crests),
+        phi = +pi/2 (convex), phi = -pi/2 (concave). Sign convention
+        follows :data:`MORPHOLOGY_PHASES`.
 
     Notes
     -----
     The phase offset is the key parameter that determines the dual-wrinkle
-    morphology. It relates to a geometric longitudinal offset Delta_x by:
+    morphology. It is a pure angle (radians) that relates to a *geometric*
+    longitudinal offset Delta_x (mm) between wrinkle centres by:
 
-        phi = 2 * pi * Delta_x / lambda
+        phi = 2 * pi * Delta_x / lambda      (radians)
 
-    where lambda is the wrinkle wavelength (Jin et al., 2026, Eq. 4).
+    where lambda is the wrinkle wavelength (mm) (Jin et al., 2026, Eq. 4).
+    Equivalently Delta_x = phi * lambda / (2 * pi) (mm). Because both
+    Delta_x and lambda are in millimetres, phi is dimensionless.
     """
 
     profile: Union[WrinkleProfile, WrinkleSurface3D]
@@ -147,6 +154,17 @@ class WrinkleConfiguration:
     wrinkles : list of WrinklePlacement
         One or more wrinkle placements sorted by ply interface. At least
         one wrinkle is required.
+    decay_mode : str, optional
+        Through-thickness amplitude distribution. ``"default"`` (linear
+        decay from the wrinkle interface to the laminate surfaces),
+        ``"uniform"`` (full amplitude at every ply), or ``"graded"``
+        (linear decay from mid-ply to surfaces). Default ``"default"``.
+    decay_floor : float, optional
+        Dimensionless fraction in ``[0, 1]`` used only by the ``"graded"``
+        decay mode: the minimum fraction of the wrinkle amplitude retained
+        at the surface plies. ``0.0`` means full decay to zero amplitude
+        at the surfaces (pure graded); ``1.0`` means no decay (equivalent
+        to uniform). Values outside ``[0, 1]`` are clamped. Default 0.0.
 
     Raises
     ------

--- a/src/wrinklefe/core/wrinkle.py
+++ b/src/wrinklefe/core/wrinkle.py
@@ -5,6 +5,17 @@ and several alternative envelope shapes. Each profile class provides analytical
 displacement, slope, and curvature, plus convenience methods for fiber
 misalignment angle computation.
 
+Units convention
+-----------------
+Every length parameter in this module -- ``amplitude`` (*A*),
+``wavelength`` (*lambda*), ``width`` (*w*), ``center`` (*x0*), and the
+coordinate arrays *x*, *y* -- is in **millimetres (mm)**, consistent
+with ``Ply.thickness`` and ``domain_length`` used elsewhere in the
+package.  Slopes (``dz/dx``) are dimensionless, curvatures are 1/mm,
+and all fibre misalignment angles are in **radians**.  See
+:class:`WrinkleProfile` for the full geometric definitions and sign
+conventions.
+
 References
 ----------
 Jin, L. et al. (2026). Interlaminar damage analysis of dual-wrinkled composite
@@ -28,17 +39,55 @@ from scipy.optimize import minimize_scalar
 class WrinkleProfile(ABC):
     """Base class for 1-D wrinkle profiles z(x).
 
+    Geometry and units
+    ------------------
+    All length quantities use a single, consistent unit: **millimetres
+    (mm)**, the same unit as ``Ply.thickness`` and ``domain_length``
+    elsewhere in the package (e.g. the reference amplitude
+    ``A = 0.183 mm`` is exactly one ply thickness, and the README
+    default ``0.366 mm`` is two ply thicknesses).  The longitudinal
+    coordinate *x* runs along the laminate in the fibre direction; the
+    out-of-plane displacement *z(x)* is measured from the flat
+    (undeformed) mid-surface.  Angles are returned in **radians**.
+
+    Sign / convention notes:
+
+    - Profiles are *crest-referenced*: at ``x = center`` the cosine is at
+      a maximum, so ``z(center) = amplitude`` (a positive +z crest).
+    - ``amplitude`` is the peak-to-midplane height, **not** peak-to-peak.
+      For a measured wrinkle, ``A = (z_max - z_min) / 2``.
+    - The peak fibre misalignment angle scales as
+      ``theta_max ~= arctan(2*pi*A/lambda)`` (exact for a pure cosine);
+      this is dimensionless precisely because *A* and *lambda* share the
+      same length unit.
+
     Parameters
     ----------
     amplitude : float
-        Peak out-of-plane displacement *A* (mm).
+        Peak out-of-plane crest height *A* (mm), measured from the flat
+        mid-surface to the wrinkle crest (peak-to-midplane, not
+        peak-to-peak).  Must be non-negative.  Larger *A* increases the
+        fibre misalignment angle and the strength knockdown.
     wavelength : float
-        Sinusoidal wavelength *lambda* (mm).
+        Sinusoidal wavelength *lambda* (mm) along the longitudinal
+        *x*-direction: the period of the underlying ``cos(2*pi*x/lambda)``
+        carrier, i.e. the crest-to-crest distance of the wave.  Must be
+        positive.  The wavenumber is ``k = 2*pi/lambda`` (1/mm).
     width : float
-        Envelope width parameter *w* (mm).  Interpretation depends on the
-        concrete subclass (Gaussian sigma, half-extent, etc.).
+        Envelope width parameter *w* (mm) controlling how far the wrinkle
+        decays longitudinally about ``center``.  Must be positive.  Its
+        precise geometric meaning depends on the concrete subclass:
+        Gaussian ``exp(-(x-x0)^2 / w^2)`` length scale
+        (:class:`GaussianSinusoidal`, :class:`GaussianBump`), the
+        full flat-top extent of the tapered window
+        (:class:`RectangularSinusoidal`, plateau ``|x-x0| < w/2``), the
+        triangular half-base (:class:`TriangularSinusoidal`, support
+        ``|x-x0| < w``), or unused for the unbounded
+        :class:`PureSinusoidal`.
     center : float, optional
-        Longitudinal center position *x0* (mm).  Default is 0.0.
+        Longitudinal centre position *x0* (mm) of the wrinkle crest /
+        envelope peak, expressed in the same global *x* coordinate as the
+        mesh.  Default is 0.0.
     """
 
     def __init__(


### PR DESCRIPTION
Closes #5.

## Problem

Issue #5 reports that the README gives numeric values for `amplitude`, `wavelength`, and `width` but never states their units, coordinate directions, or geometric interpretation (mm vs. normalized thickness, peak-to-midplane vs. peak-to-peak, etc.), so users can't reproduce results or configure realistic wrinkles.

## Unit convention confirmed (from code, not guessed)

**All length parameters are in millimetres (mm), consistent throughout.** Evidence traced in the codebase:

- `core/laminate.py`: `Ply.thickness` documented "in mm", example `Ply(mat, angle=45.0, thickness=0.183)`.
- `analysis.py:65`: `_A_REF = 0.183  # Reference amplitude (1 ply thickness, mm)`; default `amplitude=0.366` = exactly 2 ply thicknesses (2 x 0.183 mm). The README example `ply_thickness=0.152` is likewise mm.
- `analysis.py:170-178`: amplitude/wavelength/width/domain_length/ply_thickness all annotated `[mm]`.
- The closed form `WrinkleProfile.max_angle_approx() = arctan(2*pi*A/lambda)` is dimensionless only if A and lambda share a length unit — consistent with both being mm.

Lengths are **not** normalized by ply thickness. Slopes are dimensionless, curvature is 1/mm, all misalignment angles are radians. Profiles are crest-referenced (`z(center) = amplitude`, a +z crest); amplitude is peak-to-midplane, not peak-to-peak.

## Changes (doc-only, no runtime behavior changed)

- `src/wrinklefe/core/wrinkle.py`: module docstring "Units convention" block; expanded `WrinkleProfile` class docstring with a "Geometry and units" section and precise per-parameter definitions/units/sign conventions for **amplitude (A)**, **wavelength (λ)**, **width (w)** (incl. profile-specific meaning), **center (x₀)**, plus the `θ_max ≈ arctan(2πA/λ)` relation.
- `src/wrinklefe/core/morphology.py`: clarified `WrinklePlacement.phase_offset` (radians, sign convention, Δx = φλ/2π relation) and documented `decay_mode` / `decay_floor` in the `WrinkleConfiguration` class docstring Parameters.
- `README.md`: new "Wrinkle geometry parameters" subsection after the Quick Start example with a compact Parameter | Symbol | Definition | Units table.

## Intentionally not touched

Per the in-flight-file constraint, `src/wrinklefe/analysis.py` (open PR #147, `AnalysisConfig.__post_init__` validation) and `app.py` were **not** modified to avoid merge conflicts. `AnalysisConfig` field docs are intentionally deferred; the equivalent definitions live in the `WrinkleProfile` docstring and the README instead.

## Verification

- `python -c "import ast; ast.parse(...)"` on both edited modules: OK.
- `pytest -q -k "wrinkle or profile"` (with `PYTHONPATH=src` due to editable-install pointing at a different worktree): **63 passed**.
- 3 doctest failures under `--doctest-modules` (`profile` undefined in `dual_wrinkle`/`from_morphology_name` examples) were verified to **pre-exist identically on `main`** via `git stash`; they are unrelated to this change and not run by the project's pytest config. No new doctest examples were added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_