### PR TITLE
Fix-forward: valid interfaces in CLI layup tests (#147 + #150 interaction)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ the configs/kwargs the CLI hands them.
 
 from __future__ import annotations
 
+import functools
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -43,6 +44,30 @@ def _stub_analysis_run():
     return captured, patch(
         "wrinklefe.analysis.WrinkleAnalysis.run", new=fake_run
     )
+
+
+def _valid_interfaces(interface_1: int, interface_2: int):
+    """Patch ``AnalysisConfig`` so the CLI builds it with valid interfaces.
+
+    ``_cmd_analyze`` does not expose ``--interface-1/--interface-2`` and
+    always relies on the dataclass defaults (11/12), which are only valid
+    for layups with >=13 plies. Tests that exercise *small* layups purely
+    to verify layup parsing must therefore supply an interface pair that
+    is valid for that ply count; otherwise ``AnalysisConfig.__post_init__``
+    (added in #147) rejects the config before parsing can be asserted.
+
+    This binds valid interface defaults via ``functools.partial`` so the
+    test stays test-only and does not alter CLI defaults or #147's
+    validation.
+    """
+    from wrinklefe import analysis as _analysis
+
+    bound = functools.partial(
+        _analysis.AnalysisConfig,
+        interface_1=interface_1,
+        interface_2=interface_2,
+    )
+    return patch("wrinklefe.analysis.AnalysisConfig", new=bound)
 
 
 # --------------------------------------------------------------------------- #
@@ -336,7 +361,9 @@ def test_analyze_contracted_layup_matches_shared_parser():
     from wrinklefe.core.layup import parse_layup
 
     captured, patcher = _stub_analysis_run()
-    with patcher:
+    # "[0/±45/90]s" expands to 8 plies; the CLI's default interfaces
+    # (11/12) are out of range for it, so supply a valid interior pair.
+    with patcher, _valid_interfaces(3, 4):
         cli_main([
             "analyze",
             "--layup", "[0/±45/90]s",
@@ -349,7 +376,9 @@ def test_analyze_contracted_layup_matches_shared_parser():
 def test_analyze_explicit_comma_list_still_works():
     """Backwards compatibility: the original comma-separated form."""
     captured, patcher = _stub_analysis_run()
-    with patcher:
+    # This layup has 4 plies; the CLI's default interfaces (11/12) are
+    # out of range for it, so supply an interface pair valid at 4 plies.
+    with patcher, _valid_interfaces(1, 2):
         cli_main([
             "analyze",
             "--angles", "0, 45, -45, 90",


### PR DESCRIPTION
## Root cause: #147 ↔ #150 parallel-merge interaction

Two PRs were each green in isolation but conflict combined, breaking `main`:

- **#147** added `AnalysisConfig.__post_init__` validation requiring `interface_1`/`interface_2` to be integers in `[0, n_plies)` where `n_plies = len(angles)`.
- **#150** added CLI layup-parsing tests in `tests/test_cli.py`. Two of them — `test_analyze_explicit_comma_list_still_works` (4-ply layup) and `test_analyze_contracted_layup_matches_shared_parser` (8-ply layup) — invoke `wrinklefe analyze` with small layups but rely on the CLI's default `interface_1=11`/`interface_2=12` (sized for the 24-ply default layup). Post-#147, validation correctly rejects `interface_1=11` for a 4- or 8-ply layup:
  - `ValueError: AnalysisConfig.interface_1 must be in [0, 4) ... got 11`
  - `ValueError: AnalysisConfig.interface_1 must be in [0, 8) ... got 11`

## The fix (test-only, minimal)

These two tests exist to verify *layup parsing*, not interface defaults — they were constructing an invalid layup/interface combination. The `analyze` subcommand exposes **no** `--interface-1`/`--interface-2` flags and `_cmd_analyze` never overrides the dataclass defaults, so the fix supplies valid interface defaults at config-construction time via a small test helper:

- Added `_valid_interfaces(interface_1, interface_2)` helper that patches `wrinklefe.analysis.AnalysisConfig` with `functools.partial` to bind valid interface defaults for the duration of the call.
- `test_analyze_contracted_layup_matches_shared_parser` (8 plies) now uses interfaces `3, 4`.
- `test_analyze_explicit_comma_list_still_works` (4 plies) now uses interfaces `1, 2`.
- Each test's original layup-parsing assertion is unchanged.

#147's validation and the CLI's default behavior are **not** modified. Diff is limited to `tests/test_cli.py` (+31/-2). No other tests touched.

## Verification

- `pytest tests/test_cli.py`: 23 passed.
- Full suite: **829 passed, 1 xfailed, 0 failed** (the 1 xfail is pre-existing and untouched).

## Follow-up (out of scope here)

The underlying usability gap is real: the CLI's default `interface_1=11`/`interface_2=12` are invalid for any layup with <13 plies, so e.g. `wrinklefe analyze --layup '0,90,0,90'` crashes unless interfaces can be overridden (and currently the CLI offers no flag to do so). Tracked in #154, which suggests deriving sensible interface defaults from the resolved ply count and/or adding `--interface-1`/`--interface-2` flags. Intentionally not implemented in this fix-forward.

Refs #147, #150. See #154 for the CLI default-interface follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWRZdCxyzynsuw4DDKeSbH)_