### PR TITLE
Add progress callback and granular Streamlit progress bar (#74)

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ import sys
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Callable, Optional
 
 import matplotlib
 
@@ -647,6 +648,15 @@ with st.sidebar:
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Module-level progress callback slot used to bridge the cached analysis
+# function (which can only accept hashable arguments) to the Streamlit
+# progress UI.  Set by the run handler before the cache miss path
+# executes, cleared afterwards.  Cache hits never invoke this — by
+# design, since cached results return instantly and there is nothing to
+# report progress on.
+_PROGRESS_CALLBACK: Optional[Callable[[str, float], None]] = None
+
+
 @st.cache_data(show_spinner=False)
 def run_analysis_cached(cfg_payload: tuple) -> dict:
     """Cached analysis run. cfg_payload is a hashable tuple of config items."""
@@ -670,7 +680,10 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         nz_per_ply=cfg_dict.get("nz_per_ply", 1),
         analytical_only=cfg_dict["analytical_only"],
     )
-    result = WrinkleAnalysis(cfg).run(analytical_only=cfg_dict["analytical_only"])
+    result = WrinkleAnalysis(cfg).run(
+        analytical_only=cfg_dict["analytical_only"],
+        progress_callback=_PROGRESS_CALLBACK,
+    )
 
     fe: dict | None = None
     if not cfg_dict["analytical_only"] and result.field_results is not None:
@@ -822,6 +835,24 @@ if run_clicked or _demo_pending:
                 "Use the **Stop** button in the top-right toolbar to "
                 "cancel a long FE solve."
             )
+        # Granular per-phase progress bar.  On a cache hit `run_analysis_cached`
+        # returns instantly without invoking the callback, so the bar simply
+        # stays at its initial value before the status flips to "complete".
+        # On a cache miss the callback fires at each phase boundary inside
+        # WrinkleAnalysis.run() (mesh build, analytical, FE assembly, FE
+        # solve, failure, retention) so the user sees which step the solver
+        # is on instead of an opaque spinner.
+        progress_bar = st.progress(0.0, text="Initializing…")
+
+        def _progress_cb(label: str, fraction: float) -> None:
+            try:
+                progress_bar.progress(fraction, text=label)
+            except Exception:
+                # Never let progress reporting break the analysis.
+                pass
+
+        global _PROGRESS_CALLBACK
+        _PROGRESS_CALLBACK = _progress_cb
         try:
             results = run_analysis_cached(cfg_payload)
         except ValueError as exc:
@@ -850,6 +881,13 @@ if run_clicked or _demo_pending:
             with st.expander("Traceback"):
                 st.exception(exc)
             st.stop()
+        finally:
+            _PROGRESS_CALLBACK = None
+        # Ensure the bar shows full completion even on cache hits.
+        try:
+            progress_bar.progress(1.0, text="Analysis complete")
+        except Exception:
+            pass
         st.write("Done.")
         status.update(label="Analysis complete", state="complete", expanded=False)
 

--- a/app.py
+++ b/app.py
@@ -851,7 +851,6 @@ if run_clicked or _demo_pending:
                 # Never let progress reporting break the analysis.
                 pass
 
-        global _PROGRESS_CALLBACK
         _PROGRESS_CALLBACK = _progress_cb
         try:
             results = run_analysis_cached(cfg_payload)

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field, fields, replace
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -724,7 +724,11 @@ class WrinkleAnalysis:
     # Main entry point
     # ------------------------------------------------------------------
 
-    def run(self, analytical_only: Optional[bool] = None) -> AnalysisResults:
+    def run(
+        self,
+        analytical_only: Optional[bool] = None,
+        progress_callback: Optional[Callable[[str, float], None]] = None,
+    ) -> AnalysisResults:
         """Execute the complete analysis pipeline.
 
         Parameters
@@ -734,6 +738,14 @@ class WrinkleAnalysis:
             solve, failure evaluation, retention factors) and return only
             the analytical predictions.  If None (default), the
             ``AnalysisConfig.analytical_only`` field is used.
+        progress_callback : callable, optional
+            Optional progress reporter invoked at each phase boundary as
+            ``progress_callback(label, fraction)`` where ``label`` is a
+            short human-readable phase name and ``fraction`` is the
+            cumulative completion in ``[0, 1]``.  Defaults to ``None``
+            (no reporting), so non-Streamlit callers (CLI, tests) are
+            unaffected.  The callback always fires at least once with
+            ``fraction == 1.0`` on successful completion.
 
         Steps
         -----
@@ -755,6 +767,23 @@ class WrinkleAnalysis:
         if analytical_only is None:
             analytical_only = cfg.analytical_only
         results = AnalysisResults(config=cfg)
+
+        # Phase weights (sum to 1.0 on the full FE path).  The FE solve
+        # dominates wall-clock for typical mesh densities, so it gets the
+        # largest slice.  In analytical-only mode the analytical step is
+        # rescaled to 1.0 below.
+        #
+        #   build mesh / wrinkle geom : 0.05
+        #   analytical predictions    : 0.05
+        #   FE assembly (mesh build)  : 0.15
+        #   FE solve                  : 0.50
+        #   failure evaluation        : 0.15  (stress recovery + criteria)
+        #   retention factors         : 0.10
+        def _report(label: str, fraction: float) -> None:
+            if progress_callback is not None:
+                progress_callback(label, max(0.0, min(1.0, float(fraction))))
+
+        _report("Building laminate", 0.0)
 
         # 1. Build laminate
         laminate = self._build_laminate()
@@ -789,12 +818,17 @@ class WrinkleAnalysis:
             )
         results.wrinkle_config = wrinkle_config
 
+        _report("Computing analytical predictions", 0.05)
+
         # 3. Analytical predictions
         self._compute_analytical(results, wrinkle_config)
 
         # In analytical-only mode, skip mesh, solve, failure, and retention.
         if analytical_only:
+            _report("Analytical predictions complete", 1.0)
             return results
+
+        _report("Assembling FE mesh", 0.10)
 
         # 4. Generate mesh
         mesh_gen = WrinkleMesh(
@@ -812,6 +846,8 @@ class WrinkleAnalysis:
         # 4b. Mesh-based max fiber angle (accounts for decay mode)
         results.mesh_max_angle_rad = float(np.max(mesh.fiber_angles)) if mesh.fiber_angles.size > 0 else 0.0
 
+        _report("Solving FE system", 0.25)
+
         # 5. Static FE solve
         solver = StaticSolver(mesh, laminate)
         bcs = BoundaryHandler.compression_bcs(
@@ -822,11 +858,17 @@ class WrinkleAnalysis:
         )
         results.field_results = field_results
 
+        _report("Evaluating failure criteria", 0.75)
+
         # 6. Failure evaluation on FE field
         self._evaluate_failure(results, laminate, field_results, mesh)
 
+        _report("Computing retention factors", 0.90)
+
         # 6b. Retention factor (baseline pristine comparison)
         self._compute_retention_factors(results, laminate)
+
+        _report("Analysis complete", 1.0)
 
         return results
 

--- a/tests/test_analysis_progress.py
+++ b/tests/test_analysis_progress.py
@@ -1,0 +1,139 @@
+"""Tests for the progress_callback parameter on WrinkleAnalysis.run().
+
+Verifies the fix for issue #74: ``WrinkleAnalysis.run()`` accepts an
+optional ``progress_callback`` so the Streamlit UI (and other callers)
+can display a granular per-phase progress bar instead of an opaque
+spinner.  The callback must be invoked multiple times with
+monotonically non-decreasing fractions in ``[0, 1]`` and must finish at
+exactly ``1.0``.  Calls without the kwarg must continue to work
+identically.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.core.material import MaterialLibrary
+
+
+def _tiny_analytical_config() -> AnalysisConfig:
+    """Smallest possible analytical-only config — runs in well under 1 s."""
+    return AnalysisConfig(
+        amplitude=0.183,
+        wavelength=16.0,
+        width=12.0,
+        morphology="stack",
+        loading="compression",
+        material=MaterialLibrary().get("IM7_8552"),
+        angles=[0, 45, -45, 90, 90, -45, 45, 0],
+        interface_1=3,
+        interface_2=4,
+        ply_thickness=0.183,
+        applied_strain=-0.005,
+        analytical_only=True,
+        verbose=False,
+    )
+
+
+def _tiny_fe_config() -> AnalysisConfig:
+    """Smallest viable FE config so the test stays under a second."""
+    return AnalysisConfig(
+        amplitude=0.183,
+        wavelength=16.0,
+        width=12.0,
+        morphology="stack",
+        loading="compression",
+        material=MaterialLibrary().get("IM7_8552"),
+        angles=[0, 45, -45, 90, 90, -45, 45, 0],
+        interface_1=3,
+        interface_2=4,
+        ply_thickness=0.183,
+        applied_strain=-0.005,
+        nx=4,
+        ny=2,
+        nz_per_ply=1,
+        domain_width=8.0,
+        analytical_only=False,
+        verbose=False,
+    )
+
+
+def _assert_progress_trace_valid(trace: List[Tuple[str, float]]) -> None:
+    """Common invariants every progress trace must satisfy."""
+    assert len(trace) >= 2, (
+        f"progress_callback should fire at least twice (got {len(trace)}): {trace}"
+    )
+
+    fractions = [frac for _, frac in trace]
+    for frac in fractions:
+        assert 0.0 <= frac <= 1.0, (
+            f"progress fraction out of [0, 1]: {frac} in {trace}"
+        )
+
+    # Monotonically non-decreasing.
+    for prev, nxt in zip(fractions, fractions[1:]):
+        assert nxt >= prev, (
+            f"progress fraction decreased: {prev} -> {nxt} in {trace}"
+        )
+
+    # Final report must be exactly 1.0.
+    assert fractions[-1] == pytest.approx(1.0), (
+        f"final progress must be 1.0, got {fractions[-1]}: {trace}"
+    )
+
+    # Every label must be a non-empty string.
+    for label, _ in trace:
+        assert isinstance(label, str) and label, (
+            f"progress label must be a non-empty string: {label!r}"
+        )
+
+
+def test_progress_callback_analytical_only():
+    """Callback fires through the analytical-only path and ends at 1.0."""
+    trace: List[Tuple[str, float]] = []
+
+    def cb(label: str, fraction: float) -> None:
+        trace.append((label, fraction))
+
+    cfg = _tiny_analytical_config()
+    WrinkleAnalysis(cfg).run(progress_callback=cb)
+
+    _assert_progress_trace_valid(trace)
+
+
+def test_progress_callback_full_fe_path():
+    """Callback fires through every FE phase boundary and ends at 1.0."""
+    trace: List[Tuple[str, float]] = []
+
+    def cb(label: str, fraction: float) -> None:
+        trace.append((label, fraction))
+
+    cfg = _tiny_fe_config()
+    WrinkleAnalysis(cfg).run(progress_callback=cb)
+
+    _assert_progress_trace_valid(trace)
+    # The FE path must surface strictly more phases than analytical-only
+    # (mesh, solve, failure, retention all in addition to laminate/analytical).
+    assert len(trace) >= 5, (
+        f"FE path should report >=5 phases, got {len(trace)}: {trace}"
+    )
+
+
+def test_run_without_callback_is_unaffected():
+    """Existing callers that do not pass progress_callback see no change."""
+    cfg = _tiny_analytical_config()
+    # Must not raise and must return a populated result.
+    result = WrinkleAnalysis(cfg).run()
+    assert result is not None
+    assert result.analytical_strength_MPa > 0.0
+
+
+def test_progress_callback_keyword_only_is_optional():
+    """progress_callback defaults to None and may be passed positionally as None."""
+    cfg = _tiny_analytical_config()
+    # Explicit None is equivalent to omitting the argument.
+    result = WrinkleAnalysis(cfg).run(progress_callback=None)
+    assert result is not None


### PR DESCRIPTION
Closes #74.

## Summary
Replaces the coarse "Running analysis..." spinner in the Streamlit app with a granular progress bar that surfaces the current FE phase and a weighted completion fraction. Adds a `progress_callback` hook on `WrinkleAnalysis.run()` so non-Streamlit callers (CLI, tests) keep working unchanged.

## Phases instrumented (cumulative fractions, weighted by typical cost)

| Phase | Start | Weight |
|---|---|---|
| Building laminate | 0.00 | 0.05 |
| Computing analytical predictions | 0.05 | 0.05 |
| Assembling FE mesh | 0.10 | 0.15 |
| **Solving FE system** | **0.25** | **0.50** |
| Evaluating failure criteria | 0.75 | 0.15 |
| Computing retention factors | 0.90 | 0.10 |
| Complete | 1.00 | — |

In analytical-only mode the final callback fires at 1.0 right after the analytical step.

## Changes
- `src/wrinklefe/analysis.py`:
  - `WrinkleAnalysis.run(progress_callback: Optional[Callable[[str, float], None]] = None)`. Fraction is clamped to `[0, 1]` inside the internal `_report` helper.
  - Default `None` preserves existing API for CLI / tests.
- `app.py`:
  - Streamlit `st.progress(0.0, text="...")` driven by the callback.
  - Cache plumbing: `@st.cache_data` can't hash the callback, so it's threaded via a module-level `_PROGRESS_CALLBACK` slot the cache wrapper sets/clears in `finally`. Cache hits return instantly without firing the callback (as the issue called out — nothing to report); on miss, the bar is nudged to 1.0 in either case so the UI ends in a consistent state.
- `tests/test_analysis_progress.py` (new, 4 tests):
  1. Analytical-only path: callback fires, fractions monotonic in [0,1], ends at 1.0.
  2. Full FE path: same invariants plus ≥5 phases reported.
  3. Existing `run()` call without kwarg still works.
  4. Explicit `progress_callback=None` equivalent to omitting.

## Test plan
- [x] Full suite: **887 passed** in 149s
- [x] `streamlit run app.py --server.headless true --server.port 8765` boots cleanly with the new code (Uvicorn served; no import or runtime errors at startup)
- [ ] Did NOT drive a full analysis run through a browser session — please eyeball once before merging to confirm the phase labels look right end-to-end.

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_