### PR TITLE
Analysis validation summary export (PDF/MD/JSON) — supersedes the NCR form

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,11 @@ from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
 from wrinklefe.core.wrinkle import GaussianSinusoidal
-from wrinklefe.io.export import build_ncr, render_ncr_markdown, render_ncr_pdf
+from wrinklefe.io.export import (
+    build_analysis_summary,
+    render_summary_markdown,
+    render_summary_pdf,
+)
 
 import streamlit_viz
 
@@ -1427,16 +1431,18 @@ with tab_export:
         )
 
         # ------------------------------------------------------------------
-        # Nonconformance Report (NCR) — MRB decision-support tool
+        # Analysis validation summary — NCR attachment
         # ------------------------------------------------------------------
         st.divider()
-        st.subheader("Create a Nonconformance Report (NCR)")
+        st.subheader("Analysis validation summary (NCR attachment)")
         st.caption(
-            "For a field engineer to raise an NCR on this wrinkle. WrinkleFE "
-            "produces a structured analysis, cites the criteria, and "
-            "recommends a disposition path. It does **not** issue a final "
-            "disposition — a qualified Material Review Board reviews, may "
-            "modify, and approves the outcome."
+            "A concise engineering validation of this wrinkle, intended to "
+            "be attached to a Nonconformance Report. It carries the "
+            "geometry, laminate, WrinkleFE analysis, cited criteria, and a "
+            "**non-binding** recommended disposition — no part/serial or "
+            "MRB sign-off (that lives on the NCR itself). It does not issue "
+            "a final disposition; a qualified Material Review Board reviews, "
+            "may modify, and approves the outcome."
         )
 
         _cfg = dict(st.session_state["cfg_payload"])
@@ -1444,52 +1450,22 @@ with tab_export:
         _angles = list(_cfg.get("angles_tuple", ()))
         _res = st.session_state["results"]
 
-        with st.form("ncr_form"):
-            nc1, nc2 = st.columns(2)
-            with nc1:
-                ncr_number = st.text_input("NCR number", placeholder="NCR-…")
-                part_number = st.text_input("Part number")
-                serial_lot = st.text_input("Serial / lot number")
-                program = st.text_input("Program / project")
-                originator = st.text_input("Originating engineer")
-            with nc2:
-                part_name = st.text_input("Part name / description")
-                work_order = st.text_input("Work order / job number")
-                quantity = st.text_input("Quantity affected", value="1")
-                defect_location = st.text_input("Defect location on part")
-                detection_method = st.selectbox(
-                    "Detection method",
-                    [
-                        "Visual",
-                        "Ultrasonic (UT)",
-                        "Radiographic / CT",
-                        "Cross-section / metallography",
-                        "Other",
-                    ],
-                )
-            drawing_spec = st.text_input(
-                "Violated drawing / specification requirement"
+        with st.form("summary_form"):
+            summary_reference = st.text_input(
+                "Reference (optional)",
+                placeholder="e.g. NCR no. or part reference",
             )
-            remarks = st.text_area("Originator remarks", height=80)
-            ncr_submit = st.form_submit_button("Generate NCR")
+            summary_prepared_by = st.text_input("Prepared by (optional)")
+            summary_notes = st.text_area(
+                "Engineering notes (optional)", height=80
+            )
+            summary_submit = st.form_submit_button(
+                "Generate analysis summary"
+            )
 
-        if ncr_submit:
+        if summary_submit:
             _fe = _res.get("fe")
-            ncr = build_ncr(
-                metadata={
-                    "ncr_number": ncr_number,
-                    "originator": originator,
-                    "part_number": part_number,
-                    "part_name": part_name,
-                    "serial_lot": serial_lot,
-                    "work_order": work_order,
-                    "program": program,
-                    "quantity": quantity,
-                    "defect_location": defect_location,
-                    "detection_method": detection_method,
-                    "drawing_spec": drawing_spec,
-                    "remarks": remarks,
-                },
+            summary = build_analysis_summary(
                 defect={
                     "amplitude_mm": _cfg.get("amplitude"),
                     "wavelength_mm": _cfg.get("wavelength"),
@@ -1526,37 +1502,46 @@ with tab_export:
                         else None
                     ),
                 },
+                reference=summary_reference,
+                prepared_by=summary_prepared_by,
+                notes=summary_notes,
+                tool_version=_wrinklefe_version,
             )
 
-            _dr = ncr["disposition_recommendation"]
+            _dr = summary["disposition_recommendation"]
             st.success(
                 f"Severity: **{_dr['severity']}** · Recommended path "
                 f"(non-binding): {_dr['recommended_path']}"
             )
-            ncr_md = render_ncr_markdown(ncr)
-            with st.expander("Preview NCR", expanded=True):
-                st.markdown(ncr_md)
+            summary_md = render_summary_markdown(summary)
+            with st.expander("Preview summary", expanded=True):
+                st.markdown(summary_md)
 
-            _fn_base = (ncr_number or "ncr").strip().replace(" ", "_") or "ncr"
+            _fn_base = (
+                (summary_reference or "wrinkle_analysis_summary")
+                .strip()
+                .replace(" ", "_")
+                or "wrinkle_analysis_summary"
+            )
             dl1, dl2, dl3 = st.columns(3)
             with dl1:
                 st.download_button(
-                    "Download NCR (PDF)",
-                    data=render_ncr_pdf(ncr),
+                    "Download summary (PDF)",
+                    data=render_summary_pdf(summary),
                     file_name=f"{_fn_base}.pdf",
                     mime="application/pdf",
                 )
             with dl2:
                 st.download_button(
-                    "Download NCR (Markdown)",
-                    data=ncr_md.encode(),
+                    "Download summary (Markdown)",
+                    data=summary_md.encode(),
                     file_name=f"{_fn_base}.md",
                     mime="text/markdown",
                 )
             with dl3:
                 st.download_button(
-                    "Download NCR (JSON)",
-                    data=json.dumps(ncr, indent=2).encode(),
+                    "Download summary (JSON)",
+                    data=json.dumps(summary, indent=2).encode(),
                     file_name=f"{_fn_base}.json",
                     mime="application/json",
                 )

--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
 from wrinklefe.core.wrinkle import GaussianSinusoidal
-from wrinklefe.io.export import build_ncr, render_ncr_markdown
+from wrinklefe.io.export import build_ncr, render_ncr_markdown, render_ncr_pdf
 
 import streamlit_viz
 
@@ -1538,15 +1538,22 @@ with tab_export:
                 st.markdown(ncr_md)
 
             _fn_base = (ncr_number or "ncr").strip().replace(" ", "_") or "ncr"
-            dl1, dl2 = st.columns(2)
+            dl1, dl2, dl3 = st.columns(3)
             with dl1:
+                st.download_button(
+                    "Download NCR (PDF)",
+                    data=render_ncr_pdf(ncr),
+                    file_name=f"{_fn_base}.pdf",
+                    mime="application/pdf",
+                )
+            with dl2:
                 st.download_button(
                     "Download NCR (Markdown)",
                     data=ncr_md.encode(),
                     file_name=f"{_fn_base}.md",
                     mime="text/markdown",
                 )
-            with dl2:
+            with dl3:
                 st.download_button(
                     "Download NCR (JSON)",
                     data=json.dumps(ncr, indent=2).encode(),

--- a/src/wrinklefe/io/__init__.py
+++ b/src/wrinklefe/io/__init__.py
@@ -5,31 +5,31 @@ Public API
 .. autofunction:: export_results_json
 .. autofunction:: export_abaqus_inp
 .. autofunction:: export_vtk
-.. autofunction:: build_ncr
+.. autofunction:: build_analysis_summary
 .. autofunction:: recommend_disposition
-.. autofunction:: render_ncr_markdown
-.. autofunction:: render_ncr_pdf
-.. autofunction:: export_ncr
+.. autofunction:: render_summary_markdown
+.. autofunction:: render_summary_pdf
+.. autofunction:: export_summary
 """
 
 from wrinklefe.io.export import (
-    build_ncr,
+    build_analysis_summary,
     export_abaqus_inp,
-    export_ncr,
     export_results_json,
+    export_summary,
     export_vtk,
     recommend_disposition,
-    render_ncr_markdown,
-    render_ncr_pdf,
+    render_summary_markdown,
+    render_summary_pdf,
 )
 
 __all__ = [
     "export_results_json",
     "export_abaqus_inp",
     "export_vtk",
-    "build_ncr",
+    "build_analysis_summary",
     "recommend_disposition",
-    "render_ncr_markdown",
-    "render_ncr_pdf",
-    "export_ncr",
+    "render_summary_markdown",
+    "render_summary_pdf",
+    "export_summary",
 ]

--- a/src/wrinklefe/io/__init__.py
+++ b/src/wrinklefe/io/__init__.py
@@ -8,6 +8,7 @@ Public API
 .. autofunction:: build_ncr
 .. autofunction:: recommend_disposition
 .. autofunction:: render_ncr_markdown
+.. autofunction:: render_ncr_pdf
 .. autofunction:: export_ncr
 """
 
@@ -19,6 +20,7 @@ from wrinklefe.io.export import (
     export_vtk,
     recommend_disposition,
     render_ncr_markdown,
+    render_ncr_pdf,
 )
 
 __all__ = [
@@ -28,5 +30,6 @@ __all__ = [
     "build_ncr",
     "recommend_disposition",
     "render_ncr_markdown",
+    "render_ncr_pdf",
     "export_ncr",
 ]

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -810,6 +810,193 @@ def render_ncr_markdown(ncr: dict) -> str:
     return "\n".join(lines)
 
 
+# A4 portrait page geometry (inches) and 1-inch margins.
+_PDF_PAGE_W = 8.27
+_PDF_PAGE_H = 11.69
+_PDF_MARGIN = 0.9
+# Per-line style: fontsize (pt), bold, italic, x-indent (in), gap-before (in).
+_PDF_STYLES = {
+    "title": (17.0, True, False, 0.0, 0.0),
+    "h2": (12.5, True, False, 0.0, 0.22),
+    "subhead": (10.0, True, False, 0.0, 0.10),
+    "bullet": (9.5, False, False, 0.18, 0.0),
+    "quote": (9.5, False, True, 0.22, 0.06),
+    "table": (8.5, False, False, 0.10, 0.0),
+    "rule": (9.5, False, False, 0.0, 0.06),
+    "normal": (9.5, False, False, 0.0, 0.0),
+    "disclaimer": (8.0, False, True, 0.0, 0.10),
+}
+
+
+def _classify_ncr_line(line: str) -> tuple[str, str]:
+    """Map one Markdown line to a (style-kind, plain-text) pair."""
+    raw = line.rstrip()
+    stripped = raw.strip()
+    if stripped == "":
+        return "blank", ""
+    if stripped.startswith("# "):
+        return "title", stripped[2:].strip()
+    if stripped.startswith("## "):
+        return "h2", stripped[3:].strip()
+    if stripped.startswith(("---", "***", "___")) and set(
+        stripped
+    ) <= {"-", "*", "_"}:
+        return "rule", ""
+    if stripped.startswith(">"):
+        return "quote", _strip_md_inline(stripped[1:].strip())
+    if stripped.startswith("|"):
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        non_empty = [c for c in cells if c]
+        if non_empty and all(set(c) <= {"-", ":"} for c in non_empty):
+            return "rule", ""
+        widths = (26, 16, 16, 12)
+        out = []
+        for i, c in enumerate(cells):
+            w = widths[i] if i < len(widths) else 14
+            out.append(c.ljust(w))
+        return "table", " ".join(out).rstrip()
+    if stripped.startswith("- "):
+        return "bullet", _strip_md_inline(stripped[2:].strip())
+    if (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and len(stripped) > 2
+    ):
+        return "disclaimer", _strip_md_inline(stripped)
+    if (
+        stripped.startswith("**")
+        and stripped.endswith("**")
+        and "**" not in stripped[2:-2]
+    ):
+        return "subhead", _strip_md_inline(stripped)
+    return "normal", _strip_md_inline(stripped)
+
+
+def _strip_md_inline(text: str) -> str:
+    """Drop inline Markdown emphasis markers for flat PDF text."""
+    return (
+        text.replace("**", "")
+        .replace("`", "")
+        .replace("__", "")
+        .strip("_")
+    )
+
+
+def render_ncr_pdf(ncr: dict) -> bytes:
+    """Render an NCR (from :func:`build_ncr`) as a paginated PDF.
+
+    Uses Matplotlib's PDF backend (already a project dependency, headless-
+    safe) so no extra packages are required. The structured Markdown form
+    is laid out in a monospaced font with automatic word-wrap and
+    pagination.
+
+    Parameters
+    ----------
+    ncr : dict
+        A report produced by :func:`build_ncr`.
+
+    Returns
+    -------
+    bytes
+        The PDF document.
+    """
+    import io as _io
+    import textwrap
+
+    from matplotlib.backends.backend_pdf import PdfPages
+    from matplotlib.figure import Figure
+    from matplotlib.lines import Line2D
+
+    lines = render_ncr_markdown(ncr).split("\n")
+    usable_w = _PDF_PAGE_W - 2 * _PDF_MARGIN
+    usable_h = _PDF_PAGE_H - 2 * _PDF_MARGIN
+
+    # Pre-compute wrapped, styled physical lines: (kind, text, fs, bold,
+    # italic, indent_in, gap_in, line_h_in).
+    items: list[tuple] = []
+    for line in lines:
+        kind, text = _classify_ncr_line(line)
+        if kind == "blank":
+            items.append(("blank", "", 9.5, False, False, 0.0, 0.0, 0.11))
+            continue
+        fs, bold, italic, indent, gap = _PDF_STYLES[kind]
+        line_h = fs / 72.0 * 1.55
+        if kind == "rule":
+            items.append(
+                ("rule", "", fs, False, False, 0.0, gap, line_h)
+            )
+            continue
+        char_w = fs * 0.60 / 72.0  # monospace advance, inches
+        max_chars = max(8, int((usable_w - indent) / char_w))
+        if kind == "table":
+            wrapped = [text]  # keep table rows intact (monospaced)
+        else:
+            wrapped = textwrap.wrap(
+                text, width=max_chars, break_long_words=True
+            ) or [""]
+        for j, seg in enumerate(wrapped):
+            items.append(
+                (
+                    kind,
+                    seg,
+                    fs,
+                    bold,
+                    italic,
+                    indent,
+                    gap if j == 0 else 0.0,
+                    line_h,
+                )
+            )
+
+    buf = _io.BytesIO()
+    fig: Optional[Any] = None
+    cursor = 0.0  # inches consumed from the top of the usable area
+
+    def _new_page(pdf: Any) -> Any:
+        f = Figure(figsize=(_PDF_PAGE_W, _PDF_PAGE_H))
+        return f
+
+    with PdfPages(buf) as pdf:
+        fig = _new_page(pdf)
+        for kind, text, fs, bold, italic, indent, gap, line_h in items:
+            need = gap + line_h
+            if cursor + need > usable_h:
+                pdf.savefig(fig)
+                fig = _new_page(pdf)
+                cursor = 0.0
+            cursor += gap
+            y = 1.0 - (_PDF_MARGIN + cursor + line_h * 0.5) / _PDF_PAGE_H
+            if kind == "rule":
+                xa = _PDF_MARGIN / _PDF_PAGE_W
+                xb = (_PDF_PAGE_W - _PDF_MARGIN) / _PDF_PAGE_W
+                fig.add_artist(
+                    Line2D(
+                        [xa, xb],
+                        [y, y],
+                        transform=fig.transFigure,
+                        color="0.4",
+                        linewidth=0.6,
+                    )
+                )
+            elif text:
+                x = (_PDF_MARGIN + indent) / _PDF_PAGE_W
+                fig.text(
+                    x,
+                    y,
+                    text,
+                    fontsize=fs,
+                    fontweight="bold" if bold else "normal",
+                    fontstyle="italic" if italic else "normal",
+                    family="monospace",
+                    va="center",
+                    ha="left",
+                )
+            cursor += line_h
+        pdf.savefig(fig)
+
+    return buf.getvalue()
+
+
 def export_ncr(
     ncr: dict,
     filepath: Union[str, Path],
@@ -824,9 +1011,10 @@ def export_ncr(
         The structured NCR.
     filepath : str or Path
         Output path.
-    fmt : {'md', 'json'}
+    fmt : {'md', 'json', 'pdf'}
         ``'md'`` writes the rendered Markdown form (default); ``'json'``
-        writes the structured report.
+        writes the structured report; ``'pdf'`` writes a paginated PDF
+        of the NCR form.
     """
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -834,5 +1022,9 @@ def export_ncr(
         filepath.write_text(json.dumps(ncr, indent=2), encoding="utf-8")
     elif fmt == "md":
         filepath.write_text(render_ncr_markdown(ncr), encoding="utf-8")
+    elif fmt == "pdf":
+        filepath.write_bytes(render_ncr_pdf(ncr))
     else:
-        raise ValueError(f"Unsupported fmt {fmt!r}; use 'md' or 'json'.")
+        raise ValueError(
+            f"Unsupported fmt {fmt!r}; use 'md', 'json', or 'pdf'."
+        )

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -329,23 +329,26 @@ def export_vtk(
 
 
 # ====================================================================== #
-# Nonconformance Report (NCR) — MRB decision-support export
+# Wrinkle analysis validation summary — NCR attachment
 # ====================================================================== #
 #
 # These helpers turn a WrinkleFE analysis of an out-of-plane fibre wrinkle
-# into a structured Nonconformance Report for a field engineer to raise and
-# for a Material Review Board (MRB) to review.
+# into a concise engineering validation summary that an engineer can
+# attach to a Nonconformance Report (NCR).  It deliberately carries no
+# QMS/admin fields (NCR number, part/serial, work order, MRB sign-off):
+# that paperwork lives on the NCR itself.  This artefact is the technical
+# validation only.
 #
 # Scope/authority note: the recommendation produced here is *decision
 # support only*.  It does not constitute a final disposition.  Severity
 # thresholds below are generic engineering guidance and MUST be superseded
 # by the program-specific allowables, drawing requirements, and process
-# specifications that the MRB applies.  The qualified MRB reviews, may
-# modify, and approves the final disposition.
+# specifications that the Material Review Board (MRB) applies.  The
+# qualified MRB reviews, may modify, and approves the final disposition.
 
 # Residual-strength fraction (= analytical knockdown) and damage-index
 # severity bands.  The worst (lowest) tier from either metric governs.
-_NCR_SEVERITY_BANDS = (
+_SEVERITY_BANDS = (
     # (label, min_knockdown, max_damage_index, recommended_path, approvals)
     (
         "Negligible",
@@ -430,22 +433,22 @@ def recommend_disposition(
 
     # Pick the worst (latest) band each metric falls into, then take the
     # more conservative of the two.
-    by_knockdown = len(_NCR_SEVERITY_BANDS) - 1
-    for idx, (_, min_kd, _, _, _) in enumerate(_NCR_SEVERITY_BANDS):
+    by_knockdown = len(_SEVERITY_BANDS) - 1
+    for idx, (_, min_kd, _, _, _) in enumerate(_SEVERITY_BANDS):
         if kd >= min_kd:
             by_knockdown = idx
             break
 
     by_damage = 0
-    for idx, (_, _, max_di, _, _) in enumerate(_NCR_SEVERITY_BANDS):
+    for idx, (_, _, max_di, _, _) in enumerate(_SEVERITY_BANDS):
         if di < max_di:
             by_damage = idx
             break
     else:
-        by_damage = len(_NCR_SEVERITY_BANDS) - 1
+        by_damage = len(_SEVERITY_BANDS) - 1
 
     band_idx = max(by_knockdown, by_damage)
-    label, _, _, path, approvals = _NCR_SEVERITY_BANDS[band_idx]
+    label, _, _, path, approvals = _SEVERITY_BANDS[band_idx]
 
     if by_knockdown >= by_damage:
         governed_by = "residual strength (analytical knockdown)"
@@ -484,52 +487,58 @@ def recommend_disposition(
     }
 
 
-def build_ncr(
+def build_analysis_summary(
     *,
-    metadata: Optional[dict] = None,
     defect: dict,
     engineering: dict,
+    reference: Optional[str] = None,
+    prepared_by: Optional[str] = None,
+    notes: Optional[str] = None,
+    tool_version: Optional[str] = None,
 ) -> dict:
-    """Assemble a structured Nonconformance Report (NCR) for an MRB.
+    """Assemble a wrinkle-analysis validation summary for an NCR.
 
-    Combines field-engineer metadata, the as-found wrinkle defect, and
-    the WrinkleFE engineering analysis into a single structured report,
-    including the cited criteria and a *recommended* (non-binding)
-    disposition path for the Material Review Board.
+    Produces the *technical validation only* — the wrinkle geometry, the
+    affected laminate, the WrinkleFE engineering analysis, the cited
+    criteria, and a *recommended* (non-binding) disposition path. It
+    carries no QMS/admin fields (NCR number, part/serial, work order, MRB
+    sign-off): that paperwork lives on the NCR this is attached to.
 
     Parameters
     ----------
-    metadata : dict, optional
-        Field-engineer / QMS fields.  Recognised keys (all optional):
-        ``ncr_number``, ``originator``, ``date``, ``part_number``,
-        ``part_name``, ``serial_lot``, ``work_order``, ``program``,
-        ``quantity``, ``defect_location``, ``detection_method``,
-        ``drawing_spec``, ``remarks``.
     defect : dict
-        As-found wrinkle + laminate.  Recognised keys: ``amplitude_mm``,
-        ``wavelength_mm``, ``width_mm``, ``morphology``, ``loading``,
-        ``ply_thickness_mm``, ``n_plies``, ``layup``, ``material_name``.
+        As-analyzed wrinkle + laminate.  Recognised keys:
+        ``amplitude_mm``, ``wavelength_mm``, ``width_mm``, ``morphology``,
+        ``loading``, ``ply_thickness_mm``, ``n_plies``, ``layup``,
+        ``material_name``.
     engineering : dict
         WrinkleFE results.  Recognised keys: ``analytical_knockdown``,
         ``analytical_strength_MPa``, ``damage_index``, ``max_angle_deg``,
         ``effective_angle_deg``, ``morphology_factor``, and an optional
         ``fe`` sub-dict (``modulus_retention``, ``retention_factors``,
         ``critical_criterion``, ``critical_mode``, ``critical_ply``).
+    reference : str, optional
+        Free-text label tying this attachment to its NCR (e.g. the NCR
+        number or part reference).  Optional by design.
+    prepared_by : str, optional
+        Who ran the analysis.
+    notes : str, optional
+        Free-text engineering notes.
+    tool_version : str, optional
+        WrinkleFE version string, recorded for traceability.
 
     Returns
     -------
     dict
-        The structured NCR.  JSON-serialisable.
+        The structured validation summary.  JSON-serialisable.
     """
-    meta = dict(metadata or {})
 
-    def _m(key: str, default: str = "(to be assigned)") -> Any:
-        val = meta.get(key)
+    def _clean(val: Optional[str], default: str) -> str:
         if val is None or (isinstance(val, str) and not val.strip()):
             return default
-        return val
+        return str(val).strip()
 
-    date = _m("date", datetime.now(timezone.utc).date().isoformat())
+    date = datetime.now(timezone.utc).date().isoformat()
 
     kd = float(engineering.get("analytical_knockdown", 1.0))
     di = float(engineering.get("damage_index", 0.0))
@@ -565,48 +574,36 @@ def build_ncr(
                 + "."
             )
     criteria.append(
-        "Generic severity banding in this report is advisory only and is "
+        "Generic severity banding in this summary is advisory only and is "
         "superseded by the program-specific allowables, drawing "
         "requirements, and process specifications applied by the MRB."
     )
 
-    ncr = {
-        "report_type": "Nonconformance Report (NCR)",
-        "tool": "WrinkleFE MRB decision-support export",
+    summary = {
+        "report_type": "Wrinkle Analysis Validation Summary",
+        "intended_use": (
+            "Engineering validation attachment to a Nonconformance "
+            "Report (NCR). Not a standalone NCR."
+        ),
+        "tool": "WrinkleFE",
         "header": {
-            "ncr_number": _m("ncr_number"),
             "date": date,
-            "originator": _m("originator", "(field engineer)"),
-            "program": _m("program"),
-            "part_number": _m("part_number"),
-            "part_name": _m("part_name", "(not specified)"),
-            "serial_or_lot": _m("serial_lot"),
-            "work_order": _m("work_order"),
-            "quantity_affected": _m("quantity", "1"),
+            "reference": _clean(reference, "(not specified)"),
+            "prepared_by": _clean(prepared_by, "(not specified)"),
+            "tool_version": _clean(tool_version, "(unspecified)"),
         },
-        "nonconformance": {
-            "defect_type": "Out-of-plane fibre wrinkle (ply waviness)",
-            "defect_location": _m("defect_location", "(not specified)"),
-            "detection_method": _m("detection_method", "(not specified)"),
-            "violated_requirement": _m(
-                "drawing_spec",
-                "(drawing/specification reference not supplied — MRB "
-                "to confirm the controlling requirement)",
-            ),
-            "as_found_geometry": {
-                "amplitude_mm": defect.get("amplitude_mm"),
-                "wavelength_mm": defect.get("wavelength_mm"),
-                "envelope_half_width_mm": defect.get("width_mm"),
-                "morphology": defect.get("morphology"),
-                "loading_condition": loading,
-            },
-            "laminate": {
-                "material": defect.get("material_name"),
-                "ply_thickness_mm": defect.get("ply_thickness_mm"),
-                "n_plies": defect.get("n_plies"),
-                "layup_deg": defect.get("layup"),
-            },
-            "originator_remarks": _m("remarks", "(none)"),
+        "wrinkle_geometry": {
+            "amplitude_mm": defect.get("amplitude_mm"),
+            "wavelength_mm": defect.get("wavelength_mm"),
+            "envelope_half_width_mm": defect.get("width_mm"),
+            "morphology": defect.get("morphology"),
+            "loading_condition": loading,
+        },
+        "laminate": {
+            "material": defect.get("material_name"),
+            "ply_thickness_mm": defect.get("ply_thickness_mm"),
+            "n_plies": defect.get("n_plies"),
+            "layup_deg": defect.get("layup"),
         },
         "engineering_analysis": {
             "analytical_knockdown": kd,
@@ -635,23 +632,17 @@ def build_ncr(
                 "the controlling drawing and program allowables."
             ),
         },
-        "mrb_disposition": {
-            "final_disposition": "",  # MRB to complete
-            "mrb_rationale": "",
-            "approvals": [
-                {"role": role, "name": "", "signature": "", "date": ""}
-                for role in disposition["required_approvals"]
-            ],
-        },
+        "notes": _clean(notes, "(none)"),
         "disclaimer": (
-            "This NCR was prepared with WrinkleFE decision-support "
-            "tooling. The analysis and recommendation are advisory and do "
-            "not constitute a final material disposition. A qualified "
-            "Material Review Board must review, may modify, and formally "
-            "approve the disposition."
+            "This validation summary was prepared with WrinkleFE "
+            "decision-support tooling and is intended as an attachment to "
+            "a Nonconformance Report. The analysis and recommendation are "
+            "advisory and do not constitute a final material disposition. "
+            "A qualified Material Review Board must review, may modify, "
+            "and formally approve the disposition."
         ),
     }
-    return ncr
+    return summary
 
 
 def _fmt(value: Any, default: str = "—") -> str:
@@ -664,58 +655,40 @@ def _fmt(value: Any, default: str = "—") -> str:
     return str(value)
 
 
-def render_ncr_markdown(ncr: dict) -> str:
-    """Render a :func:`build_ncr` report as a human-readable Markdown form.
+def render_summary_markdown(summary: dict) -> str:
+    """Render a :func:`build_analysis_summary` as Markdown.
 
-    Suitable for a field engineer to print/attach to the MRB package.
+    Produces a concise validation attachment an engineer can staple to
+    an NCR — geometry, laminate, analysis, criteria, and the non-binding
+    recommended disposition. No QMS/admin or MRB sign-off block.
 
     Parameters
     ----------
-    ncr : dict
-        A report produced by :func:`build_ncr`.
+    summary : dict
+        A report produced by :func:`build_analysis_summary`.
 
     Returns
     -------
     str
         Markdown text.
     """
-    h = ncr["header"]
-    nc = ncr["nonconformance"]
-    ea = ncr["engineering_analysis"]
-    dr = ncr["disposition_recommendation"]
-    geo = nc["as_found_geometry"]
-    lam = nc["laminate"]
+    h = summary["header"]
+    geo = summary["wrinkle_geometry"]
+    lam = summary["laminate"]
+    ea = summary["engineering_analysis"]
+    dr = summary["disposition_recommendation"]
 
     lines: list[str] = []
-    lines.append("# Nonconformance Report (NCR)")
+    lines.append("# Wrinkle Analysis Validation Summary")
     lines.append("")
-    lines.append(f"**NCR No.:** {_fmt(h['ncr_number'])}  ")
+    lines.append(f"_{summary['intended_use']}_")
+    lines.append("")
     lines.append(f"**Date:** {_fmt(h['date'])}  ")
-    lines.append(f"**Originator:** {_fmt(h['originator'])}  ")
-    lines.append(f"**Program:** {_fmt(h['program'])}")
+    lines.append(f"**Reference:** {_fmt(h['reference'])}  ")
+    lines.append(f"**Prepared by:** {_fmt(h['prepared_by'])}  ")
+    lines.append(f"**WrinkleFE version:** {_fmt(h['tool_version'])}")
     lines.append("")
-    lines.append("## 1. Part Identification")
-    lines.append("")
-    lines.append(f"- **Part number:** {_fmt(h['part_number'])}")
-    lines.append(f"- **Part name:** {_fmt(h['part_name'])}")
-    lines.append(f"- **Serial / lot:** {_fmt(h['serial_or_lot'])}")
-    lines.append(f"- **Work order:** {_fmt(h['work_order'])}")
-    lines.append(
-        f"- **Quantity affected:** {_fmt(h['quantity_affected'])}"
-    )
-    lines.append("")
-    lines.append("## 2. Nonconformance")
-    lines.append("")
-    lines.append(f"- **Defect type:** {_fmt(nc['defect_type'])}")
-    lines.append(f"- **Location on part:** {_fmt(nc['defect_location'])}")
-    lines.append(
-        f"- **Detection method:** {_fmt(nc['detection_method'])}"
-    )
-    lines.append(
-        f"- **Violated requirement:** {_fmt(nc['violated_requirement'])}"
-    )
-    lines.append("")
-    lines.append("**As-found wrinkle geometry**")
+    lines.append("## 1. As-analyzed wrinkle geometry")
     lines.append("")
     lines.append(f"- Amplitude: {_fmt(geo['amplitude_mm'])} mm")
     lines.append(f"- Wavelength: {_fmt(geo['wavelength_mm'])} mm")
@@ -725,7 +698,7 @@ def render_ncr_markdown(ncr: dict) -> str:
     lines.append(f"- Morphology: {_fmt(geo['morphology'])}")
     lines.append(f"- Loading condition: {_fmt(geo['loading_condition'])}")
     lines.append("")
-    lines.append("**Affected laminate**")
+    lines.append("## 2. Affected laminate")
     lines.append("")
     lines.append(f"- Material: {_fmt(lam['material'])}")
     lines.append(
@@ -734,9 +707,7 @@ def render_ncr_markdown(ncr: dict) -> str:
     )
     lines.append(f"- Layup (deg): {_fmt(lam['layup_deg'])}")
     lines.append("")
-    lines.append(f"**Originator remarks:** {_fmt(nc['originator_remarks'])}")
-    lines.append("")
-    lines.append("## 3. Engineering Analysis (WrinkleFE)")
+    lines.append("## 3. Engineering analysis (WrinkleFE)")
     lines.append("")
     lines.append(
         f"- Analytical knockdown: **{_fmt(ea['analytical_knockdown'])}** "
@@ -776,12 +747,12 @@ def render_ncr_markdown(ncr: dict) -> str:
             f"ply: {_fmt(fe_block['critical_ply'])})"
         )
     lines.append("")
-    lines.append("## 4. Criteria Cited")
+    lines.append("## 4. Criteria cited")
     lines.append("")
-    for c in ncr["criteria_cited"]:
+    for c in summary["criteria_cited"]:
         lines.append(f"- {c}")
     lines.append("")
-    lines.append("## 5. Recommended Disposition (NON-BINDING)")
+    lines.append("## 5. Recommended disposition (NON-BINDING)")
     lines.append("")
     lines.append(f"- **Severity:** {_fmt(dr['severity'])}")
     lines.append(f"- **Recommended path:** {_fmt(dr['recommended_path'])}")
@@ -793,19 +764,13 @@ def render_ncr_markdown(ncr: dict) -> str:
     lines.append("")
     lines.append(f"> {dr['note']}")
     lines.append("")
-    lines.append("## 6. MRB Disposition (to be completed by the Board)")
+    lines.append("## 6. Notes")
     lines.append("")
-    lines.append("- Final disposition: ___________________________________")
-    lines.append("- MRB rationale: ______________________________________")
-    lines.append("")
-    lines.append("| Role | Name | Signature | Date |")
-    lines.append("| --- | --- | --- | --- |")
-    for ap in ncr["mrb_disposition"]["approvals"]:
-        lines.append(f"| {ap['role']} | | | |")
+    lines.append(_fmt(summary["notes"]))
     lines.append("")
     lines.append("---")
     lines.append("")
-    lines.append(f"_{ncr['disclaimer']}_")
+    lines.append(f"_{summary['disclaimer']}_")
     lines.append("")
     return "\n".join(lines)
 
@@ -828,7 +793,7 @@ _PDF_STYLES = {
 }
 
 
-def _classify_ncr_line(line: str) -> tuple[str, str]:
+def _classify_md_line(line: str) -> tuple[str, str]:
     """Map one Markdown line to a (style-kind, plain-text) pair."""
     raw = line.rstrip()
     stripped = raw.strip()
@@ -882,8 +847,8 @@ def _strip_md_inline(text: str) -> str:
     )
 
 
-def render_ncr_pdf(ncr: dict) -> bytes:
-    """Render an NCR (from :func:`build_ncr`) as a paginated PDF.
+def render_summary_pdf(summary: dict) -> bytes:
+    """Render a validation summary as a paginated PDF.
 
     Uses Matplotlib's PDF backend (already a project dependency, headless-
     safe) so no extra packages are required. The structured Markdown form
@@ -892,8 +857,8 @@ def render_ncr_pdf(ncr: dict) -> bytes:
 
     Parameters
     ----------
-    ncr : dict
-        A report produced by :func:`build_ncr`.
+    summary : dict
+        A report produced by :func:`build_analysis_summary`.
 
     Returns
     -------
@@ -907,7 +872,7 @@ def render_ncr_pdf(ncr: dict) -> bytes:
     from matplotlib.figure import Figure
     from matplotlib.lines import Line2D
 
-    lines = render_ncr_markdown(ncr).split("\n")
+    lines = render_summary_markdown(summary).split("\n")
     usable_w = _PDF_PAGE_W - 2 * _PDF_MARGIN
     usable_h = _PDF_PAGE_H - 2 * _PDF_MARGIN
 
@@ -915,7 +880,7 @@ def render_ncr_pdf(ncr: dict) -> bytes:
     # italic, indent_in, gap_in, line_h_in).
     items: list[tuple] = []
     for line in lines:
-        kind, text = _classify_ncr_line(line)
+        kind, text = _classify_md_line(line)
         if kind == "blank":
             items.append(("blank", "", 9.5, False, False, 0.0, 0.0, 0.11))
             continue
@@ -997,33 +962,34 @@ def render_ncr_pdf(ncr: dict) -> bytes:
     return buf.getvalue()
 
 
-def export_ncr(
-    ncr: dict,
+def export_summary(
+    summary: dict,
     filepath: Union[str, Path],
     *,
     fmt: str = "md",
 ) -> None:
-    """Write an NCR (from :func:`build_ncr`) to disk.
+    """Write a validation summary (from :func:`build_analysis_summary`).
 
     Parameters
     ----------
-    ncr : dict
-        The structured NCR.
+    summary : dict
+        The structured validation summary.
     filepath : str or Path
         Output path.
     fmt : {'md', 'json', 'pdf'}
         ``'md'`` writes the rendered Markdown form (default); ``'json'``
-        writes the structured report; ``'pdf'`` writes a paginated PDF
-        of the NCR form.
+        writes the structured report; ``'pdf'`` writes a paginated PDF.
     """
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
     if fmt == "json":
-        filepath.write_text(json.dumps(ncr, indent=2), encoding="utf-8")
+        filepath.write_text(json.dumps(summary, indent=2), encoding="utf-8")
     elif fmt == "md":
-        filepath.write_text(render_ncr_markdown(ncr), encoding="utf-8")
+        filepath.write_text(
+            render_summary_markdown(summary), encoding="utf-8"
+        )
     elif fmt == "pdf":
-        filepath.write_bytes(render_ncr_pdf(ncr))
+        filepath.write_bytes(render_summary_pdf(summary))
     else:
         raise ValueError(
             f"Unsupported fmt {fmt!r}; use 'md', 'json', or 'pdf'."

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -19,14 +19,14 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 from wrinklefe.io.export import (
-    build_ncr,
+    build_analysis_summary,
     export_abaqus_inp,
-    export_ncr,
     export_results_json,
+    export_summary,
     export_vtk,
     recommend_disposition,
-    render_ncr_markdown,
-    render_ncr_pdf,
+    render_summary_markdown,
+    render_summary_pdf,
 )
 
 
@@ -401,12 +401,12 @@ class TestVTKExport:
 
 
 # ======================================================================
-# NCR (MRB decision-support) tests
+# Analysis validation summary (NCR attachment) tests
 # ======================================================================
 
 @pytest.fixture(scope="module")
-def ncr_inputs(analysis_result):
-    """Build build_ncr() defect/engineering dicts from the fixture."""
+def summary_inputs(analysis_result):
+    """Build build_analysis_summary() defect/engineering dicts."""
     r = analysis_result
     cfg = r.config
     defect = {
@@ -473,69 +473,77 @@ class TestRecommendDisposition:
         assert "compression" in d["rationale"].lower()
 
 
-class TestBuildNCR:
-    """Tests for build_ncr structured report."""
+class TestBuildAnalysisSummary:
+    """Tests for build_analysis_summary structured report."""
 
-    def test_required_sections(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
+    def test_required_sections(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
         for key in (
             "header",
-            "nonconformance",
+            "wrinkle_geometry",
+            "laminate",
             "engineering_analysis",
             "criteria_cited",
             "disposition_recommendation",
-            "mrb_disposition",
+            "notes",
             "disclaimer",
         ):
-            assert key in ncr
+            assert key in s
 
-    def test_recommendation_not_final(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        rec = ncr["disposition_recommendation"]
+    def test_no_qms_admin_or_mrb_signoff(self, summary_inputs):
+        """The attachment must not carry NCR/part admin or sign-off."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        assert "mrb_disposition" not in s
+        assert "nonconformance" not in s
+        for forbidden in ("ncr_number", "part_number", "serial_or_lot",
+                          "work_order", "quantity_affected"):
+            assert forbidden not in s["header"]
+
+    def test_recommendation_not_final(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        rec = s["disposition_recommendation"]
         assert rec["is_final_disposition"] is False
         assert "Material Review Board" in rec["note"]
 
-    def test_mrb_signoff_is_blank(self, ncr_inputs):
-        """The MRB block is left for the board to complete."""
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        mrb = ncr["mrb_disposition"]
-        assert mrb["final_disposition"] == ""
-        assert all(a["signature"] == "" for a in mrb["approvals"])
-        assert len(mrb["approvals"]) >= 1
-
-    def test_metadata_passthrough(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(
-            metadata={"ncr_number": "NCR-2026-001", "part_number": "PN-42"},
+    def test_optional_fields_passthrough(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
             defect=defect,
             engineering=engineering,
+            reference="NCR-2026-001",
+            prepared_by="J. Field",
+            notes="UT-detected; adjacent bay clear.",
+            tool_version="1.0.0",
         )
-        assert ncr["header"]["ncr_number"] == "NCR-2026-001"
-        assert ncr["header"]["part_number"] == "PN-42"
+        assert s["header"]["reference"] == "NCR-2026-001"
+        assert s["header"]["prepared_by"] == "J. Field"
+        assert s["header"]["tool_version"] == "1.0.0"
+        assert s["notes"] == "UT-detected; adjacent bay clear."
 
-    def test_missing_metadata_has_placeholders(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        assert ncr["header"]["ncr_number"] == "(to be assigned)"
+    def test_missing_optionals_have_placeholders(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        assert s["header"]["reference"] == "(not specified)"
+        assert s["notes"] == "(none)"
 
-    def test_geometry_carried_through(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        geo = ncr["nonconformance"]["as_found_geometry"]
+    def test_geometry_carried_through(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        geo = s["wrinkle_geometry"]
         assert geo["amplitude_mm"] == pytest.approx(defect["amplitude_mm"])
         assert geo["wavelength_mm"] == pytest.approx(defect["wavelength_mm"])
 
-    def test_json_serialisable(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
+    def test_json_serialisable(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
         # Must not raise.
-        json.dumps(ncr)
+        json.dumps(s)
 
-    def test_fe_block_cited_when_present(self, ncr_inputs):
-        defect, engineering = ncr_inputs
+    def test_fe_block_cited_when_present(self, summary_inputs):
+        defect, engineering = summary_inputs
         eng = dict(engineering)
         eng["fe"] = {
             "modulus_retention": 0.92,
@@ -544,89 +552,97 @@ class TestBuildNCR:
             "critical_mode": "fiber_compression",
             "critical_ply": 3,
         }
-        ncr = build_ncr(defect=defect, engineering=eng)
-        fe_block = ncr["engineering_analysis"]["finite_element"]
+        s = build_analysis_summary(defect=defect, engineering=eng)
+        fe_block = s["engineering_analysis"]["finite_element"]
         assert fe_block["min_strength_retention"] == pytest.approx(0.81)
         assert any(
-            "hashin" in c.lower() for c in ncr["criteria_cited"]
+            "hashin" in c.lower() for c in s["criteria_cited"]
         )
 
 
-class TestRenderAndExportNCR:
-    """Tests for render_ncr_markdown and export_ncr."""
+class TestRenderAndExportSummary:
+    """Tests for render_summary_markdown / pdf and export_summary."""
 
-    def test_markdown_has_key_headers(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        md = render_ncr_markdown(build_ncr(defect=defect, engineering=engineering))
-        assert "# Nonconformance Report (NCR)" in md
-        assert "Engineering Analysis" in md
-        assert "Recommended Disposition (NON-BINDING)" in md
-        assert "MRB Disposition" in md
+    def test_markdown_has_key_headers(self, summary_inputs):
+        defect, engineering = summary_inputs
+        md = render_summary_markdown(
+            build_analysis_summary(defect=defect, engineering=engineering)
+        )
+        assert "# Wrinkle Analysis Validation Summary" in md
+        assert "As-analyzed wrinkle geometry" in md
+        assert "Engineering analysis" in md
+        assert "Recommended disposition (NON-BINDING)" in md
 
-    def test_markdown_states_non_binding(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        md = render_ncr_markdown(build_ncr(defect=defect, engineering=engineering))
+    def test_markdown_states_non_binding(self, summary_inputs):
+        defect, engineering = summary_inputs
+        md = render_summary_markdown(
+            build_analysis_summary(defect=defect, engineering=engineering)
+        )
         assert "do not constitute a final material disposition" in md
 
-    def test_export_md(self, ncr_inputs, tmp_path):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        out = tmp_path / "sub" / "ncr.md"
-        export_ncr(ncr, out, fmt="md")
+    def test_export_md(self, summary_inputs, tmp_path):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        out = tmp_path / "sub" / "summary.md"
+        export_summary(s, out, fmt="md")
         assert out.exists()
-        assert out.read_text().startswith("# Nonconformance Report")
+        assert out.read_text().startswith(
+            "# Wrinkle Analysis Validation Summary"
+        )
 
-    def test_export_json(self, ncr_inputs, tmp_path):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        out = tmp_path / "ncr.json"
-        export_ncr(ncr, out, fmt="json")
+    def test_export_json(self, summary_inputs, tmp_path):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        out = tmp_path / "summary.json"
+        export_summary(s, out, fmt="json")
         data = json.loads(out.read_text())
-        assert data["report_type"] == "Nonconformance Report (NCR)"
+        assert data["report_type"] == "Wrinkle Analysis Validation Summary"
 
-    def test_export_invalid_fmt(self, ncr_inputs, tmp_path):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
+    def test_export_invalid_fmt(self, summary_inputs, tmp_path):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
         with pytest.raises(ValueError):
-            export_ncr(ncr, tmp_path / "ncr.txt", fmt="txt")
+            export_summary(s, tmp_path / "s.txt", fmt="txt")
 
-    def test_render_pdf_returns_pdf_bytes(self, ncr_inputs):
-        defect, engineering = ncr_inputs
-        pdf = render_ncr_pdf(build_ncr(defect=defect, engineering=engineering))
+    def test_render_pdf_returns_pdf_bytes(self, summary_inputs):
+        defect, engineering = summary_inputs
+        pdf = render_summary_pdf(
+            build_analysis_summary(defect=defect, engineering=engineering)
+        )
         assert isinstance(pdf, bytes)
         assert pdf.startswith(b"%PDF")
         assert b"%%EOF" in pdf
 
-    def test_export_pdf(self, ncr_inputs, tmp_path):
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(defect=defect, engineering=engineering)
-        out = tmp_path / "deep" / "ncr.pdf"
-        export_ncr(ncr, out, fmt="pdf")
+    def test_export_pdf(self, summary_inputs, tmp_path):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        out = tmp_path / "deep" / "summary.pdf"
+        export_summary(s, out, fmt="pdf")
         assert out.exists()
         assert out.read_bytes().startswith(b"%PDF")
 
-    def test_pdf_paginates_long_report(self, ncr_inputs):
-        """A long remarks block must not raise and must paginate.
+    def test_pdf_paginates_long_report(self, summary_inputs):
+        """A long notes block must not raise and must paginate.
 
         The exported PDF should contain more than one page object once the
         content overflows a single A4 page.
         """
-        defect, engineering = ncr_inputs
-        ncr = build_ncr(
-            metadata={"remarks": ("Lorem ipsum dolor sit amet. " * 400)},
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
             defect=defect,
             engineering=engineering,
+            notes=("Lorem ipsum dolor sit amet. " * 400),
         )
-        pdf = render_ncr_pdf(ncr)
+        pdf = render_summary_pdf(s)
         assert pdf.startswith(b"%PDF")
         # Each page is emitted as a "/Type /Page" object in the PDF.
         assert pdf.count(b"/Type /Page") >= 2
 
     def test_pdf_handles_minimal_inputs(self):
-        """No metadata / no FE block still produces a valid PDF."""
-        ncr = build_ncr(
+        """No optionals / no FE block still produces a valid PDF."""
+        s = build_analysis_summary(
             defect={"loading": "compression"},
             engineering={"analytical_knockdown": 0.6, "damage_index": 0.5},
         )
-        pdf = render_ncr_pdf(ncr)
+        pdf = render_summary_pdf(s)
         assert pdf.startswith(b"%PDF")

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -26,6 +26,7 @@ from wrinklefe.io.export import (
     export_vtk,
     recommend_disposition,
     render_ncr_markdown,
+    render_ncr_pdf,
 )
 
 
@@ -588,3 +589,44 @@ class TestRenderAndExportNCR:
         ncr = build_ncr(defect=defect, engineering=engineering)
         with pytest.raises(ValueError):
             export_ncr(ncr, tmp_path / "ncr.txt", fmt="txt")
+
+    def test_render_pdf_returns_pdf_bytes(self, ncr_inputs):
+        defect, engineering = ncr_inputs
+        pdf = render_ncr_pdf(build_ncr(defect=defect, engineering=engineering))
+        assert isinstance(pdf, bytes)
+        assert pdf.startswith(b"%PDF")
+        assert b"%%EOF" in pdf
+
+    def test_export_pdf(self, ncr_inputs, tmp_path):
+        defect, engineering = ncr_inputs
+        ncr = build_ncr(defect=defect, engineering=engineering)
+        out = tmp_path / "deep" / "ncr.pdf"
+        export_ncr(ncr, out, fmt="pdf")
+        assert out.exists()
+        assert out.read_bytes().startswith(b"%PDF")
+
+    def test_pdf_paginates_long_report(self, ncr_inputs):
+        """A long remarks block must not raise and must paginate.
+
+        The exported PDF should contain more than one page object once the
+        content overflows a single A4 page.
+        """
+        defect, engineering = ncr_inputs
+        ncr = build_ncr(
+            metadata={"remarks": ("Lorem ipsum dolor sit amet. " * 400)},
+            defect=defect,
+            engineering=engineering,
+        )
+        pdf = render_ncr_pdf(ncr)
+        assert pdf.startswith(b"%PDF")
+        # Each page is emitted as a "/Type /Page" object in the PDF.
+        assert pdf.count(b"/Type /Page") >= 2
+
+    def test_pdf_handles_minimal_inputs(self):
+        """No metadata / no FE block still produces a valid PDF."""
+        ncr = build_ncr(
+            defect={"loading": "compression"},
+            engineering={"analytical_knockdown": 0.6, "damage_index": 0.5},
+        )
+        pdf = render_ncr_pdf(ncr)
+        assert pdf.startswith(b"%PDF")


### PR DESCRIPTION
## Summary

Follows up the already-merged NCR tool (PR #158). Per review feedback, the Export-tab tool is reworked from a full Nonconformance Report form into a concise **engineering validation summary intended to be attached to a separately-raised NCR**, and gains **PDF export**.

This PR contains the two commits made after #158 was merged:

- **Add PDF export** — `render_summary_pdf` renders the summary to a paginated A4 PDF using Matplotlib's PDF backend (already a project dependency, headless-safe — no new packages). `export_*` supports `md`/`json`/`pdf`.
- **Rework into an analysis validation summary attachment** — drops the QMS/admin fields (NCR number, part/serial, work order, quantity, detection method, drawing spec) and the **MRB sign-off table**; that paperwork lives on the NCR itself. The artifact now carries only the technical validation: wrinkle geometry, laminate, WrinkleFE analysis, cited criteria, and a **non-binding** recommended disposition.

Because the original NCR commit is already in `main`, this PR's diff reads as: remove the NCR admin/MRB scaffolding, add the summary attachment + PDF.

## API changes

- New: `build_analysis_summary`, `render_summary_markdown`, `render_summary_pdf`, `export_summary`
- Kept: `recommend_disposition` (five-tier severity, worst-metric-governs, non-binding)
- Removed: `build_ncr`, `render_ncr_markdown`, `render_ncr_pdf`, `export_ncr`
- `app.py`: minimal form (optional reference / prepared-by / notes) with PDF, Markdown, and JSON downloads
- `wrinklefe.io` public API updated accordingly

## Behavioural guarantees

- The summary explicitly carries no QMS/admin or MRB sign-off block (asserted by tests).
- The recommendation is decision support only — never a final disposition; the MRB reviews, may modify, and approves.

## Test plan

- [x] `tests/test_io/test_export.py` rewritten for the new API (46 tests pass), incl. a test asserting admin/MRB blocks are absent, PDF validity, multi-page pagination, and minimal-input robustness
- [x] Full suite green: 880 passed, 1 xfailed, no regressions
- [ ] Reviewer: sanity-check a generated PDF/Markdown summary

Related follow-up: #159 (investigate/document `stack` vs `uniform` morphology).

https://claude.ai/code/session_019pGvQpiBmpS7jwUFSo66Pj

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGvQpiBmpS7jwUFSo66Pj)_