### PR TITLE
Fix fiber_angles_at_nodes n_plies desync vs apply_to_nodes (closes #146)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -806,7 +806,12 @@ class WrinkleMesh:
         """
         if self.wrinkle_config is None:
             return np.zeros(nodes.shape[0], dtype=float)
-        return self.wrinkle_config.fiber_angles_at_nodes(nodes, ply_ids_per_node)
+        # Pass the authoritative laminate ply count -- the same value
+        # given to apply_to_nodes -- so the displacement and fibre-angle
+        # decay fields share an identical through-thickness basis (#146).
+        return self.wrinkle_config.fiber_angles_at_nodes(
+            nodes, ply_ids_per_node, self.laminate.n_plies
+        )
 
     # =======================================================================
     # Export methods

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -600,6 +600,7 @@ class WrinkleConfiguration:
         self,
         nodes: np.ndarray,
         ply_ids: np.ndarray,
+        n_plies: int | None = None,
     ) -> np.ndarray:
         """Compute local fiber misalignment angle at each node.
 
@@ -618,6 +619,15 @@ class WrinkleConfiguration:
             Shape (N, 3) array of node coordinates [x, y, z].
         ply_ids : np.ndarray
             Shape (N,) integer array of ply indices for each node.
+        n_plies : int, optional
+            Total number of plies in the laminate. This is the same
+            authoritative count that :meth:`apply_to_nodes` takes, and
+            it sets the through-thickness decay basis. It MUST be passed
+            (matching the value given to :meth:`apply_to_nodes`) whenever
+            ``ply_ids`` does not span the full laminate, otherwise the
+            displacement and angle decay fields desynchronise (issue
+            #146). When omitted it falls back to ``ply_ids.max() + 1``,
+            which is only correct when ``ply_ids`` reaches the top ply.
 
         Returns
         -------
@@ -639,7 +649,12 @@ class WrinkleConfiguration:
         the aggregate misalignment.
         """
         n_nodes = len(nodes)
-        n_plies = int(ply_ids.max()) + 1 if len(ply_ids) > 0 else 1
+        if n_plies is None:
+            # Backward-compatible fallback: only correct when ply_ids
+            # spans the full laminate. Callers with a partial ply_ids
+            # array must pass the explicit n_plies (the same value given
+            # to apply_to_nodes) so both decay fields stay synced (#146).
+            n_plies = int(ply_ids.max()) + 1 if len(ply_ids) > 0 else 1
         angle_sq = np.zeros(n_nodes, dtype=np.float64)
 
         for wrinkle in self.wrinkles:

--- a/tests/test_morphology_apply_nodes.py
+++ b/tests/test_morphology_apply_nodes.py
@@ -507,17 +507,6 @@ class TestPhaseVsNamedMorphology:
 # KNOWN BUG (issue #146): partial ply_ids desyncs the two decay fields
 # ----------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Issue #146: fiber_angles_at_nodes infers n_plies = ply_ids.max()+1 "
-        "while apply_to_nodes takes n_plies explicitly. With a partial "
-        "ply_ids array (top ply absent) the displacement and angle decay "
-        "fields silently desynchronise. TEST-ONLY scope: pinned as a "
-        "strict xfail until #146 is fixed (do not assert the buggy value "
-        "as correct)."
-    ),
-)
 def test_partial_ply_ids_decay_stays_synced():
     prof = GaussianSinusoidal(
         amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
@@ -532,7 +521,7 @@ def test_partial_ply_ids_decay_stays_synced():
     nodes = np.array([[x, 0.0, 0.0] for _ in ply], float)
 
     dz = (cfg.apply_to_nodes(nodes, ply, n_plies=8) - nodes)[:, 2]
-    ang = cfg.fiber_angles_at_nodes(nodes, ply)
+    ang = cfg.fiber_angles_at_nodes(nodes, ply, n_plies=8)
 
     decay_from_disp = dz / prof_val
     decay_from_angle = ang / ang_base


### PR DESCRIPTION
## Root cause

`WrinkleConfiguration.apply_to_nodes` takes `n_plies` as an explicit argument, but `fiber_angles_at_nodes` inferred it as `int(ply_ids.max()) + 1`. Both feed the same `_ply_decay(p, k, n_plies)` (and the graded `p_mid = (n_plies-1)/2`). When the caller passes a `ply_ids` array that does not span the full laminate (mesh slice / region iteration / interior band / single-ply subset), the two methods compute the through-thickness decay against **different** `n_plies`, so the displacement field and the fibre-angle field silently desynchronise (the issue's repro: ~0.667 decay mismatch at an interior ply with the top ply absent -> quietly wrong knockdown). The real production caller `WrinkleMesh._compute_fiber_angles` (mesh.py) called `fiber_angles_at_nodes` **without** `n_plies` even though it already passes `self.laminate.n_plies` to `apply_to_nodes` one block earlier; full meshes happened to mask it because ply_ids reach the top ply.

## Minimal fix

- **`morphology.py` (`fiber_angles_at_nodes`)**: added an explicit optional `n_plies: int | None = None` parameter mirroring `apply_to_nodes`. When provided it is the shared, authoritative decay basis for `_ply_decay` / the graded formula. When omitted it falls back to the old `ply_ids.max()+1` inference, which is only correct when `ply_ids` spans the laminate -- backward compatible for full-array callers (e.g. the existing `TestGradedDecayParity` sweep). Docstring documents the requirement. No public signature change beyond the new optional kwarg; `_ply_decay` and `apply_to_nodes` untouched.
- **`mesh.py` (`_compute_fiber_angles`)**: now passes `self.laminate.n_plies` -- the exact value already handed to `apply_to_nodes` -- so the displacement and fibre-angle decay fields share an identical through-thickness basis (root-cause fix for the production path, not a downstream paper-over).

## xfail marker removed

Removed the `@pytest.mark.xfail(strict=True, reason="Issue #146 ...")` decorator from `test_partial_ply_ids_decay_stays_synced` in `tests/test_morphology_apply_nodes.py`. The test now threads the authoritative `n_plies=8` into the `fiber_angles_at_nodes` call (the direct counterpart of the fixed API, exactly as `apply_to_nodes` is already called on the line above); the `assert_allclose` assertion is unchanged and now genuinely verifies the two decay fields stay synced on a partial `ply_ids` array. It PASSES (not xpass, not xfail). No other test or marker touched. Confirmed via grep: no other xfail/xpass anywhere references #146 -- this pin was the only one.

## Full suite

`828 passed, 2 failed` (276 s). The 2 failures are `tests/test_cli.py::test_analyze_contracted_layup_matches_shared_parser` and `::test_analyze_explicit_comma_list_still_works`. **These are pre-existing on `main` and unrelated to #146**: an interaction between #150 (CLI contracted-layup -> 8-ply laminate) and #147 (`AnalysisConfig.__post_init__` rejecting the default interfaces 11/12 for <13-ply layups: `AnalysisConfig.interface_1 must be in [0, 4) ... got 11`). Verified by stashing the worktree's unrelated in-progress `test_cli.py` edits and re-running against the pristine `origin/main` version -- they still fail, with no involvement of morphology/mesh. Kept out of scope; this PR's diff is 3 files (morphology.py, mesh.py, test_morphology_apply_nodes.py), +23/-14. The full morphology suite (`test_morphology_apply_nodes.py` + `test_morphology.py`) is 74 passed.

## Downstream effects

None negative. `mesh.py` is the only production caller; it now passes the authoritative count it already had, eliminating the latent desync. No caller relied on the old `ply_ids.max()+1` behaviour for partial arrays. Ruff-clean on all changed lines.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_