### PR TITLE
Fix Streamlit y-slice to respect view mode (#77)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1270,6 +1270,25 @@ with tab_results:
                     horizontal=True,
                     key="viz_view_mode",
                 )
+                y_centers = fe["element_centers"][:, 1]
+                y_unique = np.unique(y_centers)
+
+                def _y_station_slider() -> float | None:
+                    """Render the shared keyed y-station slider.
+
+                    Uses a stable ``key`` so the chosen station is
+                    preserved across view-mode switches. Returns
+                    ``None`` if the mesh has no y-variation to scrub.
+                    """
+                    if y_unique.size <= 1:
+                        return None
+                    return st.select_slider(
+                        "y-station [mm]",
+                        options=[float(y) for y in y_unique],
+                        value=float(y_unique[len(y_unique) // 2]),
+                        key="viz_y_station",
+                    )
+
                 if view_mode == "Stress contour":
                     comp = st.selectbox(
                         "Stress component (Voigt)",
@@ -1284,6 +1303,24 @@ with tab_results:
                         component_label=comp[1],
                     )
                     st.plotly_chart(fig_3d, width="stretch")
+
+                    st.markdown("**y-slice scrubber**")
+                    y_station = _y_station_slider()
+                    if y_station is not None:
+                        slice_comp = st.selectbox(
+                            "Slice stress component",
+                            STRESS_COMPONENTS,
+                            index=2,
+                            format_func=lambda t: t[1],
+                            key="viz_slice_component",
+                        )
+                        fig_slice = streamlit_viz.y_slice_figure(
+                            fe["element_centers"], fe["elements"], fe["nodes"],
+                            fe["stress_per_elem"], slice_comp[0], y_station,
+                            component_label=slice_comp[1],
+                        )
+                        if fig_slice is not None:
+                            st.plotly_chart(fig_slice, width="stretch")
                 elif view_mode == "Deformed mesh":
                     scale = st.slider(
                         "Deformation exaggeration",
@@ -1300,6 +1337,10 @@ with tab_results:
                         scale=scale,
                     )
                     st.plotly_chart(fig_3d, width="stretch")
+                    # No y-slice for the deformed-mesh view: a stress
+                    # component picker would be confusing here and a
+                    # displacement-magnitude slice helper does not
+                    # exist. See issue #77.
                 else:
                     fi_dict = fe.get("fi_per_gauss", {})
                     fi_keys = list(fi_dict.keys())
@@ -1321,30 +1362,16 @@ with tab_results:
                         )
                         st.plotly_chart(fig_3d, width="stretch")
 
-                st.markdown("**y-slice scrubber**")
-                y_centers = fe["element_centers"][:, 1]
-                y_unique = np.unique(y_centers)
-                if y_unique.size > 1:
-                    y_station = st.select_slider(
-                        "y-station [mm]",
-                        options=[float(y) for y in y_unique],
-                        value=float(y_unique[len(y_unique) // 2]),
-                        key="viz_y_station",
-                    )
-                    slice_comp = st.selectbox(
-                        "Slice stress component",
-                        STRESS_COMPONENTS,
-                        index=2,
-                        format_func=lambda t: t[1],
-                        key="viz_slice_component",
-                    )
-                    fig_slice = streamlit_viz.y_slice_figure(
-                        fe["element_centers"], fe["elements"], fe["nodes"],
-                        fe["stress_per_elem"], slice_comp[0], y_station,
-                        component_label=slice_comp[1],
-                    )
-                    if fig_slice is not None:
-                        st.plotly_chart(fig_slice, width="stretch")
+                        st.markdown("**y-slice scrubber**")
+                        y_station = _y_station_slider()
+                        if y_station is not None:
+                            fig_slice = streamlit_viz.fi_y_slice_figure(
+                                fe["element_centers"], fe["elements"],
+                                fe["nodes"], fi_dict[crit_for_3d], y_station,
+                                criterion=crit_for_3d,
+                            )
+                            if fig_slice is not None:
+                                st.plotly_chart(fig_slice, width="stretch")
 
             with st.expander("Mesh statistics"):
                 st.write(

--- a/streamlit_viz.py
+++ b/streamlit_viz.py
@@ -276,3 +276,75 @@ def y_slice_figure(
     )
     fig.update_yaxes(scaleanchor="x", scaleratio=1)
     return fig
+
+
+def fi_y_slice_figure(
+    element_centers: np.ndarray,
+    elements: np.ndarray,
+    nodes: np.ndarray,
+    fi_per_gauss: np.ndarray,
+    y_station: float,
+    *,
+    criterion: str = "FI",
+) -> go.Figure | None:
+    """Filter elements at the given y-station and render a 2D scatter in
+    the (x, z) plane coloured by the per-element max failure index for
+    the given criterion.
+
+    Mirrors :func:`y_slice_figure` but uses a sequential (Reds) colour
+    scale starting at 0 since FI is non-negative.
+    """
+    yc = element_centers[:, 1]
+    unique_y = np.unique(yc)
+    if unique_y.size == 0:
+        return None
+    nearest_y = unique_y[np.argmin(np.abs(unique_y - y_station))]
+    mask = yc == nearest_y
+    if not mask.any():
+        return None
+
+    xs = element_centers[mask, 0]
+    zs = element_centers[mask, 2]
+    fi_max_per_elem = np.asarray(fi_per_gauss).max(axis=1)
+    vals = fi_max_per_elem[mask]
+    vmax = float(np.nanmax(vals)) if vals.size else 1.0
+    if not np.isfinite(vmax) or vmax <= 0.0:
+        vmax = 1.0
+
+    elem_node_xyz = nodes[elements[mask]]
+    dx = float(np.ptp(elem_node_xyz[:, :, 0], axis=1).mean()) if mask.sum() else 1.0
+    dz = float(np.ptp(elem_node_xyz[:, :, 2], axis=1).mean()) if mask.sum() else 1.0
+
+    fig = go.Figure(
+        go.Scatter(
+            x=xs,
+            y=zs,
+            mode="markers",
+            marker=dict(
+                size=14,
+                color=vals,
+                colorscale="Reds",
+                cmin=0.0,
+                cmax=vmax,
+                symbol="square",
+                line=dict(width=0),
+                colorbar=dict(title=f"FI ({criterion})"),
+            ),
+            hovertemplate=(
+                f"x = %{{x:.2f}} mm<br>z = %{{y:.3f}} mm"
+                f"<br>FI ({criterion}) = %{{marker.color:.3f}}<extra></extra>"
+            ),
+        )
+    )
+    fig.update_layout(
+        title=(
+            f"FI ({criterion}) at y ≈ {nearest_y:.2f} mm  ·  "
+            f"Δx≈{dx:.2f} mm  Δz≈{dz:.3f} mm"
+        ),
+        xaxis_title="x [mm]",
+        yaxis_title="z [mm]",
+        height=360,
+        margin=dict(l=10, r=10, t=50, b=10),
+    )
+    fig.update_yaxes(scaleanchor="x", scaleratio=1)
+    return fig


### PR DESCRIPTION
Fixes #77.

## Summary
The y-slice scrubber on the Results tab was rendered outside the view-mode `if/elif` block, so it always showed a "Slice stress component" selectbox and a stress-contour slice — even when the user had picked "Deformed mesh" or "Failure index". Moved the slice into per-view branches so it mirrors the active view.

## Changes
- `app.py` — y-slice block moved into each view-mode branch:
  - **Stress contour**: unchanged (existing selectbox + `y_slice_figure`).
  - **Deformed mesh**: slice hidden (no displacement-magnitude helper exists; explicit comment).
  - **Failure index**: renders an FI slice via the new `fi_y_slice_figure` using the same `crit_for_3d` chosen for the 3D view above. No stress-component picker.
  - Shared inner helper `_y_station_slider()` uses `key="viz_y_station"` so the y-station persists across mode switches.
- `streamlit_viz.py` — new `fi_y_slice_figure` (mirrors `y_slice_figure`, Reds colorscale starting at 0, colorbar/hover labeled by criterion).

## Test plan
- [x] Python syntax validated (`ast.parse`)
- [ ] Browser smoke test of all three view modes — could not run; `numpy` not available in the dev environment used. Please verify locally.
- [ ] Confirm y-station value persists across switching view modes.

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_