### PR TITLE
Add validation ledger documenting paper assessment decisions

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -127,14 +127,22 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   (S-A-2 is S-M-2 geometry at a near-surface interface.)
 - **Finding (model-wide structural limitation)**: the diagnostic trio
   S-M-2 / S-M-4 / S-M-5 has an *identical* peak angle (20°) with amplitude
-  1.5 / 1.0 / 0.5 mm; measured strength spans 0.63 → 1.00 (~60%), yet the
-  FE LaRC05 max FI is 0.767 / 0.765 / 0.777 (≤1.5% spread) and FE modulus
-  retention is 0.945 for all three. The amplitude-at-constant-angle effect
-  is captured by **neither** the analytical Budiansky–Fleck path **nor**
-  the FE LaRC05 path — both reduce the wrinkle to its peak misalignment
-  angle. Capturing it needs geometrically nonlinear progressive-damage FE
-  (issue #161). S-A-2 additionally exposes a missing through-thickness
-  wrinkle-position parameter (out of scope; excluded on future inclusion).
+  1.5 / 1.0 / 0.5 mm and a measured strength span of 0.63 → 1.00 (~60%).
+  On a proper **strength** basis — LaRC05 max-FI scales ~linearly with
+  load (k ≈ 0.82–0.91), load scaled to FI = 1, σ_f = E_eff·ε_f, referenced
+  to the near-pristine wrinkle S-M-5 — the FE strength knockdown for the
+  trio is 1.000 / 1.000 / 1.000 (the FE does not reach first-ply failure
+  for ≤20° wrinkles at all, regardless of amplitude). The
+  amplitude-at-constant-angle effect is captured by **neither** the
+  analytical Budiansky–Fleck path **nor** the FE LaRC05 strength path —
+  both reduce the wrinkle to its peak misalignment angle, and the FE
+  strength response is in fact flatter than the analytical one (S-M-2 FE
+  strength error ≈ 59%). (Underlying FE LaRC05 max-FI at ε = −0.01:
+  0.767 / 0.765 / 0.777, ≤1.5% spread; modulus retention 0.945 for all
+  three — both confirm the same flat behaviour.) Capturing the effect
+  needs geometrically nonlinear progressive-damage FE (issue #161). S-A-2
+  additionally exposes a missing through-thickness wrinkle-position
+  parameter (out of scope; excluded on future inclusion).
 - **Related**: the `graded` compression through-thickness decay has a
   separate real bug (`decay_floor` inert in compression, decay scale
   hard-wired to amplitude A). A "mirror the tension path" fix was

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -96,10 +96,52 @@ wrinkle defects.* AIP Advances 15, 065118. DOI 10.1063/5.0276297.
   would yield only a figure-derived, non-pristine apparent KD biased to the
   initial-damage region — below the database data-quality bar.
 
+## Evaluated — deferred (pending model capability)
+
+### Li, Li, Ge & Liang (2025)
+
+*Experimental Investigation on the Effect of Multi-Wrinkle Fiber Defects
+on the Compressive Testing of Unidirectional Composites.* Polymer
+Composites 46(16):15176–15187. DOI 10.1002/pc.30121. **Distinct** from
+Li et al. (2026), *Compos. A* 205:109719 already in the database
+(different journal, year, and specimens; same material system).
+
+- **Evaluated**: 2026-05-18
+- **Decision**: *Qualifies* methodologically (meets every inclusion
+  criterion: material with Xc `AC318_S6C10`, UD `[0]₁₄` ply 0.44 mm,
+  wrinkle geometry, compression, measured strength with a pristine
+  baseline). **Inclusion deferred** pending a model capability tracked by
+  [issue #161](https://github.com/ranipdx-glitch/wrinkleFE/issues/161).
+- **Dataset** (pristine plate 335.52 MPa; A = peak-to-peak amplitude;
+  θ_max = arctan(2π·(A/2)/λ)):
+
+  | Case | A (mm) | λ (mm) | α_max | σ (MPa) | KD meas | KD analytical | FE max FI |
+  |------|--------|--------|-------|---------|---------|---------------|-----------|
+  | S-M-1 | 1.5 | 26.0 | 10° | 298.81 | 0.891 | 0.839 | 0.396 |
+  | S-M-2 | 1.5 | 12.9 | 20° | 211.10 | 0.629 | 0.782 | 0.767 |
+  | S-M-3 | 1.5 |  8.1 | 30° | 158.41 | 0.472 | 0.744 | 1.058 |
+  | S-M-4 | 1.0 |  8.6 | 20° | 316.34 | 0.943 | 0.855 | 0.765 |
+  | S-M-5 | 0.5 |  4.3 | 20° | 335.63 | 1.000 | 0.923 | 0.777 |
+  | S-A-2 | 1.5 | 12.9 | 20° | 329.29 | 0.981 | 0.782 | 0.767 |
+
+  (S-A-2 is S-M-2 geometry at a near-surface interface.)
+- **Finding (model-wide structural limitation)**: the diagnostic trio
+  S-M-2 / S-M-4 / S-M-5 has an *identical* peak angle (20°) with amplitude
+  1.5 / 1.0 / 0.5 mm; measured strength spans 0.63 → 1.00 (~60%), yet the
+  FE LaRC05 max FI is 0.767 / 0.765 / 0.777 (≤1.5% spread) and FE modulus
+  retention is 0.945 for all three. The amplitude-at-constant-angle effect
+  is captured by **neither** the analytical Budiansky–Fleck path **nor**
+  the FE LaRC05 path — both reduce the wrinkle to its peak misalignment
+  angle. Capturing it needs geometrically nonlinear progressive-damage FE
+  (issue #161). S-A-2 additionally exposes a missing through-thickness
+  wrinkle-position parameter (out of scope; excluded on future inclusion).
+- **Related**: the `graded` compression through-thickness decay has a
+  separate real bug (`decay_floor` inert in compression, decay scale
+  hard-wired to amplitude A). A "mirror the tension path" fix was
+  prototyped and **reverted** (commit `00584b4`) pending a reproducible
+  harness for *all* existing datasets; it corrects the angle response but
+  does not address the amplitude gap above.
+
 ## Identified — pending evaluation
 
-- Li, Y., Li, X., Ge, J. & Liang, J. (2025). *Experimental Investigation on
-  the Effect of Multi-Wrinkle Fiber Defects on the Compressive Testing of
-  Unidirectional Composites.* Polymer Composites (Wiley). **Distinct** from
-  Li et al. (2026), *Compos. A* 205:109719 already in the database
-  (different journal, year, and specimens). Not yet evaluated.
+- _None currently._

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -64,6 +64,38 @@ DOI 10.1007/s12289-019-01514-2.
   paper's refs [3]/[4] — Mukhopadhyay, Jones & Hallett (2015) — already an
   active dataset above.
 
+### Sun, Zhou, Zheng & Wang (2025)
+
+*Inversion analysis of constitutive relations of blade spar laminates with
+wrinkle defects.* AIP Advances 15, 065118. DOI 10.1063/5.0276297.
+
+- **Evaluated**: 2026-05-17
+- **Decision**: Not added to the knockdown validation database.
+- **Rationale**:
+  1. *No measured strength or knockdown* — the paper is an inverse
+     parameter-identification study (BRBP neural network + PSO) that
+     back-fits elastic constants (E₁, E₂, G₁₂, ν₂₁) from tensile
+     load–displacement curves. Outputs are load–displacement curves and
+     inverted moduli focused on *initial-damage onset* (stress relaxation),
+     not ultimate failure. No failure-stress vs A/λ data is reported.
+  2. *No pristine baseline* — all four groups (A–D) are wrinkled, so no
+     defect-free reference exists to normalise a knockdown against.
+  3. *Strengths are reference values, not measurements* — Table III
+     (XT=2100, XC=−1346, YT=44.46, SL=60.28 MPa, etc.) are taken from
+     GB/T 3961-2005, the manufacturer, and wind-farm literature as FE
+     inputs; explicitly not measured here, so they cannot anchor a
+     "measured" material entry.
+  4. Paper validates an ML inversion method (errors <5%, FE-vs-test <8%),
+     not a wrinkle knockdown model.
+- **Usable cross-reference only**: flat UD `[0]₆` glass/epoxy coupons
+  (A12/HRC1, single-ply 0.734 mm, 150×25×5 mm, ASTM D3039) in tension with
+  clean wrinkle geometry (A/λ = 0.01 / 0.1 / 0.18 / 0.25; amplitudes from
+  0.1 / 1.1 / 1.8 / 2.5 mm copper-wire molds, λ ≈ 10 mm). Geometrically in
+  our model's domain, but the strength response is absent. Digitising the
+  Fig. 4 / Fig. 14 load–displacement curves against the near-flat Group A
+  would yield only a figure-derived, non-pristine apparent KD biased to the
+  initial-damage region — below the database data-quality bar.
+
 ## Identified — pending evaluation
 
 - Li, Y., Li, X., Ge, J. & Liang, J. (2025). *Experimental Investigation on

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -1,0 +1,73 @@
+# WrinkleFE Validation Ledger
+
+This file tracks every external paper assessed for inclusion in the
+WrinkleFE knockdown validation database, with the decision and rationale.
+The active validation dataset (data points, pass counts, MAE) lives in the
+**Validation** section of [README.md](README.md); this file is the
+evaluation history behind it.
+
+## Inclusion methodology
+
+A paper qualifies as a knockdown validation point when it reports, for a
+**flat coupon containing fiber waviness**:
+
+- a material with tensile/compressive strength allowables (Xt / Xc),
+- the stacking sequence and ply thickness,
+- the wrinkle geometry (amplitude A, wavelength λ, or peak misalignment θ),
+- the loading mode (tension or compression),
+- the measured strength (or knockdown) of the wrinkled vs pristine coupon.
+
+Each case is run through `WrinkleAnalysis`; predicted vs measured knockdown
+gives the per-point error, aggregated into the README table.
+
+## Included datasets
+
+See the table in [README.md](README.md). Current sources:
+
+- Elhajjar (2025), *Scientific Reports* 15:25977 — compression + tension.
+- Mukhopadhyay, Jones & Hallett (2015), *Compos. A* 73:132–142
+  (compression) and 77:219–228 (tension).
+- Li, Y. et al. (2026), *Composites Part A* 205:109719 — S-glass/epoxy,
+  compression (material `AC318_S6C10`).
+
+## Evaluated — not included
+
+### Varkonyi, Belnoue, Kratz & Hallett (2020)
+
+*Predicting consolidation-induced wrinkles and their effects on composites
+structural performance.* Int. J. Material Forming 13:907–921.
+DOI 10.1007/s12289-019-01514-2.
+
+- **Evaluated**: 2026-05-17
+- **Decision**: Not added to the knockdown validation database.
+- **Rationale**:
+  1. *Failure-mechanism mismatch* — strength is governed by skin–stringer
+     interface delamination at a stepped ply run-out under tension-induced
+     bending, not the fiber kink-band (compression) or fiber/matrix/OOP
+     (tension) mechanisms WrinkleFE's analytical knockdown represents.
+     Matrix cracking and fiber failure were explicitly not modelled.
+  2. *Geometry mismatch* — the specimen is a stepped stringer-foot run-out
+     (skin `[−45/0/45/90]₆S`, upper block `[−45/0/45/90]₃S`), not a flat
+     coupon with a single embedded wrinkle representable by `AnalysisConfig`.
+  3. *No strength allowables* — only elastic constants (Table 3) and
+     cohesive/delamination properties (Table 4: σᴵ=60, σᴵᴵ=90 MPa,
+     GᵢC=0.26, GᵢᵢC=1.002 N/mm) are reported; no Xt/Xc. Material is
+     IM7/8552, already present in the library as `IM7_8552`.
+  4. *Figure 3* is experimental Load–Strain curves for the α=90° co-cured
+     and co-bonded tensile tests (delamination load-drop and progressive
+     stiffness degradation) — not a digitisable (A, λ, KD) data point.
+- **Usable cross-reference only**: Table 2 wrinkle geometry (co-cured 90°
+  h≈0.42 mm, λ≈5.91 mm, θ₊≈12.7°; co-bonded 90° h≈0.46 mm, λ≈4.07 mm,
+  θ₊≈20°) and an apparent joint knockdown 27.3–27.6 / 34 ≈ 0.80. These are
+  delamination-controlled and must not enter the kink-band/tension MAE.
+- **Follow-up**: the proper flat-coupon embedded-wrinkle data are this
+  paper's refs [3]/[4] — Mukhopadhyay, Jones & Hallett (2015) — already an
+  active dataset above.
+
+## Identified — pending evaluation
+
+- Li, Y., Li, X., Ge, J. & Liang, J. (2025). *Experimental Investigation on
+  the Effect of Multi-Wrinkle Fiber Defects on the Compressive Testing of
+  Unidirectional Composites.* Polymer Composites (Wiley). **Distinct** from
+  Li et al. (2026), *Compos. A* 205:109719 already in the database
+  (different journal, year, and specimens). Not yet evaluated.

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -135,13 +135,13 @@ def _profile_proportional_kd(
     wavelength: float,
     width: float,
     domain_length: float,
-    ply_thickness: float,
     n_plies: int,
     gamma_Y: float,
     theta_max: float,
     *,
     morphology_factor: float = 1.0,
     through_thickness_decay: bool = True,
+    decay_floor: float = 0.0,
 ) -> float:
     """Budiansky-Fleck knockdown averaged over the wrinkle profile.
 
@@ -158,7 +158,16 @@ def _profile_proportional_kd(
     with:
         |dz_w/dx|  = slope of the GaussianSinusoidal wrinkle profile
         M_f        = morphology factor (accounts for dual-wrinkle interaction)
-        Phi(z_p)   = exp(-(z_p - T/2)^2 / A^2)   (through-thickness decay)
+        Phi(z_p)   = decay_floor + (1 - decay_floor) * raw_p,
+                     raw_p = max(0, 1 - |p - p_mid| / p_mid)
+
+    The through-thickness term is a linear ply-index decay from 1.0 at the
+    midplane to ``decay_floor`` at the surface plies.  This is the same
+    grading used by the tension graded path, so the two loading modes treat
+    an embedded (graded) wrinkle consistently.  ``decay_floor`` is the
+    fraction of the wrinkle angle retained at the surface plies and is set
+    from the embedded-strip through-thickness reach (0 = waviness fully
+    decays to flat at the surfaces, 1 = no decay).
 
     When *through_thickness_decay* is False, Phi(z_p) = 1 for all plies
     (all plies see the same longitudinal profile).  This is appropriate
@@ -175,8 +184,6 @@ def _profile_proportional_kd(
         Gaussian envelope half-width w [mm].
     domain_length : float
         Specimen / domain length L_s [mm].
-    ply_thickness : float
-        Ply thickness [mm].
     n_plies : int
         Total number of plies.
     gamma_Y : float
@@ -188,17 +195,19 @@ def _profile_proportional_kd(
         for dual-wrinkle interaction (convex < 1.0, concave > 1.0,
         stack = 1.0, graded = 1.0).  Default 1.0.
     through_thickness_decay : bool
-        If True (default), apply Gaussian through-thickness decay centred
-        at the midplane with scale = amplitude.  If False, all plies see
-        the full wrinkle angle profile (Phi = 1).
+        If True (default), apply the linear ply-index through-thickness
+        decay (1.0 at the midplane to ``decay_floor`` at the surfaces).
+        If False, all plies see the full wrinkle angle profile (Phi = 1).
+    decay_floor : float
+        Fraction of the wrinkle angle retained at the surface plies in the
+        graded through-thickness decay (0 = full decay to flat, 1 = no
+        decay).  Clamped by the caller to [0, 1].  Default 0.0.
 
     Returns
     -------
     float
         Profile-averaged BF knockdown factor (0, 1].
     """
-    T = n_plies * ply_thickness
-    z_mid = T / 2.0
     L_s = domain_length
 
     # Longitudinal profile: compute |dz/dx| at each x-point
@@ -216,12 +225,16 @@ def _profile_proportional_kd(
     )
     theta_x = np.abs(np.arctan(dz_dx)) * morphology_factor  # M_f-scaled angle
 
-    # Average over plies and x-positions
+    # Average over plies and x-positions.  The through-thickness term is a
+    # linear ply-index decay from 1.0 at the midplane to decay_floor at the
+    # surface plies — identical to the tension graded path so both loading
+    # modes treat an embedded (graded) wrinkle consistently.
     kd_sum = 0.0
+    p_mid = (n_plies - 1) / 2.0
     for p in range(n_plies):
-        z_p = (p + 0.5) * ply_thickness
         if through_thickness_decay:
-            phi_p = np.exp(-((z_p - z_mid) ** 2) / (amplitude ** 2))
+            raw_p = max(0.0, 1.0 - abs(p - p_mid) / p_mid) if p_mid > 0 else 1.0
+            phi_p = decay_floor + (1.0 - decay_floor) * raw_p
         else:
             phi_p = 1.0
         theta_xz = theta_x * phi_p  # local angle at (x, z_p)
@@ -1014,12 +1027,12 @@ class WrinkleAnalysis:
                 wavelength=cfg.wavelength,
                 width=cfg.width,
                 domain_length=cfg.domain_length,
-                ply_thickness=cfg.ply_thickness,
                 n_plies=n_plies,
                 gamma_Y=gamma_Y_eff,
                 theta_max=theta_max,
                 morphology_factor=1.0,
                 through_thickness_decay=True,
+                decay_floor=cfg.decay_floor,
             )
             kd_compression = f_0 * kd_profile + (1.0 - f_0)
 

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -135,13 +135,13 @@ def _profile_proportional_kd(
     wavelength: float,
     width: float,
     domain_length: float,
+    ply_thickness: float,
     n_plies: int,
     gamma_Y: float,
     theta_max: float,
     *,
     morphology_factor: float = 1.0,
     through_thickness_decay: bool = True,
-    decay_floor: float = 0.0,
 ) -> float:
     """Budiansky-Fleck knockdown averaged over the wrinkle profile.
 
@@ -158,16 +158,7 @@ def _profile_proportional_kd(
     with:
         |dz_w/dx|  = slope of the GaussianSinusoidal wrinkle profile
         M_f        = morphology factor (accounts for dual-wrinkle interaction)
-        Phi(z_p)   = decay_floor + (1 - decay_floor) * raw_p,
-                     raw_p = max(0, 1 - |p - p_mid| / p_mid)
-
-    The through-thickness term is a linear ply-index decay from 1.0 at the
-    midplane to ``decay_floor`` at the surface plies.  This is the same
-    grading used by the tension graded path, so the two loading modes treat
-    an embedded (graded) wrinkle consistently.  ``decay_floor`` is the
-    fraction of the wrinkle angle retained at the surface plies and is set
-    from the embedded-strip through-thickness reach (0 = waviness fully
-    decays to flat at the surfaces, 1 = no decay).
+        Phi(z_p)   = exp(-(z_p - T/2)^2 / A^2)   (through-thickness decay)
 
     When *through_thickness_decay* is False, Phi(z_p) = 1 for all plies
     (all plies see the same longitudinal profile).  This is appropriate
@@ -184,6 +175,8 @@ def _profile_proportional_kd(
         Gaussian envelope half-width w [mm].
     domain_length : float
         Specimen / domain length L_s [mm].
+    ply_thickness : float
+        Ply thickness [mm].
     n_plies : int
         Total number of plies.
     gamma_Y : float
@@ -195,19 +188,17 @@ def _profile_proportional_kd(
         for dual-wrinkle interaction (convex < 1.0, concave > 1.0,
         stack = 1.0, graded = 1.0).  Default 1.0.
     through_thickness_decay : bool
-        If True (default), apply the linear ply-index through-thickness
-        decay (1.0 at the midplane to ``decay_floor`` at the surfaces).
-        If False, all plies see the full wrinkle angle profile (Phi = 1).
-    decay_floor : float
-        Fraction of the wrinkle angle retained at the surface plies in the
-        graded through-thickness decay (0 = full decay to flat, 1 = no
-        decay).  Clamped by the caller to [0, 1].  Default 0.0.
+        If True (default), apply Gaussian through-thickness decay centred
+        at the midplane with scale = amplitude.  If False, all plies see
+        the full wrinkle angle profile (Phi = 1).
 
     Returns
     -------
     float
         Profile-averaged BF knockdown factor (0, 1].
     """
+    T = n_plies * ply_thickness
+    z_mid = T / 2.0
     L_s = domain_length
 
     # Longitudinal profile: compute |dz/dx| at each x-point
@@ -225,16 +216,12 @@ def _profile_proportional_kd(
     )
     theta_x = np.abs(np.arctan(dz_dx)) * morphology_factor  # M_f-scaled angle
 
-    # Average over plies and x-positions.  The through-thickness term is a
-    # linear ply-index decay from 1.0 at the midplane to decay_floor at the
-    # surface plies — identical to the tension graded path so both loading
-    # modes treat an embedded (graded) wrinkle consistently.
+    # Average over plies and x-positions
     kd_sum = 0.0
-    p_mid = (n_plies - 1) / 2.0
     for p in range(n_plies):
+        z_p = (p + 0.5) * ply_thickness
         if through_thickness_decay:
-            raw_p = max(0.0, 1.0 - abs(p - p_mid) / p_mid) if p_mid > 0 else 1.0
-            phi_p = decay_floor + (1.0 - decay_floor) * raw_p
+            phi_p = np.exp(-((z_p - z_mid) ** 2) / (amplitude ** 2))
         else:
             phi_p = 1.0
         theta_xz = theta_x * phi_p  # local angle at (x, z_p)
@@ -1027,12 +1014,12 @@ class WrinkleAnalysis:
                 wavelength=cfg.wavelength,
                 width=cfg.width,
                 domain_length=cfg.domain_length,
+                ply_thickness=cfg.ply_thickness,
                 n_plies=n_plies,
                 gamma_Y=gamma_Y_eff,
                 theta_max=theta_max,
                 morphology_factor=1.0,
                 through_thickness_decay=True,
-                decay_floor=cfg.decay_floor,
             )
             kd_compression = f_0 * kd_profile + (1.0 - f_0)
 


### PR DESCRIPTION
## Summary
This PR introduces `VALIDATION.md`, a comprehensive ledger that documents the evaluation history and decision rationale for all external papers assessed for inclusion in the WrinkleFE knockdown validation database.

## Key Changes
- **New file**: `VALIDATION.md` with structured documentation of:
  - Inclusion methodology defining what qualifies as a knockdown validation point
  - List of currently included datasets with citations
  - Detailed evaluation records for papers that were assessed but not included, with specific rationales
  - One deferred dataset pending model capability improvements (tracked in issue #161)
  - Placeholder for future identified papers pending evaluation

## Notable Details
- **Included datasets**: Three sources (Elhajjar 2025, Mukhopadhyay et al. 2015, Li et al. 2026) with material systems and test modes documented
- **Rejected papers**: Two papers (Varkonyi et al. 2020, Sun et al. 2025) with detailed technical rationales explaining failure-mechanism mismatches, geometry mismatches, missing data, or lack of measured strength values
- **Deferred dataset**: Li et al. (2025) multi-wrinkle compression study qualifies methodologically but is deferred pending FE model enhancements to capture amplitude-at-constant-angle effects (requires geometrically nonlinear progressive-damage analysis)
- **Diagnostic findings**: Documents a structural limitation where the current analytical and FE approaches reduce wrinkles to peak misalignment angle only, missing amplitude-dependent strength variations at constant angles

This ledger provides transparency into validation data quality decisions and serves as a reference for future paper evaluations.

https://claude.ai/code/session_01MaR8kh5uchCW7je3iuw8RJ