### PR TITLE
Document Streamlit app features in README / deployment doc / contributing (#91)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,15 @@ pytest
 
 To add a new material to the built-in library, add an entry in `src/wrinklefe/core/material.py` in the `_load_builtins()` method. Include all elastic constants, strength allowables, and a literature reference.
 
+For one-off or ad-hoc materials you do not need to modify source — turn on
+**Expert mode** in the Streamlit app and pick **Custom…** from the
+**Material** selectbox. The inline editor exposes E1/E2/E3, G12/G13/G23,
+ν12/ν13/ν23 and the Xt/Xc/Yt/Yc/Zt/Zc/S12/S13/S23 allowables, seeded from
+IM7/8552. Custom materials are scoped to the current Streamlit session and
+do not persist; use the source-level workflow above for anything you want
+to keep. See [`DEPLOYMENT_STREAMLIT.md`](DEPLOYMENT_STREAMLIT.md) for a
+full feature tour.
+
 ## Questions
 
 For questions about the science or implementation, open a GitHub issue with the "question" label.

--- a/DEPLOYMENT_STREAMLIT.md
+++ b/DEPLOYMENT_STREAMLIT.md
@@ -108,3 +108,71 @@ Implications for WrinkleFE:
 - Add Streamlit secrets via the Manage panel if the app needs API keys later.
 - Configure a custom domain in Streamlit Cloud's settings.
 - Add CI to run `streamlit run --headless` smoke tests on every PR.
+
+## App features
+
+Once the app is running, the sidebar offers three features worth calling out
+that aren't exposed through the Python API. All three live in `app.py` and
+are available in both the hosted Streamlit instance and a local
+`streamlit run app.py`.
+
+### Morphology schematics
+
+When **Expert mode** is on, the **Morphology** selectbox is followed by a
+live cartoon (rendered by `_morphology_schematic()` in `app.py`) that
+matches the active choice — stack / convex / concave / uniform / graded.
+A `?` popover next to the selector also lists thumbnails of all five so you
+can compare them at a glance without changing the selection. For the
+`graded` mode an additional **Decay floor** slider appears (0 = full decay
+to zero at the surface, 1 = uniform).
+
+Below the morphology cartoon, a separate **wrinkle preview** plot tracks the
+current `amplitude` (`A`), `wavelength` (`λ`), envelope `width` (`w`) and
+`decay_floor` in real time, so you can see the through-thickness profile
+update as you drag the sidebar sliders — no analysis run needed.
+
+### Layup notation (contracted)
+
+The **Layup** textarea accepts either a contracted laminate string or an
+explicit comma/semicolon/newline-separated list of ply angles in degrees.
+Quoting the in-app help text (`app.py:417-436`):
+
+> Accepts contracted notation like `[0/45/-45/90]_3s` or an explicit
+> comma-separated list of angles in degrees.
+
+Modifiers (also from the in-app help):
+
+- `±θ` expands to `θ, -θ` (two plies)
+- `θ_n` repeats a single ply *n* times (e.g. `0_4` → four 0° plies)
+- `_n` after the bracket repeats the whole sublaminate *n* times
+- Trailing `s` mirrors the stack to enforce symmetry
+
+| Contracted input    | Expanded plies                                    | Count |
+|---------------------|---------------------------------------------------|-------|
+| `[0/45/-45/90]_3s`  | `0/45/-45/90` repeated 3× then mirrored (default) | 24    |
+| `[0/±45/90]s`       | `0, 45, -45, 90` mirrored                         | 8     |
+| `[0_2/90]_2`        | `0, 0, 90` repeated twice                         | 6     |
+| `[±30]_2`           | `30, -30` repeated twice                          | 4     |
+
+The default layup is `[0/45/-45/90]_3s` — the 24-ply quasi-isotropic stack.
+Both the contracted and explicit forms can be edited freely in the textarea
+and validated immediately by the plies-count preview below it.
+
+### Custom-material editor
+
+In **Expert mode** the **Material** selectbox gains a `Custom…` entry at
+the bottom. Selecting it opens an inline expander seeded from IM7/8552
+with editable fields for:
+
+- *Elastic constants*: `E1`, `E2`, `E3`, `G12`, `G13`, `G23`, `ν12`,
+  `ν13`, `ν23`
+- *Strength allowables*: `Xt`, `Xc`, `Yt`, `Yc`, `Zt`, `Zc`, `S12`,
+  `S13`, `S23`
+
+Override only the values you care about — every other field
+(hygrothermal coefficients, `γ_Y`, LaRC fracture-toughness parameters) is
+inherited from the seed material. The custom material is named via a
+free-text **Material name** field and used for the current run only;
+**custom materials do not persist across sessions** (the app's filesystem
+is ephemeral on Streamlit Cloud and the session state resets on reload).
+For permanent additions to the library see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,29 @@ Run the test suite:
 pytest
 ```
 
-## Quick Start (Python API)
+## Quick Start
+
+### Streamlit web app
+
+The fastest path is the hosted Streamlit instance — no install, no Python
+required: **<https://wrinklefe.streamlit.app/>**. Pick a material from the
+sidebar (or **Custom…** to enter your own elastic constants and strength
+allowables), enter a layup in contracted notation (e.g. `[0/45/-45/90]_3s`),
+set the wrinkle geometry, and click **Run analysis**. The app ships with
+per-morphology schematic cartoons, a live wrinkle preview, and the same
+analytical + FE pipeline as the Python API. See
+[`DEPLOYMENT_STREAMLIT.md`](DEPLOYMENT_STREAMLIT.md) for the full feature
+tour and instructions for self-hosting.
+
+To run the app locally:
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+streamlit run app.py
+```
+
+### Python API
 
 ```python
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
@@ -164,6 +186,53 @@ et al., 2015; Li et al., 2026) are cited in [References](#references)
 below. Reproducing case-level pass/fail tables from this repository
 alone is not currently possible — the raw data and regeneration script
 are not included.
+
+## Supported morphologies
+
+WrinkleFE ships five wrinkle morphologies (defined in
+`src/wrinklefe/core/morphology.py`). The first three are *dual-wrinkle*
+modes distinguished by the phase offset φ between two adjacent wrinkle
+centrelines; the last two are *single-wrinkle* modes that vary the
+through-thickness amplitude.
+
+- **`stack`** (φ = 0) — peaks aligned. Morphology factor `M_f = 1.0`,
+  used as the baseline.
+- **`convex`** (φ = +π/2) — interface bulges outward. `M_f < 1`; the
+  *least* damaging mode in compression.
+- **`concave`** (φ = −π/2) — interface pinches inward. `M_f > 1`; the
+  *most* damaging mode in compression.
+- **`uniform`** — single wrinkle at full amplitude on every ply through
+  the thickness.
+- **`graded`** — single wrinkle whose amplitude decays from the wrinkle
+  core toward the surfaces, controlled by `decay_floor` (0 = full
+  decay to zero at the surface, 1 = uniform).
+
+## Supported failure criteria
+
+The criteria below live in `src/wrinklefe/failure/` and can be selected
+through `FailureEvaluator` or used independently:
+
+- **LaRC04/05** (`larc05.py`) — Pinho/Camanho 3-D criterion with
+  fibre-kinking under compression, in-situ matrix strengths, and a
+  fracture-plane search. Default for the FE solve.
+- **Tsai-Wu** (`tsai_wu.py`) — 3-D tensor-polynomial criterion with a
+  configurable interaction coefficient.
+- **Tsai-Hill** (`tsai_hill.py`) — 3-D extension of the classical
+  quadratic Tsai-Hill index.
+- **Hashin** (`hashin.py`) — 3-D Hashin criterion with separate
+  fibre-tension/-compression and matrix-tension/-compression modes.
+- **Puck** (`puck.py`) — action-plane (Mode A/B/C) inter-fibre-failure
+  criterion with simplified fibre failure.
+- **Maximum Stress** (`max_stress.py`) and **Maximum Strain**
+  (`max_strain.py`) — non-interactive checks against the principal
+  material-frame allowables.
+- **Budiansky-Fleck kink-band** (`kinkband.py`) — analytical compression
+  knockdown with an optional interlaminar damage coupling
+  (`InterlaminarDamage`); this is the model exposed in the
+  `analytical_knockdown` field of `AnalysisResults`.
+- **Progressive damage** (`progressive.py`) — `PlyDiscount` and
+  `ContinuumDamage` post-failure stiffness reduction models that wrap
+  any of the criteria above.
 
 ## How It Works
 


### PR DESCRIPTION
Closes #91.

## Summary
The user-facing docs never told a reader that the Streamlit app exposes (a) contracted layup notation, (b) the Custom-material editor, or (c) per-morphology schematics — all of which landed in May 2026 (PRs #60 and #66). A reader of the docs would assume the Streamlit app was just a thin sidebar wrapper over `AnalysisConfig`. This PR closes all four acceptance-criteria items from the issue.

## Changes

### `README.md`
- **Quick Start** already had a Streamlit subsection (from earlier branch work).
- Added **Supported morphologies** section listing all five (`stack`, `convex`, `concave`, `uniform`, `graded`) with a one-line description each.
- Added **Supported failure criteria** section listing the eight user-facing criteria + the one progressive-damage wrapper:
  - LaRC04 / LaRC05
  - Tsai-Wu
  - Tsai-Hill
  - Hashin
  - Puck
  - Maximum Stress
  - Maximum Strain
  - Budiansky-Fleck kink-band
  - Progressive damage (wraps any of the above)

### `DEPLOYMENT_STREAMLIT.md`
- New **App features** section with three subsections:
  1. **Morphology schematics + live preview** — explains the inline cartoon under the Morphology selectbox and that it tracks Amplitude / Wavelength / Width / Decay floor (PR #60).
  2. **Contracted layup notation** — syntax + four examples drawn from `app.py:422-427`:
     - `[0/45/-45/90]_3s` → 24-ply default quasi-iso
     - `[0/±45/90]s` → 8 plies
     - `[0_2/90]_2` → 6 plies
     - `[±30]_2` → 4 plies
  3. **Custom-material editor** — covers the **Custom...** entry in the Material selectbox, which fields are editable, and that defaults are seeded from IM7/8552 (PR #66).

### `CONTRIBUTING.md`
- Added paragraph to **Adding Materials** pointing at the Streamlit Custom-material editor as the no-code path for ad-hoc materials, complementing the existing `core/material.py` library-extension instructions.

## Files NOT touched
- `app.py` — docs-only PR, by design.
- `ARCHITECTURE.md` — already documents the right module structure for these features; no claim was inaccurate.

## Test plan
- [x] Docs-only — no code or CI changes
- [x] All four acceptance-criteria items in the issue addressed

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_