### PR TITLE
Use quadratic-root reserve factor in Tsai-Wu evaluator (#19)

### DIFF
--- a/src/wrinklefe/failure/evaluator.py
+++ b/src/wrinklefe/failure/evaluator.py
@@ -226,6 +226,9 @@ class FailureEvaluator:
         ply_fi: dict[str, np.ndarray] = {
             c.name: np.zeros(n_plies) for c in self.criteria
         }
+        ply_rf: dict[str, np.ndarray] = {
+            c.name: np.full(n_plies, np.inf) for c in self.criteria
+        }
         ply_modes: dict[str, list[str]] = {
             c.name: [""] * n_plies for c in self.criteria
         }
@@ -247,6 +250,7 @@ class FailureEvaluator:
             for criterion in self.criteria:
                 result = criterion.evaluate(stress_6, material)
                 ply_fi[criterion.name][k] = result.index
+                ply_rf[criterion.name][k] = result.reserve_factor
                 ply_modes[criterion.name][k] = result.mode
 
         # Build FPF and LPF for each criterion
@@ -256,12 +260,17 @@ class FailureEvaluator:
         for criterion in self.criteria:
             name = criterion.name
             fi_array = ply_fi[name]
+            rf_array = ply_rf[name]
             modes = ply_modes[name]
 
-            # FPF: ply with the maximum FI (first to fail under load scaling)
-            fpf_ply = int(np.argmax(fi_array))
+            # FPF: the first ply to fail under proportional load scaling is
+            # the one with the smallest reserve factor (load factor to FI=1).
+            # For criteria linear in load scale this is equivalent to argmax FI,
+            # but for nonlinear criteria (e.g. Tsai-Wu, which is a quadratic
+            # polynomial in load scale) it can differ.
+            fpf_ply = int(np.argmin(rf_array))
             fpf_fi = float(fi_array[fpf_ply])
-            fpf_lf = 1.0 / fpf_fi if fpf_fi > 0.0 else float("inf")
+            fpf_lf = float(rf_array[fpf_ply])
 
             fpf[name] = {
                 "fi": fpf_fi,
@@ -275,7 +284,7 @@ class FailureEvaluator:
             # degradation.  Here we report the same ply as the most critical.)
             lpf_ply = int(np.argmax(fi_array))
             lpf_fi = float(fi_array[lpf_ply])
-            lpf_lf = 1.0 / lpf_fi if lpf_fi > 0.0 else float("inf")
+            lpf_lf = float(rf_array[lpf_ply])
 
             lpf[name] = {
                 "fi": lpf_fi,
@@ -468,9 +477,14 @@ class FailureEvaluator:
 
             for criterion in self.criteria:
                 name = criterion.name
-                fi_max = float(report.ply_failure_indices[name].max())
-                # Strength ratio = 1 / FI  (scale at which failure occurs)
-                sr = 1.0 / fi_max if fi_max > 0.0 else 1.0e12
+                # Strength ratio = the smallest per-ply load scale R that
+                # drives any ply to its failure surface. For criteria linear
+                # in load scale this equals 1/FI_max; for nonlinear criteria
+                # (e.g. Tsai-Wu, quadratic in R) it does not. The FPF
+                # load_factor already encodes the correct quadratic root.
+                sr = float(report.fpf[name]["load_factor"])
+                if not np.isfinite(sr):
+                    sr = 1.0e12
 
                 envelopes[name][i, 0] = sr * np.cos(theta)
                 envelopes[name][i, 1] = sr * np.sin(theta)

--- a/tests/test_failure/test_tsai_wu.py
+++ b/tests/test_failure/test_tsai_wu.py
@@ -119,3 +119,54 @@ class TestTsaiWuMixed:
         result = criterion.evaluate(stress, material)
         R = result.reserve_factor
         assert R**2 * Q + R * L == pytest.approx(1.0, abs=1e-10)
+
+    def test_reserve_factor_asymmetric_material(self, criterion):
+        """Asymmetric material (Xt != Xc, Yt != Yc): R must satisfy the
+        quadratic R^2 Q + R L = 1, and must NOT equal the naive 1/FI."""
+        mat = OrthotropicMaterial(
+            Xt=1500.0, Xc=1200.0,
+            Yt=50.0, Yc=200.0,
+            Zt=50.0, Zc=200.0,
+            S12=80.0, S13=80.0, S23=60.0,
+        )
+        s1, s2, t12 = 0.35 * mat.Xt, 0.25 * mat.Yt, 0.15 * mat.S12
+        stress = np.array([s1, s2, 0.0, 0.0, 0.0, t12])
+
+        F1 = 1.0 / mat.Xt - 1.0 / mat.Xc
+        F2 = 1.0 / mat.Yt - 1.0 / mat.Yc
+        F11 = 1.0 / (mat.Xt * mat.Xc)
+        F22 = 1.0 / (mat.Yt * mat.Yc)
+        F66 = 1.0 / mat.S12 ** 2
+        F12 = -0.5 * np.sqrt(F11 * F22)
+
+        L = F1 * s1 + F2 * s2
+        Q = F11 * s1**2 + F22 * s2**2 + 2.0 * F12 * s1 * s2 + F66 * t12**2
+
+        result = criterion.evaluate(stress, mat)
+        R = result.reserve_factor
+
+        # The polynomial identity that defines R.
+        assert R**2 * Q + R * L == pytest.approx(1.0, abs=1e-10)
+
+        # And L must be meaningfully nonzero so this test would expose a
+        # 1/FI bug -- i.e. the correct R must differ from 1/FI.
+        assert abs(L) > 1e-6
+        naive_rf = 1.0 / result.index
+        assert abs(R - naive_rf) > 1e-3 * R
+
+    def test_reserve_factor_symmetric_strengths_equals_one_over_sqrt_fi(self):
+        """When Xt == Xc, Yt == Yc, etc., F1 = F2 = F3 = 0, so L = 0 and the
+        polynomial reduces to R^2 Q = 1, giving R = 1/sqrt(FI) (NOT 1/FI)."""
+        mat = OrthotropicMaterial(
+            Xt=1500.0, Xc=1500.0,
+            Yt=100.0, Yc=100.0,
+            Zt=100.0, Zc=100.0,
+            S12=80.0, S13=80.0, S23=60.0,
+        )
+        criterion = TsaiWuCriterion(f12_star=-0.5)
+        stress = np.array([
+            0.4 * mat.Xt, 0.3 * mat.Yt, 0.0, 0.0, 0.0, 0.2 * mat.S12,
+        ])
+        result = criterion.evaluate(stress, mat)
+        expected_R = 1.0 / np.sqrt(result.index)
+        assert result.reserve_factor == pytest.approx(expected_R, rel=1e-12)


### PR DESCRIPTION
Fixes #19.

## Summary
The Tsai-Wu reserve factor was being reported as `1/FI`, but the Tsai-Wu polynomial is **quadratic** in load scale `R`:

```
f(R·σ) = R² · Q + R · L     where  Q = F_ij σ_i σ_j,  L = F_i σ_i
```

For asymmetric materials (Xt ≠ Xc) the linear term `L` is nonzero, so `1/FI` systematically miscomputes the load factor. The reserve factor is the positive root of `R² · Q + R · L = 1` — i.e. `R = (-L + sqrt(L² + 4·Q)) / (2·Q)`.

The quadratic-root formula was actually already present in `tsai_wu.py`. The real bug was in `evaluator.py`: `evaluate_laminate` was reporting `1/FI` for the load factor, and `strength_ratio_envelope` was recomputing `1/FI_max` instead of using the per-ply quadratic root.

## Changes
- `src/wrinklefe/failure/evaluator.py`:
  - `evaluate_laminate` — stores per-ply reserve factors and picks FPF via `argmin(rf_array)`, reporting `rf` as the load factor. For linear-in-load criteria this matches `argmax(FI)`; for Tsai-Wu it produces the correct quadratic root.
  - `strength_ratio_envelope` — reads `report.fpf[name]["load_factor"]` instead of recomputing `1/FI_max`, so the envelope is correct for asymmetric materials.
- `tests/test_failure/test_tsai_wu.py`:
  - `test_reserve_factor_asymmetric_material` — Xt=1500, Xc=1200, Yt=50, Yc=200; asserts the polynomial identity `R²·Q + R·L ≈ 1`, that `|L| > 1e-6`, and that `R` differs measurably from `1/FI`.
  - `test_reserve_factor_symmetric_strengths_equals_one_over_sqrt_fi` — verifies the symmetric-strengths limit gives `R = 1/sqrt(FI)`, not `1/FI`.

## Behaviour change (heads-up for review)
Callers of `FailureEvaluator.evaluate_laminate` with Tsai-Wu in the criteria list may see **different FPF ply / load_factor outputs** for asymmetric materials — this is the bug fix, not a regression. `ply_failure_indices` shape and `FailureResult` signature are unchanged.

## Test plan
- [x] Full suite: **882 passed, 1 xfailed** (xfail is the pre-existing `test_curvature_should_scale_with_D11`, unrelated; cleared once #163 merges)
- [x] No existing tests had to change — the LaRC05 `1/FI` test is criterion-specific and untouched
- [x] New asymmetric-material test verifies the polynomial identity to numerical tolerance
- [x] New symmetric-material test verifies the `1/sqrt(FI)` limit

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_