### PR TITLE
Use MORPHOLOGY_COLORS palette in plots_2d (#42)

### DIFF
--- a/src/wrinklefe/viz/plots_2d.py
+++ b/src/wrinklefe/viz/plots_2d.py
@@ -35,6 +35,7 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
 from wrinklefe.viz.style import (
+    ACCENT_GRAY,
     FIGSIZE_SINGLE_COLUMN,
     FIGSIZE_DOUBLE_COLUMN,
     FIGSIZE_SINGLE_TALL,
@@ -88,7 +89,7 @@ def plot_wrinkle_profile(
     x = np.linspace(xlo, xhi, n_points)
     z = profile.displacement(x)
 
-    ax.plot(x, z, color="#1f77b4", linewidth=1.5)
+    ax.plot(x, z, color=MORPHOLOGY_COLORS["stack"], linewidth=1.5)
     ax.axhline(0, color="0.6", linewidth=0.5, zorder=0)
     ax.set_xlabel("$x$ (mm)")
     ax.set_ylabel("$z$ (mm)")
@@ -157,14 +158,14 @@ def plot_dual_wrinkle_profiles(
     z_upper = p_upper.displacement(x)
     z_lower = p_lower.displacement(x)
 
-    ax.plot(x, z_upper, color="#1f77b4", linewidth=1.5, label="Upper wrinkle")
-    ax.plot(x, z_lower, color="#d62728", linewidth=1.5, label="Lower wrinkle")
+    ax.plot(x, z_upper, color=MORPHOLOGY_COLORS["stack"], linewidth=1.5, label="Upper wrinkle")
+    ax.plot(x, z_lower, color=MORPHOLOGY_COLORS["concave"], linewidth=1.5, label="Lower wrinkle")
 
     if show_gap:
         gap = z_upper - z_lower
         ax.fill_between(
             x, z_lower, z_upper,
-            alpha=0.15, color="#2ca02c", label="Interface gap",
+            alpha=0.15, color=MORPHOLOGY_COLORS["convex"], label="Interface gap",
         )
 
     ax.axhline(0, color="0.6", linewidth=0.5, zorder=0)
@@ -442,7 +443,7 @@ def plot_strength_distribution(
     else:
         ax.hist(
             strengths, bins=n_bins, density=True,
-            color="#1f77b4", alpha=0.7, edgecolor="white", linewidth=0.3,
+            color=MORPHOLOGY_COLORS["stack"], alpha=0.7, edgecolor="white", linewidth=0.3,
             label="Histogram",
         )
 
@@ -451,7 +452,7 @@ def plot_strength_distribution(
             from scipy.stats import gaussian_kde
             kde = gaussian_kde(strengths)
             x_kde = np.linspace(strengths.min(), strengths.max(), 300)
-            ax.plot(x_kde, kde(x_kde), color="#d62728", linewidth=1.5, label="KDE")
+            ax.plot(x_kde, kde(x_kde), color=MORPHOLOGY_COLORS["concave"], linewidth=1.5, label="KDE")
         except ImportError:
             pass
 
@@ -498,7 +499,7 @@ def plot_jensen_gap(
 
     labels = ["Overall"]
     values = [jensen_result.jensen_gap]
-    colors = ["#333333"]
+    colors = [ACCENT_GRAY]
 
     for morph, gap in sorted(jensen_result.gap_by_morphology.items()):
         labels.append(MORPHOLOGY_LABELS.get(morph, morph))
@@ -593,12 +594,12 @@ def plot_failure_envelope(
         safe_mask = ~failed
         ax.scatter(
             x_vals[safe_mask], y_vals[safe_mask],
-            c="#2ca02c", s=20, marker="o", label="Safe",
+            c=MORPHOLOGY_COLORS["convex"], s=20, marker="o", label="Safe",
             edgecolors="0.3", linewidths=0.3,
         )
         ax.scatter(
             x_vals[failed], y_vals[failed],
-            c="#d62728", s=20, marker="x", label="Failed",
+            c=MORPHOLOGY_COLORS["concave"], s=20, marker="x", label="Failed",
             linewidths=1.0,
         )
         ax.legend(loc="best", fontsize=7)

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -70,6 +70,14 @@ MORPHOLOGY_LABELS: dict[str, str] = {
 }
 """Display labels for morphology types with phase offset notation."""
 
+ACCENT_GRAY: str = "#333333"
+"""Neutral dark gray accent color for non-morphology emphasis elements.
+
+Used for overall/aggregate series in plots where a morphology color would
+be misleading (e.g. the ``Overall`` bar in a Jensen-gap bar chart that sits
+alongside per-morphology bars).
+"""
+
 
 # ======================================================================
 # Standard figure sizes


### PR DESCRIPTION
Fixes #42.

## Summary
`plots_2d.py` hard-coded the same morphology hex codes that `viz/style.py` already centralizes in `MORPHOLOGY_COLORS`. Replaced all the literals with palette lookups so a future restyle is a one-dict change.

## Changes
- `src/wrinklefe/viz/plots_2d.py` — 9 literals replaced:
  - 3× `"#1f77b4"` → `MORPHOLOGY_COLORS["stack"]`
  - 3× `"#d62728"` → `MORPHOLOGY_COLORS["concave"]`
  - 2× `"#2ca02c"` → `MORPHOLOGY_COLORS["convex"]`
  - 1× `"#333333"` → new `ACCENT_GRAY` constant
- `src/wrinklefe/viz/style.py` — added `ACCENT_GRAY: str = "#333333"` for non-morphology emphasis (e.g. the "Overall" bar in `plot_jensen_gap`).
- Import block updated to bring `ACCENT_GRAY` alongside the existing `MORPHOLOGY_COLORS` import.

## Test plan
- [x] `python -m py_compile` clean on both files
- [x] `grep -E '"#[0-9a-fA-F]{6}"' plots_2d.py` returns no matches
- [x] `ruff check` shows no new findings vs. base
- [ ] pytest — not run in the dev environment (`numpy`/`matplotlib` unavailable in the sandbox where this branch was authored). Will be exercised by CI on this PR.

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_