### PR TITLE
Add E3 to PlyDiscount matrix-failure docstring (#33)

### DIFF
--- a/src/wrinklefe/failure/progressive.py
+++ b/src/wrinklefe/failure/progressive.py
@@ -16,7 +16,7 @@ Degradation Rules
 Properties degraded depend on the failure mode:
 
 - **Fibre failure** (tension or compression): E1, nu12, nu13
-- **Matrix failure** (tension or compression): E2, G12, G23, nu23
+- **Matrix failure** (tension or compression): E2, E3, G12, G23, nu23
 - **Shear failure**: G12, G13, or G23 (depending on plane)
 - **Through-thickness failure**: E3, G13, G23
 

--- a/tests/test_failure/test_progressive.py
+++ b/tests/test_failure/test_progressive.py
@@ -53,7 +53,7 @@ class TestPlyDiscount:
         assert_allclose(degraded.nu13, x850_material.nu13 * 0.01, rtol=1e-10)
 
     def test_matrix_failure_degrades_E2(self, x850_material):
-        """Matrix failure should degrade E2, G12, G23, nu23."""
+        """Matrix failure should degrade E2, E3, G12, G23, nu23."""
         model = PlyDiscount(residual_factor=0.01)
         failure = _make_failure(1.2, "matrix_tension")
         degraded = model.degrade(x850_material, failure)


### PR DESCRIPTION
Fixes #33.

## Summary
`PlyDiscount.degrade` degrades `E3` in the matrix-failure branch (since commit 2e89527), but the surrounding documentation still listed only `E2, G12, G23, nu23`. Updated the stale text so the docstring matches the implementation.

The issue pointed at the class-level docstring around line 137, but that docstring was already correct. The only remaining incomplete copy of `"E2, G12, G23, nu23"` was the **module-level** docstring at `src/wrinklefe/failure/progressive.py:19`. Found via grep.

## Changes
- `src/wrinklefe/failure/progressive.py` — module-level docstring:
  - before: `- **Matrix failure** (tension or compression): E2, G12, G23, nu23`
  - after:  `- **Matrix failure** (tension or compression): E2, E3, G12, G23, nu23`
- `tests/test_failure/test_progressive.py` — one test docstring had the same incomplete list; updated for consistency.

## Test plan
- [x] Confirmed `PlyDiscount.degrade` (lines 177-182) really does set `props["E3"] = material.E3 * r` alongside E2, G12, G23, nu23 in the matrix-tension / matrix-compression branch
- [x] Docstring-only change; no behavior change

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_