### PR TITLE
Document intentional omission of pyvistaqt/PyQt6 in pyproject (#11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
     "pyvista>=0.42",
 ]
 
+# Note: wrinklefe is Streamlit-first / CLI-only and has no desktop GUI code.
+# pyvistaqt and PyQt6 are intentionally NOT listed (including not in any extra)
+# so plain `pip install wrinklefe` produces a headless-safe environment. See
+# requirements.txt for the rationale.
 [project.optional-dependencies]
 export = ["meshio>=5.3"]
 dev = [


### PR DESCRIPTION
Closes #11.

## Summary
Issue #11 (critical packaging bug: `pyvistaqt` hard dep but `PyQt6` gated behind `[gui]` extra) was already cleaned up — **both packages have been removed entirely** from `pyproject.toml`. The project is Streamlit-first / CLI-only and has no desktop GUI code (`grep -rn "pyvistaqt\|PyQt\|BackgroundPlotter"` across `src/`, `app.py`, `streamlit_viz.py`, and `tests/` returns zero hits). `requirements.txt:9` already states "PyQt6 / pyvistaqt deliberately do not appear here".

This PR adds a short comment block to `pyproject.toml` documenting the intentional omission so the next audit doesn't re-file the issue. No code changes; no `[gui]` extra is created (there'd be nothing to install with it).

## Changes
- `pyproject.toml` — 4-line comment block immediately before `[project.optional-dependencies]` explaining that `pyvistaqt` / `PyQt6` are intentionally omitted because the project is headless.

## Test plan
- [x] Full suite: **880 passed, 1 xfailed** in 327s (xfail cleared by #163)
- [x] `tomllib` re-parses cleanly
- [x] README untouched (no GUI section to revise; current `pip install wrinklefe` instructions are correct for a headless-only project)

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_