### PR TITLE
Pin morphology default-decay BC + fibre-angle parity with regression tests (#17, #18)

### DIFF
--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -500,10 +500,26 @@ class WrinkleConfiguration:
         The decay is 1.0 at the wrinkle interface plies (``p == k`` and
         ``p == k + 1``), 0.0 at the laminate outer surfaces (``p == 0``
         and ``p == n_plies - 1``), and interpolates linearly in between.
+        Specifically:
 
-        Degenerate cases where the wrinkle interface coincides with an
-        outer surface (``k == 0`` or ``k + 1 == n_plies - 1``) collapse
-        to: 1.0 only on the interface ply, 0.0 elsewhere.
+        - For ``p <= k``: ``decay = p / k`` (so ``p=0 -> 0``, ``p=k -> 1``).
+        - For ``p > k``:  ``decay = (n_plies - 1 - p) / ((n_plies - 1) - (k + 1))``
+          (so ``p=k+1 -> 1``, ``p=n_plies-1 -> 0``).
+
+        Both call sites (:meth:`apply_to_nodes` and
+        :meth:`fiber_angles_at_nodes`) MUST use this helper so the
+        displacement field and the local fibre-angle field share one
+        through-thickness profile (issues #17, #18).
+
+        Degenerate edge cases:
+
+        - If ``n_plies <= 1`` the helper returns 1.0 (single-ply laminate).
+        - If ``k == 0`` (wrinkle at the bottom outer surface) the ``p <= k``
+          branch collapses to ``1.0 at p=0``; the ``p > k`` side uses the
+          normal top ramp ``(n_plies - 1 - p) / ((n_plies - 1) - 1)``.
+        - If ``k + 1 == n_plies - 1`` (wrinkle at the top outer surface)
+          the ``p > k`` branch collapses to ``1.0 at p=k+1``; the ``p <= k``
+          side uses the normal bottom ramp ``p / k``.
         """
         if n_plies <= 1:
             return 1.0

--- a/tests/test_morphology_apply_nodes.py
+++ b/tests/test_morphology_apply_nodes.py
@@ -529,3 +529,100 @@ def test_partial_ply_ids_decay_stays_synced():
     npt.assert_allclose(
         decay_from_disp, decay_from_angle, rtol=1e-12, atol=1e-14
     )
+
+
+# ----------------------------------------------------------------------
+# Issues #17 / #18: BC vanishes at outer surfaces AND displacement and
+# fibre-angle fields share the same default-mode decay.
+# ----------------------------------------------------------------------
+
+class TestIssue17_18DefaultDecayBC:
+    """Regression tests pinning the contract from issues #17 and #18.
+
+    Issue #17: in default decay mode the through-thickness displacement
+    must vanish at BOTH outer surfaces (``p == 0`` and ``p == n_plies-1``)
+    and be unity at the interface plies (``p == k`` and ``p == k+1``).
+
+    Issue #18: ``apply_to_nodes`` and ``fiber_angles_at_nodes`` must apply
+    the SAME decay function in default mode -- so a ply whose geometric
+    displacement is zero must also see zero misalignment-angle decay.
+    """
+
+    @pytest.mark.parametrize("k", [1, 2, 3, 5, 8])
+    @pytest.mark.parametrize("n_plies", [4, 8, 12])
+    def test_outer_surfaces_zero_decay(self, k, n_plies):
+        """#17: bottom (p=0) and top (p=n-1) outer surfaces -> decay=0."""
+        if k >= n_plies - 1:
+            pytest.skip(f"k={k} invalid for n_plies={n_plies}")
+        prof = GaussianSinusoidal(
+            amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
+        )
+        cfg = _single_config(prof, ply_interface=k)
+        # Crest -> dz at any ply == amplitude * decay.
+        nodes, ply = _strip(np.array([0.0]), n_plies=n_plies)
+        out = cfg.apply_to_nodes(nodes, ply, n_plies=n_plies)
+        dz = (out - nodes)[:, 2]
+        # The two surfaces are explicitly zero.
+        if k > 0:
+            npt.assert_allclose(dz[ply == 0], 0.0, atol=1e-15)
+        if k + 1 < n_plies - 1:
+            npt.assert_allclose(dz[ply == n_plies - 1], 0.0, atol=1e-15)
+
+    @pytest.mark.parametrize("k", [1, 2, 3, 5])
+    @pytest.mark.parametrize("n_plies", [4, 8, 12])
+    def test_interface_plies_unit_decay(self, k, n_plies):
+        """#17: interface plies (p=k and p=k+1) carry the full profile."""
+        if k >= n_plies - 1:
+            pytest.skip(f"k={k} invalid for n_plies={n_plies}")
+        prof = GaussianSinusoidal(
+            amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
+        )
+        cfg = _single_config(prof, ply_interface=k)
+        nodes, ply = _strip(np.array([0.0]), n_plies=n_plies)
+        out = cfg.apply_to_nodes(nodes, ply, n_plies=n_plies)
+        dz = (out - nodes)[:, 2]
+        amp = prof.amplitude
+        npt.assert_allclose(dz[ply == k][0], amp, rtol=1e-12)
+        npt.assert_allclose(dz[ply == k + 1][0], amp, rtol=1e-12)
+
+    @pytest.mark.parametrize("k", [1, 2, 3, 5])
+    @pytest.mark.parametrize("n_plies", [4, 8, 12])
+    def test_displacement_and_angle_share_decay_default_mode(
+        self, k, n_plies
+    ):
+        """#18: at every ply, decay extracted from the displacement field
+        must equal decay extracted from the fibre-angle field. In
+        particular: the outer-surface plies that get zero displacement
+        must also get zero angle (no inflated misalignment downstream)."""
+        if k >= n_plies - 1:
+            pytest.skip(f"k={k} invalid for n_plies={n_plies}")
+        prof = GaussianSinusoidal(
+            amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
+        )
+        cfg = _single_config(prof, ply_interface=k)
+        # Pick a non-symmetric x where both profile value and slope are
+        # non-zero so we can divide cleanly.
+        x = 2.5
+        prof_val = prof.displacement(np.array([x]))[0]
+        ang_base = np.arctan(np.abs(prof.slope(np.array([x]))[0]))
+
+        nodes, ply = _strip(np.array([x]), n_plies=n_plies)
+        dz = (cfg.apply_to_nodes(nodes, ply, n_plies=n_plies) - nodes)[:, 2]
+        ang = cfg.fiber_angles_at_nodes(nodes, ply, n_plies=n_plies)
+
+        decay_from_disp = dz / prof_val
+        decay_from_angle = ang / ang_base
+        npt.assert_allclose(
+            decay_from_disp,
+            decay_from_angle,
+            rtol=1e-12,
+            atol=1e-14,
+        )
+        # Surface plies (when not degenerate) must be exactly zero in BOTH
+        # fields -- this is what #18 was about.
+        if k > 0:
+            assert dz[ply == 0][0] == 0.0
+            assert ang[ply == 0][0] == 0.0
+        if k + 1 < n_plies - 1:
+            assert dz[ply == n_plies - 1][0] == 0.0
+            assert ang[ply == n_plies - 1][0] == 0.0


### PR DESCRIPTION
Closes #17, closes #18.

## Summary
Both #17 (default-mode decay should vanish at the outer surfaces, matching the docstring) and #18 (`fiber_angles_at_nodes` should use the same decay as `apply_to_nodes`) were already structurally fixed on `main` by the `src/` layout migration — the `_ply_decay` helper exists and both call sites use it.

This PR formalises the regression coverage so a future refactor can't silently undo either fix, and corrects a misleading docstring in the helper itself.

## Changes
- `src/wrinklefe/core/morphology.py` — tightened the `_ply_decay` docstring. The previous wording claimed "0.0 elsewhere" when `k=0` or `k+1=n_plies-1`, which is wrong: the *opposite* side keeps the normal linear ramp. No behavioural change.
- `tests/test_morphology_apply_nodes.py` — new `TestIssue17_18DefaultDecayBC` with three parametrized regression tests (sweeping `k` ∈ {1,2,3,5,8} and `n_plies` ∈ {4,8,12}):
  1. `test_outer_surfaces_zero_decay` — `apply_to_nodes` displacement is exactly 0 at `p=0` and `p=n-1`.
  2. `test_interface_plies_unit_decay` — decay = 1 at `p=k` and `p=k+1`.
  3. `test_displacement_and_angle_share_decay_default_mode` — the implicit decay extracted from `apply_to_nodes` matches the one from `fiber_angles_at_nodes` element-for-element, and both fields hit zero at the outer surfaces.

## Decay formula (re-stated for the record, unchanged in code)
- `p ≤ k`: `p / k` (edge case `k == 0` → returns `1.0` at `p==0`)
- `p > k`: `(n_plies - 1 - p) / ((n_plies - 1) - (k + 1))` (edge case `k+1 == n_plies-1` → returns `1.0` at `p==k+1`)
- `n_plies ≤ 1` → `1.0`

## Other decay modes confirmed untouched
- `uniform` — decay=1 everywhere (covered by existing tests).
- `graded` — linear from mid to floor at surfaces (parity pinned by `TestGradedDecayParity`).
- `stack` / `convex` / `concave` — phase-offset presets that wrap dual-wrinkle configs and use the same default decay.

## Test plan
- [x] Full suite: **912 passed, 8 skipped** (skips are `parametrize` guards for `k >= n_plies - 1`)
- [x] No pre-existing tests had to be flipped
- [x] Validation cases (`test_elhajjar_validation.py`, `test_tension_validation.py`) all still pass — no shifts

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_