### PR TITLE
Fix boundary curvature to use D11/D22 (#149)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -85,6 +85,13 @@ class MeshData:
         Number of elements in y.
     nz : int
         Number of elements in z (= ``n_plies * nz_per_ply``).
+    laminate : Laminate, optional
+        The :class:`~wrinklefe.core.laminate.Laminate` the mesh was
+        generated from.  Attached by :meth:`WrinkleMesh.generate` so
+        downstream consumers (e.g. boundary-condition helpers that need
+        the bending-stiffness matrix ``D``) can recover it without a
+        separate plumbing path.  Defaults to ``None`` for hand-built
+        mesh fixtures that have no associated laminate.
     """
 
     nodes: np.ndarray
@@ -95,6 +102,7 @@ class MeshData:
     nx: int
     ny: int
     nz: int
+    laminate: Laminate | None = None
 
     # ---- derived quantities ------------------------------------------------
 
@@ -609,6 +617,7 @@ class WrinkleMesh:
             nx=self.nx,
             ny=self.ny,
             nz=self.nz,
+            laminate=self.laminate,
         )
 
         # Run basic quality checks

--- a/src/wrinklefe/solver/boundary.py
+++ b/src/wrinklefe/solver/boundary.py
@@ -597,14 +597,22 @@ class BoundaryHandler:
             z_coords = mesh.nodes[xmax_nodes, 2]
             z_mid = 0.5 * (z_coords.min() + z_coords.max())
 
-            # Estimate curvature: kappa_x = Mx / D11
-            # This is approximate; the user may need to refine.
-            # For now, apply linear displacement: ux(z) = kappa * (z - z_mid) * Lx
-            # We use a reference curvature scaled so the displacement is
-            # proportional to Mx.
-            # A more rigorous approach would use ABD inverse, but we keep it
-            # simple here.
-            kappa_x = load.Mx / 1.0  # user should normalise Mx appropriately
+            # Curvature from the laminate bending stiffness: kappa_x = Mx / D11
+            # (CLT moment-curvature relation, decoupled D-matrix form).
+            # Apply linear displacement: ux(z) = kappa_x * (z - z_mid) * Lx.
+            if mesh.laminate is None:
+                raise ValueError(
+                    "Cannot map Mx to a curvature boundary condition: the "
+                    "mesh has no attached laminate.  Use WrinkleMesh.generate() "
+                    "or attach a Laminate to MeshData.laminate."
+                )
+            D11 = float(mesh.laminate.D[0, 0])
+            if D11 == 0.0:
+                raise ValueError(
+                    "Laminate bending stiffness D11 is zero; cannot map Mx "
+                    "to a curvature boundary condition."
+                )
+            kappa_x = load.Mx / D11
 
             # Apply prescribed displacements on x_max, varying linearly with z
             if abs(load.Nx) == 0:
@@ -634,7 +642,20 @@ class BoundaryHandler:
             z_coords = mesh.nodes[ymax_nodes, 2]
             z_mid = 0.5 * (z_coords.min() + z_coords.max())
 
-            kappa_y = load.My / 1.0
+            # Curvature from the laminate bending stiffness: kappa_y = My / D22.
+            if mesh.laminate is None:
+                raise ValueError(
+                    "Cannot map My to a curvature boundary condition: the "
+                    "mesh has no attached laminate.  Use WrinkleMesh.generate() "
+                    "or attach a Laminate to MeshData.laminate."
+                )
+            D22 = float(mesh.laminate.D[1, 1])
+            if D22 == 0.0:
+                raise ValueError(
+                    "Laminate bending stiffness D22 is zero; cannot map My "
+                    "to a curvature boundary condition."
+                )
+            kappa_y = load.My / D22
 
             if abs(load.Ny) == 0 and abs(load.Nx) == 0:
                 bcs.append(BoundaryCondition(

--- a/tests/test_solver/test_boundary.py
+++ b/tests/test_solver/test_boundary.py
@@ -330,12 +330,14 @@ class TestPureMx:
         assert len(disp) == len(xmax)
         assert all(b.dofs == [0] for b in disp)
 
-    def test_linear_through_thickness_profile(self, bending_mesh):
-        """ux(z) = kappa_x * (z - z_mid) * Lx with the *current* contract
-        kappa_x = Mx / 1.0 (see #149).  Midplane node ux == 0; top &
-        bottom fibers equal and opposite."""
+    def test_linear_through_thickness_profile(self, bending_mesh,
+                                              two_ply_laminate):
+        """ux(z) = kappa_x * (z - z_mid) * Lx with the physically-correct
+        CLT contract kappa_x = Mx / D11 (see #149).  Midplane node ux == 0;
+        top & bottom fibers equal and opposite."""
         Lx, Ly, Lz = bending_mesh.domain_size
         Mx = 2.0
+        D11 = float(two_ply_laminate.D[0, 0])
         bcs = BoundaryHandler.load_state_to_bcs(LoadState(Mx=Mx), bending_mesh)
         disp = {int(b.node_ids[0]): b.value
                 for b in bcs if b.bc_type == "displacement"}
@@ -344,7 +346,7 @@ class TestPureMx:
         z_mid = 0.5 * (z.min() + z.max())
         for nid in xmax:
             zz = float(bending_mesh.nodes[nid, 2])
-            assert disp[nid] == pytest.approx(Mx * (zz - z_mid) * Lx)
+            assert disp[nid] == pytest.approx((Mx / D11) * (zz - z_mid) * Lx)
         # Midplane node (z == z_mid) has zero prescribed displacement.
         mid = [nid for nid in xmax
                if abs(float(bending_mesh.nodes[nid, 2]) - z_mid) < 1e-9]
@@ -356,16 +358,9 @@ class TestPureMx:
         bot = min(xmax, key=lambda n: bending_mesh.nodes[n, 2])
         assert disp[top] == pytest.approx(-disp[bot])
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Bug #149: kappa_x uses hard-coded 1.0 divisor, not D11. "
-               "Pins the physically-correct contract; flips green when "
-               "boundary.py is fixed.",
-    )
     def test_curvature_should_scale_with_D11(self, bending_mesh,
                                              two_ply_laminate):
-        """Physically kappa_x should be Mx / D11.  Currently it is Mx / 1.0,
-        so the top-fiber displacement is D11x too large."""
+        """Physically kappa_x must be Mx / D11 (fix for #149)."""
         Lx, Ly, Lz = bending_mesh.domain_size
         Mx = 2.0
         D11 = float(two_ply_laminate.D[0, 0])


### PR DESCRIPTION
Fixes #149.

## Summary
`BoundaryHandler.load_state_to_bcs` was computing bending curvature with a hard-coded unit divisor (`kappa_x = load.Mx / 1.0`) instead of dividing by the laminate bending stiffness `D11` / `D22` as the docstring promised. Every `Mx` / `My` bending result was off by a factor of `D11` / `D22` and the FE solve was converging to the wrong answer.

## Changes
- `src/wrinklefe/solver/boundary.py` — `kappa_x = load.Mx / D11`, `kappa_y = load.My / D22`, with `D11 = float(mesh.laminate.D[0, 0])` and `D22 = float(mesh.laminate.D[1, 1])`. Guards `mesh.laminate is None` and zero stiffness with clear `ValueError`s. Inline comments updated to match the docstring.
- `src/wrinklefe/core/mesh.py` — `MeshData` previously had no `laminate` attribute, so the docstring's promise of "the mesh's laminate" wasn't actually reachable. Added optional `laminate: Laminate | None = None` field and wired `WrinkleMesh.generate()` to attach `self.laminate`.
- `tests/test_solver/test_boundary.py` — removed the `pytest.mark.xfail(strict=True, ...)` on `test_curvature_should_scale_with_D11` (which pinned bug #149), and updated `test_linear_through_thickness_profile` to assert `(Mx / D11) * (z - z_mid) * Lx`.

## Test plan
- [x] Full suite: `881 passed`
- [x] All 27 boundary tests pass, including the formerly-xfail test
- [x] `grep -rn xfail tests/` — no remaining xfail markers

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_