### PR TITLE
Vectorize boundary_faces and trim Plotly vertex payload (#78)

### DIFF
--- a/streamlit_viz.py
+++ b/streamlit_viz.py
@@ -36,25 +36,52 @@ HEX_FACES: np.ndarray = np.array(
 def boundary_faces(elements: np.ndarray) -> np.ndarray:
     """Boundary faces of a hex mesh, with parent element id.
 
+    A face is on the boundary iff its sorted node-id tuple appears
+    exactly once across the mesh — i.e. it is not shared with a
+    neighbouring element. Implemented vectorized with NumPy: no Python
+    loops over elements, which keeps the cost dominated by a single
+    ``np.unique`` over ``6 * n_elements`` rows.
+
+    Parameters
+    ----------
+    elements : np.ndarray
+        Shape ``(n_elements, 8)`` hex8 connectivity.
+
     Returns
     -------
-    (n_boundary_faces, 5) array. Columns 0-3 are global node indices in
-    the element's local face ordering; column 4 is the parent element id.
+    np.ndarray
+        ``(n_boundary_faces, 5)`` array.  Columns 0-3 are global node
+        indices in the element's local face ordering (so quad winding
+        is preserved for downstream triangulation); column 4 is the
+        parent element id.
     """
-    face_owners: dict[tuple[int, ...], list[tuple[int, int]]] = {}
-    for ei in range(elements.shape[0]):
-        conn = elements[ei]
-        for fi, face in enumerate(HEX_FACES):
-            key = tuple(sorted(int(v) for v in conn[face]))
-            face_owners.setdefault(key, []).append((ei, fi))
+    elements = np.asarray(elements, dtype=np.int64)
+    n_elem = elements.shape[0]
+    if n_elem == 0:
+        return np.empty((0, 5), dtype=np.int64)
 
-    out: list[list[int]] = []
-    for owners in face_owners.values():
-        if len(owners) == 1:
-            ei, fi = owners[0]
-            face = HEX_FACES[fi]
-            out.append([int(elements[ei][n]) for n in face] + [ei])
-    return np.asarray(out, dtype=np.int64)
+    # (n_elem, 6, 4) global node ids per face in local winding order.
+    face_nodes = elements[:, HEX_FACES]
+    # Sort along the 4-node axis so shared faces hash identically
+    # regardless of the two parent elements' local winding.
+    face_keys = np.sort(face_nodes, axis=2).reshape(-1, 4)
+
+    # np.unique on axis=0 sorts rows lexicographically; counts==1 picks
+    # out the unshared (boundary) faces.
+    _, inverse, counts = np.unique(
+        face_keys, axis=0, return_inverse=True, return_counts=True
+    )
+    boundary_flat = counts[inverse] == 1            # (n_elem*6,)
+
+    # Parent element id for each flat face row.
+    elem_ids = np.repeat(np.arange(n_elem, dtype=np.int64), HEX_FACES.shape[0])
+
+    # Keep the original (non-sorted) winding for the boundary faces.
+    flat_nodes = face_nodes.reshape(-1, 4)
+    out = np.empty((int(boundary_flat.sum()), 5), dtype=np.int64)
+    out[:, :4] = flat_nodes[boundary_flat]
+    out[:, 4] = elem_ids[boundary_flat]
+    return out
 
 
 def quads_to_triangles(quad_faces: np.ndarray) -> np.ndarray:
@@ -106,13 +133,26 @@ def mesh3d_figure(
     bf = boundary_faces(elements)
     tri = quads_to_triangles(bf)
 
+    # Trim the vertex payload so Plotly receives ONLY nodes that the
+    # boundary triangles reference; on a structured hex brick this is
+    # O(surface) instead of O(volume).  Re-index the triangle node ids
+    # to point into the compact vertex array.
+    if tri.shape[0] > 0:
+        kept_nodes, remap = np.unique(tri[:, :3].ravel(), return_inverse=True)
+        verts = np.asarray(vertices)[kept_nodes]
+        tri_ijk = remap.reshape(-1, 3).astype(np.int64, copy=False)
+    else:
+        kept_nodes = np.empty(0, dtype=np.int64)
+        verts = np.asarray(vertices)[:0]
+        tri_ijk = np.empty((0, 3), dtype=np.int64)
+
     kwargs: dict = dict(
-        x=vertices[:, 0],
-        y=vertices[:, 1],
-        z=vertices[:, 2],
-        i=tri[:, 0],
-        j=tri[:, 1],
-        k=tri[:, 2],
+        x=verts[:, 0],
+        y=verts[:, 1],
+        z=verts[:, 2],
+        i=tri_ijk[:, 0],
+        j=tri_ijk[:, 1],
+        k=tri_ijk[:, 2],
         flatshading=True,
     )
     if cell_scalar is not None:
@@ -129,8 +169,10 @@ def mesh3d_figure(
             if vmax > 0:
                 kwargs.update(cmin=-vmax, cmax=vmax)
     elif vertex_scalar is not None:
+        # Slice the per-node scalar to match the trimmed vertex array.
+        vs = np.asarray(vertex_scalar)
         kwargs.update(
-            intensity=np.asarray(vertex_scalar),
+            intensity=vs[kept_nodes] if kept_nodes.size else vs[:0],
             intensitymode="vertex",
             colorscale=colorscale,
             colorbar=dict(title=colorbar_title, len=0.7),

--- a/tests/test_streamlit_viz.py
+++ b/tests/test_streamlit_viz.py
@@ -1,0 +1,259 @@
+"""Tests for the vectorized boundary-face extraction and Plotly payload
+trimming in :mod:`streamlit_viz`.
+
+These tests cover the perf-critical hot path used by the Streamlit 3D
+views (stress contour, deformed mesh, failure-index surface) on
+medium-sized hex8 meshes.  See issue #78.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# streamlit_viz lives at the repo root, not under src/, so make sure the
+# top-level directory is importable regardless of pytest's cwd.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("plotly")
+
+import streamlit_viz as sv  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _structured_hex_mesh(nx: int, ny: int, nz: int):
+    """Build a unit-spaced structured hex8 mesh of shape (nx, ny, nz).
+
+    Returns ``(nodes, elements)`` with the same node numbering convention
+    used in :mod:`wrinklefe.core.mesh`:
+
+        node id (i, j, k) = k * (ny+1)*(nx+1) + j * (nx+1) + i.
+    """
+    nxp, nyp, nzp = nx + 1, ny + 1, nz + 1
+    nodes = np.array(
+        [
+            [i, j, k]
+            for k in range(nzp)
+            for j in range(nyp)
+            for i in range(nxp)
+        ],
+        dtype=float,
+    )
+
+    def nid(i: int, j: int, k: int) -> int:
+        return k * nyp * nxp + j * nxp + i
+
+    elems = []
+    for k in range(nz):
+        for j in range(ny):
+            for i in range(nx):
+                elems.append(
+                    [
+                        nid(i, j, k),
+                        nid(i + 1, j, k),
+                        nid(i + 1, j + 1, k),
+                        nid(i, j + 1, k),
+                        nid(i, j, k + 1),
+                        nid(i + 1, j, k + 1),
+                        nid(i + 1, j + 1, k + 1),
+                        nid(i, j + 1, k + 1),
+                    ]
+                )
+    return nodes, np.asarray(elems, dtype=np.int64)
+
+
+def _boundary_faces_reference(elements: np.ndarray) -> np.ndarray:
+    """Pure-Python reference: a face is on the boundary iff its sorted
+    node-id tuple is unique across the mesh."""
+    HEX_FACES = sv.HEX_FACES
+    face_owners: dict[tuple[int, ...], list[tuple[int, int]]] = {}
+    for ei in range(elements.shape[0]):
+        conn = elements[ei]
+        for fi, face in enumerate(HEX_FACES):
+            key = tuple(sorted(int(v) for v in conn[face]))
+            face_owners.setdefault(key, []).append((ei, fi))
+    out: list[list[int]] = []
+    for owners in face_owners.values():
+        if len(owners) == 1:
+            ei, fi = owners[0]
+            face = HEX_FACES[fi]
+            out.append([int(elements[ei][n]) for n in face] + [ei])
+    return np.asarray(out, dtype=np.int64)
+
+
+# ---------------------------------------------------------------------------
+# boundary_faces — correctness
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_face_count_3x3x3():
+    """Structured 3x3x3 brick: surface area = 6 * 9 = 54 quad faces."""
+    _, elems = _structured_hex_mesh(3, 3, 3)
+    bf = sv.boundary_faces(elems)
+    assert bf.shape == (54, 5)
+    # Expected by the analytic formula 2*(nx*ny + nx*nz + ny*nz).
+    assert bf.shape[0] == 2 * (3 * 3 + 3 * 3 + 3 * 3)
+
+
+@pytest.mark.parametrize("shape", [(2, 2, 2), (4, 3, 2), (5, 5, 5), (3, 1, 4)])
+def test_boundary_face_count_matches_formula(shape):
+    nx, ny, nz = shape
+    _, elems = _structured_hex_mesh(nx, ny, nz)
+    bf = sv.boundary_faces(elems)
+    expected = 2 * (nx * ny + nx * nz + ny * nz)
+    assert bf.shape[0] == expected, (
+        f"{shape}: expected {expected} boundary faces, got {bf.shape[0]}"
+    )
+
+
+def test_vectorized_matches_reference_full_structured():
+    """The vectorized algorithm must return the same set of boundary
+    quads as the Python reference (face-counting) algorithm."""
+    _, elems = _structured_hex_mesh(4, 3, 5)
+    bf_new = sv.boundary_faces(elems)
+    bf_ref = _boundary_faces_reference(elems)
+    assert bf_new.shape == bf_ref.shape
+    # Compare as sets of sorted-node tuples (ignore winding direction
+    # and ordering of rows).
+    set_new = {tuple(sorted(r[:4])) for r in bf_new}
+    set_ref = {tuple(sorted(r[:4])) for r in bf_ref}
+    assert set_new == set_ref
+
+
+def test_vectorized_matches_reference_cutaway():
+    """A general (unstructured) subset: remove a corner element and
+    check that the algorithm correctly exposes the new interior faces."""
+    _, elems = _structured_hex_mesh(3, 3, 3)
+    # Drop element at (i=0, j=0, k=0) -> flat index 0.
+    sub_elems = elems[1:]
+    bf_new = sv.boundary_faces(sub_elems)
+    bf_ref = _boundary_faces_reference(sub_elems)
+    # Removing a corner element exposes 3 new boundary faces (and
+    # removes 3 of the original outer ones) -> net same total.
+    assert bf_new.shape[0] == bf_ref.shape[0]
+    assert {tuple(sorted(r[:4])) for r in bf_new} == {
+        tuple(sorted(r[:4])) for r in bf_ref
+    }
+
+
+def test_boundary_faces_empty_input():
+    bf = sv.boundary_faces(np.empty((0, 8), dtype=np.int64))
+    assert bf.shape == (0, 5)
+
+
+def test_parent_element_id_is_in_range():
+    _, elems = _structured_hex_mesh(3, 3, 3)
+    bf = sv.boundary_faces(elems)
+    assert bf[:, 4].min() >= 0
+    assert bf[:, 4].max() < elems.shape[0]
+
+
+# ---------------------------------------------------------------------------
+# quads_to_triangles
+# ---------------------------------------------------------------------------
+
+
+def test_quads_to_triangles_doubles_rows_and_preserves_owner():
+    _, elems = _structured_hex_mesh(2, 2, 2)
+    bf = sv.boundary_faces(elems)
+    tri = sv.quads_to_triangles(bf)
+    assert tri.shape == (2 * bf.shape[0], 4)
+    # Both triangles of each quad must reference the same parent elem.
+    assert np.array_equal(tri[0::2, 3], bf[:, 4])
+    assert np.array_equal(tri[1::2, 3], bf[:, 4])
+
+
+# ---------------------------------------------------------------------------
+# mesh3d_figure — vertex trimming + smoke
+# ---------------------------------------------------------------------------
+
+
+def test_mesh3d_figure_trims_vertex_payload():
+    """Plotly should receive only the nodes referenced by boundary
+    triangles, not the full mesh.  On a structured brick the interior
+    nodes are dropped, so the saving is substantial."""
+    nodes, elems = _structured_hex_mesh(4, 4, 4)
+    fig = sv.mesh3d_figure(
+        nodes, elems, cell_scalar=np.arange(elems.shape[0], dtype=float)
+    )
+    sent_x = np.asarray(fig.data[0].x)
+    # Compute the expected unique-boundary-node count for cross-check.
+    bf = sv.boundary_faces(elems)
+    tri = sv.quads_to_triangles(bf)
+    unique_boundary_nodes = np.unique(tri[:, :3].ravel())
+    assert sent_x.size == unique_boundary_nodes.size
+    # And it must be strictly smaller than the full node array
+    # (otherwise the trimming did nothing).
+    assert sent_x.size < nodes.shape[0]
+
+
+def test_mesh3d_figure_i_indices_in_range():
+    """The re-indexed (i, j, k) triangle indices must fit into the
+    trimmed vertex array; an out-of-range index here would crash the
+    browser's WebGL renderer with no Python error."""
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    fig = sv.mesh3d_figure(nodes, elems)
+    mesh = fig.data[0]
+    n_verts = len(mesh.x)
+    for arr_name in ("i", "j", "k"):
+        idx = np.asarray(getattr(mesh, arr_name))
+        assert idx.min() >= 0
+        assert idx.max() < n_verts
+
+
+def test_mesh3d_figure_cell_scalar_intensity_matches_triangles():
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    cell_scalar = np.arange(elems.shape[0], dtype=float)
+    fig = sv.mesh3d_figure(nodes, elems, cell_scalar=cell_scalar)
+    intensity = np.asarray(fig.data[0].intensity)
+    bf = sv.boundary_faces(elems)
+    tri = sv.quads_to_triangles(bf)
+    # intensity is per-triangle (cell mode), broadcast from parent elem.
+    assert intensity.shape == (tri.shape[0],)
+    assert np.array_equal(intensity, cell_scalar[tri[:, 3]])
+
+
+def test_mesh3d_figure_vertex_scalar_sliced_to_kept_nodes():
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    vertex_scalar = np.arange(nodes.shape[0], dtype=float)
+    fig = sv.mesh3d_figure(nodes, elems, vertex_scalar=vertex_scalar)
+    intensity = np.asarray(fig.data[0].intensity)
+    sent_x = np.asarray(fig.data[0].x)
+    assert intensity.shape == (sent_x.size,)
+
+
+def test_deformed_mesh_figure_smoke():
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    disp = np.zeros_like(nodes)
+    disp[:, 2] = 0.01 * nodes[:, 0]
+    fig = sv.deformed_mesh_figure(nodes, elems, disp, scale=10.0)
+    assert fig is not None
+    assert len(fig.data) == 1
+
+
+def test_stress_contour_figure_smoke():
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    stress = np.zeros((elems.shape[0], 6))
+    stress[:, 2] = np.linspace(-100.0, 100.0, elems.shape[0])
+    fig = sv.stress_contour_figure(nodes, elems, stress, component_index=2)
+    assert fig is not None
+    # cmin/cmax should be symmetric for signed stress.
+    mesh = fig.data[0]
+    assert mesh.cmin == pytest.approx(-mesh.cmax)
+
+
+def test_fi_3d_figure_smoke():
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    # fi_per_gauss has shape (n_elem, n_gauss).
+    fi = np.random.RandomState(0).rand(elems.shape[0], 8)
+    fig = sv.fi_3d_figure(nodes, elems, fi, criterion="MaxStress")
+    assert fig is not None


### PR DESCRIPTION
Closes #78.

## Summary
The Plotly mesh pipeline in `streamlit_viz.py` was the dominant cost on meshes of ~10k+ hex elements for two reasons that compound:

1. `boundary_faces()` was a pure-Python loop with O(N) cost in element count, building Python lists / sets.
2. The function returned ALL vertices (interior + boundary) and Plotly then received a huge mesh — a real problem on Streamlit Cloud where the data is sent over the wire to the browser.

This PR vectorizes `boundary_faces()` with NumPy and trims the vertex array to only boundary nodes.

## Algorithm
Single vectorized face-counting path (no structured-mesh shortcut, since `boundary_faces(elements)` only takes a connectivity array — there's no `(nx, ny, nz)` to key off):

1. Gather `elements[:, HEX_FACES]` → `(n_elem, 6, 4)` global node IDs per face.
2. Sort along the 4-node axis so shared faces hash identically regardless of winding.
3. `np.unique(..., axis=0, return_inverse=True, return_counts=True)` — a face is on the boundary iff `counts[inverse] == 1`.
4. Reshape back, keep boundary rows in their **original winding** so quad triangulation stays correct, and tag with parent elem id via `np.repeat(arange(n_elem), 6)`.

## Vertex trimming
`mesh3d_figure` now does `np.unique(tri[:, :3])` to get kept node IDs, slices `vertices` (and any `vertex_scalar`) down, and re-indexes `(i, j, k)`. Plotly receives only surface nodes.

## Results on a 20×20×24 mesh (9,600 elements)
- Vertex count sent to Plotly: **11,025 → 2,722 (-75.3%)**
- Boundary face count matches analytic `2·(nx·ny + nx·nz + ny·nz) = 2,720`.
- `boundary_faces` wall-clock: **118 ms → 35 ms (~3.3× faster)**, outputs identical face sets.

## API preserved
`boundary_faces` returns the same `(n_boundary_faces, 5)` shape and column semantics; `quads_to_triangles`, `mesh3d_figure`, and all four figure builders keep their existing signatures. `app.py` and the (now-merged) PR #164 `fi_y_slice_figure` need no changes.

## Tests added (17, all pass) in `tests/test_streamlit_viz.py`
- 3×3×3 boundary-count == 54.
- Parametrized analytic count across 4 mesh shapes.
- Vectorized vs Python-reference agreement on full mesh and on a cutaway (corner-removed) mesh.
- Empty-input edge case and parent-id range.
- `quads_to_triangles` doubles rows & preserves owner.
- Vertex-trim invariant (Plotly `x` length == unique boundary nodes, < full node count).
- Triangle index in-range (would crash WebGL silently otherwise).
- Cell-scalar intensity per triangle and vertex-scalar slice match.
- Smoke for `deformed_mesh_figure`, `stress_contour_figure`, `fi_3d_figure`.

## Test plan
- [x] Full suite: **900 passed** in 148s
- [x] Speed sanity check on 20×20×24 mesh — ~3.3× faster, outputs identical
- [x] Plotly index-range check (catches the silent WebGL crash mode)

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_