### PR TITLE
Cull interior faces and vectorize 3D plot face/colour assembly (#80)

### DIFF
--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -61,14 +61,27 @@ if TYPE_CHECKING:
 
 # Each hex8 element has 6 faces, each defined by 4 node local indices.
 # Node ordering: bottom CCW (0,1,2,3), top CCW (4,5,6,7).
-_HEX_FACES = [
-    [0, 1, 2, 3],  # bottom (-z)
-    [4, 5, 6, 7],  # top (+z)
-    [0, 1, 5, 4],  # front (-y)
-    [2, 3, 7, 6],  # back (+y)
-    [0, 3, 7, 4],  # left (-x)
-    [1, 2, 6, 5],  # right (+x)
-]
+#
+# Face index convention used throughout this module (must stay aligned
+# with ``_HEX_FACE_AXIS`` and ``_HEX_FACE_SIDE`` below):
+#   0: -z (bottom), 1: +z (top), 2: -y (front), 3: +y (back),
+#   4: -x (left),   5: +x (right)
+_HEX_FACES = np.array(
+    [
+        [0, 1, 2, 3],  # 0: bottom (-z)
+        [4, 5, 6, 7],  # 1: top (+z)
+        [0, 1, 5, 4],  # 2: front (-y)
+        [2, 3, 7, 6],  # 3: back (+y)
+        [0, 3, 7, 4],  # 4: left (-x)
+        [1, 2, 6, 5],  # 5: right (+x)
+    ],
+    dtype=np.int64,
+)
+
+# For each face index above: which structured-grid axis it lies on
+# (0 = i / x, 1 = j / y, 2 = k / z) and which side ("min" = -, "max" = +).
+_HEX_FACE_AXIS = np.array([2, 2, 1, 1, 0, 0], dtype=np.int64)
+_HEX_FACE_SIDE = np.array([0, 1, 0, 1, 0, 1], dtype=np.int64)  # 0 = min, 1 = max
 
 
 # ======================================================================
@@ -100,36 +113,160 @@ def _sample_elements(mesh: "MeshData", max_elements: int = 2000) -> np.ndarray:
     return np.arange(0, n_elem, step)
 
 
-def _collect_faces(
+def _is_full_structured_set(mesh: "MeshData", elem_indices: np.ndarray) -> bool:
+    """Return True if ``elem_indices`` covers the full structured mesh.
+
+    The fast structured-mesh boundary-culling shortcut is only valid when
+    we are rendering every element in the natural ``(i, j, k)`` order; any
+    sampling / cropping creates "holes" that the structured rule cannot
+    detect, so the caller must fall back to the general algorithm.
+    """
+    nx = getattr(mesh, "nx", None)
+    ny = getattr(mesh, "ny", None)
+    nz = getattr(mesh, "nz", None)
+    if nx is None or ny is None or nz is None:
+        return False
+    expected = int(nx) * int(ny) * int(nz)
+    if expected != mesh.n_elements:
+        return False
+    if elem_indices.size != expected:
+        return False
+    # _create_hex_connectivity ravels (k, j, i) so flat index 0..N-1 is the
+    # natural order; we accept the trivial arange(N) covering the full mesh.
+    if elem_indices[0] != 0 or elem_indices[-1] != expected - 1:
+        return False
+    # Cheap monotonicity check (avoid full equality on large arrays).
+    return bool(np.array_equal(elem_indices, np.arange(expected)))
+
+
+def _structured_boundary_mask(mesh: "MeshData") -> np.ndarray:
+    """Boolean mask over ``(n_elements, 6)`` marking boundary faces.
+
+    Uses the structured-grid rule: face ``f`` of element ``(i, j, k)`` is
+    on the domain boundary iff its grid index along the face's axis is
+    ``0`` (for ``-`` faces) or ``n_axis - 1`` (for ``+`` faces).
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n_elements, 6)`` boolean array.
+    """
+    nx, ny, nz = int(mesh.nx), int(mesh.ny), int(mesh.nz)
+    # Element flat index = k*(ny*nx) + j*nx + i  (see _create_hex_connectivity)
+    flat = np.arange(nx * ny * nz, dtype=np.int64)
+    ii = flat % nx
+    jj = (flat // nx) % ny
+    kk = flat // (nx * ny)
+
+    grid = np.stack([ii, jj, kk], axis=1)            # (N, 3)
+    axis_size = np.array([nx, ny, nz], dtype=np.int64)
+
+    # For each of the 6 faces, look up the element's index on that face's
+    # axis and compare against either 0 (min side) or n-1 (max side).
+    coord_on_axis = grid[:, _HEX_FACE_AXIS]           # (N, 6)
+    max_on_axis = axis_size[_HEX_FACE_AXIS] - 1       # (6,)
+    is_min_face = (_HEX_FACE_SIDE == 0)               # (6,) bool
+    boundary = np.where(
+        is_min_face[np.newaxis, :],
+        coord_on_axis == 0,
+        coord_on_axis == max_on_axis[np.newaxis, :],
+    )
+    return boundary
+
+
+def _general_boundary_mask(
+    mesh: "MeshData", elem_indices: np.ndarray
+) -> np.ndarray:
+    """Boolean mask over ``(len(elem_indices), 6)`` for arbitrary subsets.
+
+    A face is on the boundary iff its sorted node-id tuple appears in the
+    subset exactly once.  This handles sampled / cropped / cutaway meshes
+    where the structured shortcut would be incorrect.
+    """
+    if elem_indices.size == 0:
+        return np.zeros((0, 6), dtype=bool)
+
+    # (n_sub, 6, 4) node ids per face for each selected element.
+    conn = mesh.elements[elem_indices]                # (n_sub, 8)
+    face_nodes = conn[:, _HEX_FACES]                  # (n_sub, 6, 4)
+
+    # Sort node ids within each face so shared faces hash identically.
+    face_keys = np.sort(face_nodes, axis=2)           # (n_sub, 6, 4)
+    flat_keys = face_keys.reshape(-1, 4)              # (n_sub*6, 4)
+
+    # Identify unique faces and how many elements claim each one.
+    _, inverse, counts = np.unique(
+        flat_keys, axis=0, return_inverse=True, return_counts=True
+    )
+    boundary_flat = counts[inverse] == 1
+    return boundary_flat.reshape(elem_indices.size, 6)
+
+
+def _gather_boundary_faces(
     mesh: "MeshData",
     elem_indices: np.ndarray,
-    nodes: Optional[np.ndarray] = None,
-) -> list[np.ndarray]:
-    """Collect face vertex arrays for a set of elements.
+    nodes: np.ndarray,
+    elem_scalar: Optional[np.ndarray] = None,
+) -> tuple[np.ndarray, Optional[np.ndarray]]:
+    """Return boundary-face vertices (and optional per-face scalars).
+
+    Combines structured-mesh culling (when the full mesh is selected) with
+    a general face-counting fallback, and vectorizes the face-vertex
+    gather so we never iterate Python-side over elements.
 
     Parameters
     ----------
     mesh : MeshData
         The finite element mesh.
     elem_indices : np.ndarray
-        Element indices to include.
-    nodes : np.ndarray, optional
-        Node coordinates to use. If ``None``, uses ``mesh.nodes``.
+        Element indices to include (output of :func:`_sample_elements`).
+    nodes : np.ndarray
+        Node coordinates of shape ``(n_nodes, 3)`` — typically the
+        (possibly deformed) coordinates used for rendering.
+    elem_scalar : np.ndarray, optional
+        Shape ``(n_elements,)`` per-element scalar (e.g. mean stress).
+        If given, the returned scalar array is per-boundary-face,
+        broadcasting the element value onto all of its boundary faces.
 
     Returns
     -------
-    list of np.ndarray
-        Each entry is shape ``(4, 3)`` -- the four vertices of a face.
+    face_verts : np.ndarray
+        Shape ``(n_boundary_faces, 4, 3)``.
+    face_scalar : np.ndarray or None
+        Shape ``(n_boundary_faces,)`` if ``elem_scalar`` was provided.
     """
-    if nodes is None:
-        nodes = mesh.nodes
-    faces = []
-    for eid in elem_indices:
-        conn = mesh.elements[eid]
-        for face_local in _HEX_FACES:
-            verts = nodes[conn[face_local]]  # (4, 3)
-            faces.append(verts)
-    return faces
+    if elem_indices.size == 0:
+        return np.empty((0, 4, 3), dtype=nodes.dtype), (
+            None if elem_scalar is None else np.empty((0,), dtype=float)
+        )
+
+    if _is_full_structured_set(mesh, elem_indices):
+        mask = _structured_boundary_mask(mesh)        # (n_elem, 6)
+        # Sub-selection follows elem_indices (which equals arange(N)).
+        sub_conn = mesh.elements                      # (n_elem, 8)
+    else:
+        mask = _general_boundary_mask(mesh, elem_indices)
+        sub_conn = mesh.elements[elem_indices]        # (n_sub, 8)
+
+    # Vectorized vertex gather: (n_sub, 6, 4) node ids -> (n_sub, 6, 4, 3) coords
+    face_nodes = sub_conn[:, _HEX_FACES]              # (n_sub, 6, 4)
+    face_verts_all = nodes[face_nodes]                # (n_sub, 6, 4, 3)
+
+    face_verts = face_verts_all[mask]                 # (n_bnd, 4, 3)
+
+    face_scalar: Optional[np.ndarray] = None
+    if elem_scalar is not None:
+        if _is_full_structured_set(mesh, elem_indices):
+            elem_vals = elem_scalar
+        else:
+            elem_vals = elem_scalar[elem_indices]
+        # Broadcast each element's value over its 6 faces, then mask.
+        scalar_per_face = np.broadcast_to(
+            elem_vals[:, np.newaxis], (elem_vals.shape[0], 6)
+        )
+        face_scalar = scalar_per_face[mask].astype(float, copy=False)
+
+    return face_verts, face_scalar
 
 
 # ======================================================================
@@ -173,11 +310,12 @@ def plot_mesh_3d(
         return ax
 
     elem_idx = _sample_elements(mesh, max_elements)
-    faces = _collect_faces(mesh, elem_idx)
+    # Cull interior (shared) faces and assemble vertex array vectorized.
+    face_verts, _ = _gather_boundary_faces(mesh, elem_idx, mesh.nodes)
 
     edge_color = "0.3" if show_edges else "none"
     poly = Poly3DCollection(
-        faces,
+        face_verts,
         facecolors=(0.7, 0.85, 1.0, face_alpha),
         edgecolors=edge_color,
         linewidths=0.2,
@@ -255,18 +393,22 @@ def plot_displacement_3d(
 
     elem_idx = _sample_elements(mesh, max_elements)
 
-    # Compute face colors from average node values
-    face_verts = []
-    face_values = []
-    for eid in elem_idx:
-        conn = mesh.elements[eid]
-        for face_local in _HEX_FACES:
-            face_nodes = conn[face_local]
-            verts = deformed_nodes[face_nodes]
-            face_verts.append(verts)
-            face_values.append(np.mean(node_scalar[face_nodes]))
+    # Cull interior faces and gather boundary-face vertices vectorized.
+    face_verts, _ = _gather_boundary_faces(mesh, elem_idx, deformed_nodes)
 
-    face_values = np.array(face_values)
+    # For the per-face scalar we average the node scalar over the 4 face
+    # nodes.  Reconstruct the same boundary mask used inside
+    # ``_gather_boundary_faces`` and apply it to the (n_sub, 6) array of
+    # mean-node-scalar values.
+    if _is_full_structured_set(mesh, elem_idx):
+        _mask = _structured_boundary_mask(mesh)
+        _sub_conn = mesh.elements
+    else:
+        _mask = _general_boundary_mask(mesh, elem_idx)
+        _sub_conn = mesh.elements[elem_idx]
+    _face_node_ids = _sub_conn[:, _HEX_FACES]            # (n_sub, 6, 4)
+    _face_mean = node_scalar[_face_node_ids].mean(axis=2)  # (n_sub, 6)
+    face_values = _face_mean[_mask].astype(float, copy=False)
     vmin = face_values.min()
     vmax = face_values.max()
     if abs(vmax - vmin) < 1e-15:
@@ -380,18 +522,14 @@ def plot_stress_contour_3d(
 
     elem_idx = _sample_elements(mesh, max_elements)
 
-    face_verts = []
-    face_values = []
-    for eid in elem_idx:
-        conn = mesh.elements[eid]
-        s_val = elem_stress[eid]
-        for face_local in _HEX_FACES:
-            face_nodes = conn[face_local]
-            verts = deformed_nodes[face_nodes]
-            face_verts.append(verts)
-            face_values.append(s_val)
-
-    face_values = np.array(face_values)
+    # Cull interior (shared) faces and broadcast each element's stress onto
+    # its surviving boundary faces in a single vectorized pass.
+    face_verts, face_values = _gather_boundary_faces(
+        mesh, elem_idx, deformed_nodes, elem_scalar=elem_stress
+    )
+    # ``_gather_boundary_faces`` returns ``None`` only when no elem_scalar was
+    # supplied; here we always supplied one.
+    assert face_values is not None
     vmin = face_values.min()
     vmax = face_values.max()
     if abs(vmax - vmin) < 1e-15:
@@ -505,17 +643,20 @@ def plot_buckling_mode(
 
     elem_idx = _sample_elements(mesh, max_elements)
 
-    face_verts = []
-    face_values = []
-    for eid in elem_idx:
-        conn = mesh.elements[eid]
-        for face_local in _HEX_FACES:
-            face_nodes = conn[face_local]
-            verts = deformed_nodes[face_nodes]
-            face_verts.append(verts)
-            face_values.append(np.mean(uz[face_nodes]))
+    # Cull interior faces and gather boundary-face vertices vectorized.
+    face_verts, _ = _gather_boundary_faces(mesh, elem_idx, deformed_nodes)
 
-    face_values = np.array(face_values)
+    # Per-face scalar = average of uz at the 4 face nodes, computed on the
+    # same (n_sub, 6) lattice and then masked down to boundary faces.
+    if _is_full_structured_set(mesh, elem_idx):
+        _mask = _structured_boundary_mask(mesh)
+        _sub_conn = mesh.elements
+    else:
+        _mask = _general_boundary_mask(mesh, elem_idx)
+        _sub_conn = mesh.elements[elem_idx]
+    _face_node_ids = _sub_conn[:, _HEX_FACES]
+    _face_mean = uz[_face_node_ids].mean(axis=2)
+    face_values = _face_mean[_mask].astype(float, copy=False)
     vmin = face_values.min()
     vmax = face_values.max()
     if abs(vmax - vmin) < 1e-15:

--- a/tests/test_viz/test_plots_3d_boundary_culling.py
+++ b/tests/test_viz/test_plots_3d_boundary_culling.py
@@ -1,0 +1,173 @@
+"""Tests for boundary-face culling and vectorization in :mod:`wrinklefe.viz.plots_3d`.
+
+The 3D matplotlib plots used to emit every face of every sampled hex element
+(6N faces).  For a structured ``(nx, ny, nz)`` mesh, interior elements share
+five of their six faces with neighbours, so only the outer "skin"
+``2 * (nx*ny + ny*nz + nz*nx)`` faces are actually visible.  These tests pin
+down that culling and verify that the public API still renders without
+raising on a small mesh.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.core.mesh import MeshData, WrinkleMesh
+from wrinklefe.viz import plot_mesh_3d
+from wrinklefe.viz.plots_3d import (
+    _gather_boundary_faces,
+    _general_boundary_mask,
+    _structured_boundary_mask,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_figures():
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def _build_structured_mesh(nx: int, ny: int, nz: int) -> MeshData:
+    """Build a small structured hex mesh via ``WrinkleMesh`` (real factory).
+
+    ``nz`` is realised through the laminate: we pick a ply count equal to
+    ``nz`` with one element per ply, so the resulting mesh has exactly
+    ``nx * ny * nz`` hex elements.
+    """
+    mat = OrthotropicMaterial()
+    laminate = Laminate.symmetric(
+        [0] * ((nz + 1) // 2), material=mat, ply_thickness=0.1
+    )
+    # symmetric([0]*k) produces 2k plies; if nz is odd we built one extra ply,
+    # so trim by truncating ``nz`` to the actual count.
+    actual_nz = laminate.n_plies
+    gen = WrinkleMesh(
+        laminate=laminate,
+        wrinkle_config=None,
+        Lx=float(nx),
+        Ly=float(ny),
+        nx=nx,
+        ny=ny,
+        nz_per_ply=1,
+    )
+    mesh = gen.generate()
+    assert mesh.nx == nx and mesh.ny == ny and mesh.nz == actual_nz
+    return mesh
+
+
+def test_structured_boundary_count_3x3x3():
+    """3x3x3 hex mesh: boundary faces = 2*(3*3+3*3+3*3) = 54, NOT 27*6 = 162."""
+    mesh = _build_structured_mesh(3, 3, 4)  # 4 plies, so nz=4
+    elem_idx = np.arange(mesh.n_elements)
+
+    face_verts, _ = _gather_boundary_faces(mesh, elem_idx, mesh.nodes)
+
+    nx, ny, nz = mesh.nx, mesh.ny, mesh.nz
+    expected = 2 * (nx * ny + ny * nz + nz * nx)
+    total = mesh.n_elements * 6
+    assert face_verts.shape == (expected, 4, 3)
+    assert expected < total, (
+        f"culling should strictly reduce face count "
+        f"(got expected={expected}, total={total})"
+    )
+
+
+def test_structured_boundary_count_2x2x2():
+    """2x2x2 mesh: every element is on the boundary, so faces = 2*(4+4+4) = 24."""
+    mesh = _build_structured_mesh(2, 2, 2)
+    elem_idx = np.arange(mesh.n_elements)
+    face_verts, _ = _gather_boundary_faces(mesh, elem_idx, mesh.nodes)
+    assert face_verts.shape == (24, 4, 3)
+
+
+def test_structured_mask_shape_and_count():
+    """The direct mask helper matches the analytical boundary-face count."""
+    mesh = _build_structured_mesh(3, 3, 4)
+    mask = _structured_boundary_mask(mesh)
+    assert mask.shape == (mesh.n_elements, 6)
+    expected = 2 * (mesh.nx * mesh.ny + mesh.ny * mesh.nz + mesh.nz * mesh.nx)
+    assert int(mask.sum()) == expected
+
+
+def test_general_mask_matches_structured_on_full_mesh():
+    """Face-counting fallback agrees with the structured shortcut."""
+    mesh = _build_structured_mesh(3, 3, 4)
+    elem_idx = np.arange(mesh.n_elements)
+    structured = _structured_boundary_mask(mesh)
+    general = _general_boundary_mask(mesh, elem_idx)
+    assert general.shape == structured.shape
+    assert np.array_equal(general, structured)
+
+
+def test_general_mask_handles_cutaway_subset():
+    """On a sampled / cropped subset the general mask treats element-internal
+    shared faces correctly: removing one element should expose a face that
+    was hidden in the full mesh.
+    """
+    mesh = _build_structured_mesh(2, 2, 2)
+    # Drop the (0, 0, 0) element from the subset; the +x, +y and +z faces of
+    # the now-removed element used to be shared with neighbours, so those
+    # neighbours' opposing faces should now be on the boundary.
+    full = np.arange(mesh.n_elements)
+    subset = full[1:]  # 7 elements
+    mask = _general_boundary_mask(mesh, subset)
+    full_mask = _general_boundary_mask(mesh, full)
+    # Surface area of the 8-element cube = 24.  Removing one corner element
+    # exposes 3 new internal faces and removes 3 outer faces from the
+    # boundary set, so the count stays at 24.
+    assert int(mask.sum()) == 24
+    # The full-mesh count should also be 24 (2x2x2 = all elements on the
+    # outer skin).
+    assert int(full_mask.sum()) == 24
+
+
+def test_plot_mesh_3d_smoke():
+    """plot_mesh_3d on a small mesh renders without raising and emits faces."""
+    mesh = _build_structured_mesh(3, 3, 2)
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    out_ax = plot_mesh_3d(mesh, ax=ax)
+    assert out_ax is ax
+    # Force a draw so any deferred matplotlib error surfaces here.
+    fig.canvas.draw()
+    plt.close(fig)
+
+
+def test_plot_mesh_3d_bounding_box_preserved():
+    """Boundary faces span the same x/y/z bounding box as the full mesh.
+
+    Interior faces (which we now drop) are strictly inside the bounding
+    box, so culling them must not change the visible extent.
+    """
+    mesh = _build_structured_mesh(3, 3, 4)
+    elem_idx = np.arange(mesh.n_elements)
+    face_verts, _ = _gather_boundary_faces(mesh, elem_idx, mesh.nodes)
+
+    # Each boundary face is (4, 3); flatten to all vertex coords.
+    rendered = face_verts.reshape(-1, 3)
+    np.testing.assert_allclose(rendered.min(axis=0), mesh.nodes.min(axis=0))
+    np.testing.assert_allclose(rendered.max(axis=0), mesh.nodes.max(axis=0))
+
+
+def test_gather_with_elem_scalar_broadcasts_correctly():
+    """Per-element scalar values are broadcast onto every surviving face."""
+    mesh = _build_structured_mesh(2, 2, 2)
+    elem_idx = np.arange(mesh.n_elements)
+    elem_scalar = np.arange(mesh.n_elements, dtype=float)
+
+    face_verts, face_scalar = _gather_boundary_faces(
+        mesh, elem_idx, mesh.nodes, elem_scalar=elem_scalar
+    )
+    assert face_scalar is not None
+    assert face_scalar.shape == (face_verts.shape[0],)
+    # All scalar values come from the element pool.
+    assert set(np.unique(face_scalar)).issubset(set(elem_scalar))


### PR DESCRIPTION
Closes #80.

## Summary
`plots_3d.py` was rendering all six faces of every sampled hex element — 5 of every 6 faces were hidden behind neighbours but still allocated, coloured, and drawn. Added boundary-face culling + NumPy-vectorized face/colour assembly. On a 20×20×24 mesh that's a ~21× reduction in face count (57,600 → 2,720) with no API change.

## Algorithm
Two helpers in `src/wrinklefe/viz/plots_3d.py`:

- **`_structured_boundary_mask(mesh)`** — for the natural full-mesh case, a face is boundary iff its element's `(i, j, k)` coordinate on that face's axis is `0` (minus faces) or `n_axis - 1` (plus faces). Single vectorized `np.where`.
- **`_general_boundary_mask(mesh, elem_indices)`** — fallback for sampled / cutaway subsets. Sort each candidate face's 4 node IDs; keep faces whose sorted tuple appears in the subset exactly once (`np.unique(..., return_counts=True)`).

`_gather_boundary_faces` dispatches based on `_is_full_structured_set(...)`, gathers vertices via `nodes[mesh.elements[:, _HEX_FACES]]` (shape `(n_sub, 6, 4, 3)`), and broadcasts the optional per-element scalar onto surviving faces — all NumPy, no Python per-element loop.

## API preserved
All four `plot_*` signatures, defaults, and return types are unchanged. `app.py`, Streamlit, and CLI call sites need no updates.

## Tests
New `tests/test_viz/test_plots_3d_boundary_culling.py` (8 tests):
- boundary-face count for 3×3×4 (= 66) and 2×2×2 (= 24)
- structured mask == general mask on a full mesh
- cutaway subset re-exposes interior faces
- `plot_mesh_3d` smoke render
- bounding-box preserved across culling
- per-element scalar broadcast survives the mask

## Test plan
- [x] Full suite: **889 passed** in 160s
- [ ] **Visual diff caveat** — please eyeball the deformed-mesh and stress/buckling 3D figures in `app.py` once before merging. The interior-faces-vanishing change is expected; colour mapping on the outer skin should be identical. When sampling kicks in (`n_elem > max_elements`), the general fallback culls faces shared between sampled elements, which can make the skin look slightly denser than before when sampled elements happen to be adjacent. If the previous "every sampled element renders all 6 faces" look is desired anywhere, the dispatch in `_gather_boundary_faces` is the single place to change.

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_