### PR TITLE
Add spatially varying amplitude profile (constant / gaussian / linear) (#3)

### DIFF
--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -32,7 +32,7 @@ References
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np
 
@@ -165,11 +165,35 @@ class WrinkleConfiguration:
         at the surface plies. ``0.0`` means full decay to zero amplitude
         at the surfaces (pure graded); ``1.0`` means no decay (equivalent
         to uniform). Values outside ``[0, 1]`` are clamped. Default 0.0.
+    amplitude_profile : {"constant", "gaussian", "linear"}, optional
+        Spatially varying in-plane amplitude modulation applied on top of
+        the wrinkle's own longitudinal envelope. ``"constant"`` (default)
+        preserves the legacy behaviour -- the amplitude *A* set on the
+        wrinkle profile is used uniformly across the in-plane domain.
+        ``"gaussian"`` multiplies *A* by ``exp(-(s/d)**2)`` where *s* is the
+        coordinate (relative to the wrinkle centre) along the chosen axis
+        and *d* is the decay length. ``"linear"`` multiplies *A* by
+        ``max(0, 1 - |s|/d)`` (clipped at zero).
+    amplitude_profile_decay_length : float, optional
+        Length scale *d* (mm) controlling the Gaussian sigma or the
+        linear-decay extent. When ``None`` (default) the helper falls back
+        to the wrinkle profile's own ``width``, which is the natural choice
+        because users typically want the amplitude to taper on the same
+        length scale as the envelope. Must be positive when provided.
+    amplitude_profile_axis : {"x", "y"}, optional
+        In-plane axis along which the amplitude modulation runs. Default
+        ``"x"``. NOTE: the existing longitudinal envelope (e.g. the
+        Gaussian in :class:`GaussianSinusoidal`) already runs on *x*, so
+        choosing ``amplitude_profile_axis="x"`` with ``"gaussian"`` will
+        effectively square the Gaussian on *x*; this is a degenerate but
+        allowed configuration -- pick ``"y"`` (transverse axis) to obtain
+        an independent in-plane tapering of *A*.
 
     Raises
     ------
     ValueError
-        If the wrinkle list is empty.
+        If the wrinkle list is empty, the amplitude profile name is
+        unknown, or the decay length is non-positive.
 
     Examples
     --------
@@ -191,11 +215,17 @@ class WrinkleConfiguration:
     - Elhajjar (2025), Scientific Reports 15:25977, Eq. 7-12.
     """
 
+    _VALID_AMPLITUDE_PROFILES = ("constant", "gaussian", "linear")
+    _VALID_AMPLITUDE_PROFILE_AXES = ("x", "y")
+
     def __init__(
         self,
         wrinkles: list[WrinklePlacement],
         decay_mode: str = "default",
         decay_floor: float = 0.0,
+        amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant",
+        amplitude_profile_decay_length: Optional[float] = None,
+        amplitude_profile_axis: Literal["x", "y"] = "x",
     ) -> None:
         if not wrinkles:
             raise ValueError("At least one WrinklePlacement is required.")
@@ -213,6 +243,34 @@ class WrinkleConfiguration:
         # Physically: surface plies retain some waviness even far from
         # the wrinkle core. Interpolates between graded (0) and uniform (1).
         self.decay_floor: float = max(0.0, min(1.0, decay_floor))
+
+        # Spatially varying in-plane amplitude profile (issue #3). This is
+        # a SEPARATE multiplicative modulation applied on top of the
+        # wrinkle's own longitudinal envelope -- it lets a single wrinkle
+        # be modelled with a tapered or localised amplitude.
+        if amplitude_profile not in self._VALID_AMPLITUDE_PROFILES:
+            raise ValueError(
+                f"Unknown amplitude_profile '{amplitude_profile}'. "
+                f"Choose from: {list(self._VALID_AMPLITUDE_PROFILES)}"
+            )
+        if amplitude_profile_axis not in self._VALID_AMPLITUDE_PROFILE_AXES:
+            raise ValueError(
+                f"Unknown amplitude_profile_axis '{amplitude_profile_axis}'. "
+                f"Choose from: {list(self._VALID_AMPLITUDE_PROFILE_AXES)}"
+            )
+        if (
+            amplitude_profile_decay_length is not None
+            and amplitude_profile_decay_length <= 0.0
+        ):
+            raise ValueError(
+                "amplitude_profile_decay_length must be positive, "
+                f"got {amplitude_profile_decay_length}"
+            )
+        self.amplitude_profile: str = amplitude_profile
+        self.amplitude_profile_decay_length: Optional[float] = (
+            amplitude_profile_decay_length
+        )
+        self.amplitude_profile_axis: str = amplitude_profile_axis
 
     # ------------------------------------------------------------------
     # Phase & Morphology (static methods)
@@ -493,6 +551,86 @@ class WrinkleConfiguration:
     # Mesh deformation
     # ------------------------------------------------------------------
 
+    def _amplitude_scale(
+        self,
+        wrinkle: WrinklePlacement,
+        x: float,
+        y: float,
+    ) -> float:
+        """In-plane scale factor for the spatially varying amplitude profile.
+
+        Returns a dimensionless multiplicative factor in ``[0, 1]`` that
+        modulates the wrinkle's *A* in addition to the wrinkle's own
+        longitudinal envelope. The factor depends on the coordinate
+        *s* (along the chosen axis) relative to the wrinkle centre:
+
+        - ``"constant"`` (default) -> ``1.0`` (legacy behaviour).
+        - ``"gaussian"`` -> ``exp(-(s / d) ** 2)``.
+        - ``"linear"`` -> ``max(0, 1 - |s| / d)`` (clipped at zero).
+
+        The decay length *d* defaults to the wrinkle profile's own
+        ``width`` when :attr:`amplitude_profile_decay_length` is ``None``.
+
+        Parameters
+        ----------
+        wrinkle : WrinklePlacement
+            The wrinkle whose centre defines *s = coord - centre*. For
+            the x-axis the centre is ``profile.center + delta_x`` (so the
+            phase-offset shift is respected). For the y-axis the centre is
+            ``span_y / 2`` for a :class:`WrinkleSurface3D` (matching the
+            transverse modes' convention) and ``0.0`` for a plain 1-D
+            profile (which has no y-extent of its own).
+        x, y : float
+            World-frame coordinates of the node.
+
+        Returns
+        -------
+        float
+            Multiplicative scale factor applied on top of the wrinkle's
+            own profile.displacement / profile.slope output. Both
+            :meth:`apply_to_nodes` and :meth:`fiber_angles_at_nodes`
+            call this helper so the displacement and angle fields stay
+            mutually consistent (#18 invariant).
+
+        Notes
+        -----
+        The new modulation stacks multiplicatively with the wrinkle's
+        own longitudinal envelope. Choosing ``amplitude_profile_axis="x"``
+        with ``"gaussian"`` therefore squares the Gaussian along *x* (the
+        existing envelope plus this new one) -- a degenerate but allowed
+        configuration. Pick the transverse axis (``"y"``) to get a
+        decoupled tapering of *A*.
+        """
+        if self.amplitude_profile == "constant":
+            return 1.0
+
+        profile = wrinkle.profile
+        # Resolve the per-wrinkle base profile and centre.
+        if isinstance(profile, WrinkleSurface3D):
+            base_profile = profile.profile
+            y_center = profile.span_y / 2.0
+        else:
+            base_profile = profile
+            y_center = 0.0
+
+        # Longitudinal centre in the world frame includes the phase shift.
+        delta_x = wrinkle.phase_offset * base_profile.wavelength / (2.0 * np.pi)
+        x_center = base_profile.center + delta_x
+
+        if self.amplitude_profile_axis == "x":
+            s = x - x_center
+        else:  # "y" -- validated in __init__
+            s = y - y_center
+
+        d = self.amplitude_profile_decay_length
+        if d is None:
+            d = base_profile.width
+
+        if self.amplitude_profile == "gaussian":
+            return float(np.exp(-((s / d) ** 2)))
+        # "linear" -- validated in __init__
+        return float(max(0.0, 1.0 - abs(s) / d))
+
     @staticmethod
     def _ply_decay(p: int, k: int, n_plies: int) -> float:
         """Through-thickness linear decay factor for the default mode.
@@ -605,7 +743,13 @@ class WrinkleConfiguration:
                         np.atleast_1d(x_shifted), np.atleast_1d(y)
                     )[0])
                 else:
+                    y = nodes[node_idx, 1]
                     dz = float(profile.displacement(np.atleast_1d(x_shifted))[0])
+
+                # In-plane spatially varying amplitude modulation (#3).
+                # This is a SEPARATE multiplicative scale on top of the
+                # wrinkle's own longitudinal envelope.
+                dz *= self._amplitude_scale(wrinkle, x, y)
 
                 # Through-thickness decay
                 if self.decay_mode == "uniform":
@@ -700,6 +844,7 @@ class WrinkleConfiguration:
 
             for node_idx in range(n_nodes):
                 x = nodes[node_idx, 0]
+                y = nodes[node_idx, 1] if nodes.shape[1] >= 2 else 0.0
                 p = int(ply_ids[node_idx])
 
                 # Shift x by phase offset before evaluating slope
@@ -707,6 +852,11 @@ class WrinkleConfiguration:
 
                 # Get the slope dz/dx at the shifted x position
                 slope = profile.slope(x_shifted)
+
+                # In-plane spatially varying amplitude modulation (#3).
+                # Mirrors the scale applied in apply_to_nodes so the
+                # displacement and angle fields stay consistent (#18).
+                amp_scale = self._amplitude_scale(wrinkle, x, y)
 
                 # Through-thickness decay for angle
                 if self.decay_mode == "uniform":
@@ -722,6 +872,10 @@ class WrinkleConfiguration:
                     # Default: same through-thickness decay as the
                     # displacement field (see apply_to_nodes).
                     decay = self._ply_decay(p, k, n_plies)
+
+                # Combine through-thickness decay with in-plane
+                # amplitude-profile scale.
+                decay = decay * amp_scale
 
                 # Angle from slope, scaled by decay
                 angle = np.arctan(np.abs(slope)) * decay

--- a/tests/test_morphology_amplitude_profile.py
+++ b/tests/test_morphology_amplitude_profile.py
@@ -1,0 +1,374 @@
+"""Spatially varying in-plane amplitude profile tests (issue #3).
+
+The :class:`WrinkleConfiguration` accepts an ``amplitude_profile`` kwarg
+that multiplies the wrinkle's *A* by a position-dependent scale along the
+chosen in-plane axis. Tests here cover:
+
+- the three profile kinds (``constant``, ``gaussian``, ``linear``) at the
+  centre, at one decay-length, and beyond,
+- the #18 invariant -- where the displacement scale vanishes the local
+  fibre-angle deviation also vanishes,
+- validation of bad inputs,
+- a smoke test that ``apply_to_nodes`` runs end-to-end for every kind.
+
+The standard ``gaussian_wrinkle`` fixture (A=0.366, lambda=16, w=12, x0=0)
+from ``tests/conftest.py`` is reused throughout.
+"""
+
+import math
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from wrinklefe.core.morphology import (
+    WrinkleConfiguration,
+    WrinklePlacement,
+)
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+def _strip(xs, n_plies, y=0.0):
+    """Build a (n_plies * len(xs), 3) node strip + matching ply_ids."""
+    nodes = []
+    ply_ids = []
+    for p in range(n_plies):
+        for x in xs:
+            nodes.append([x, y, 0.0])
+            ply_ids.append(p)
+    return np.asarray(nodes, dtype=float), np.asarray(ply_ids, dtype=int)
+
+
+def _single_config(profile, ply_interface=1, phase=0.0, **kw):
+    return WrinkleConfiguration(
+        [WrinklePlacement(profile, ply_interface=ply_interface, phase_offset=phase)],
+        **kw,
+    )
+
+
+# ----------------------------------------------------------------------
+# Constant profile -- backwards-compat baseline
+# ----------------------------------------------------------------------
+
+class TestConstantProfileBaseline:
+    """``amplitude_profile='constant'`` (the default) must leave the
+    legacy displacement field untouched."""
+
+    def test_default_matches_legacy(self, gaussian_wrinkle):
+        cfg_default = _single_config(gaussian_wrinkle, ply_interface=1)
+        cfg_const = _single_config(
+            gaussian_wrinkle, ply_interface=1, amplitude_profile="constant"
+        )
+        xs = np.linspace(-8.0, 8.0, 9)
+        nodes, ply = _strip(xs, n_plies=4)
+        out_default = cfg_default.apply_to_nodes(nodes, ply, n_plies=4)
+        out_const = cfg_const.apply_to_nodes(nodes, ply, n_plies=4)
+        npt.assert_allclose(out_default, out_const, rtol=1e-14, atol=1e-15)
+
+    def test_constant_scale_is_unity_everywhere(self, gaussian_wrinkle):
+        """At every probed (x, y) the internal scale must be exactly 1.0."""
+        cfg = _single_config(
+            gaussian_wrinkle, ply_interface=1, amplitude_profile="constant"
+        )
+        wrinkle = cfg.wrinkles[0]
+        for x in (-20.0, -5.0, 0.0, 3.7, 50.0):
+            for y in (-5.0, 0.0, 5.0):
+                assert cfg._amplitude_scale(wrinkle, x, y) == 1.0
+
+
+# ----------------------------------------------------------------------
+# Gaussian profile -- decay-law check
+# ----------------------------------------------------------------------
+
+class TestGaussianProfile:
+    """``A_eff(s) = A * exp(-(s/d)**2)``."""
+
+    def test_center_unity(self, gaussian_wrinkle):
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="gaussian",
+            amplitude_profile_decay_length=4.0,
+            amplitude_profile_axis="x",
+        )
+        wrinkle = cfg.wrinkles[0]
+        # Wrinkle centre is at profile.center=0 (no phase offset),
+        # so s=0 -> scale = exp(0) = 1.
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, 0.0, 0.0), 1.0, rtol=1e-14
+        )
+
+    def test_one_decay_length(self, gaussian_wrinkle):
+        d = 5.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="gaussian",
+            amplitude_profile_decay_length=d,
+        )
+        wrinkle = cfg.wrinkles[0]
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, d, 0.0),
+            math.exp(-1.0),
+            rtol=1e-14,
+        )
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, -d, 0.0),
+            math.exp(-1.0),
+            rtol=1e-14,
+        )
+
+    def test_two_decay_lengths(self, gaussian_wrinkle):
+        d = 3.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="gaussian",
+            amplitude_profile_decay_length=d,
+        )
+        wrinkle = cfg.wrinkles[0]
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, 2.0 * d, 0.0),
+            math.exp(-4.0),
+            rtol=1e-14,
+        )
+
+    def test_default_decay_length_falls_back_to_width(self):
+        """When decay_length is None, the helper uses profile.width."""
+        prof = GaussianSinusoidal(
+            amplitude=0.5, wavelength=10.0, width=6.0, center=0.0
+        )
+        cfg = _single_config(
+            prof, ply_interface=1, amplitude_profile="gaussian"
+        )
+        wrinkle = cfg.wrinkles[0]
+        # At s = width=6, expect exp(-1).
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, 6.0, 0.0),
+            math.exp(-1.0),
+            rtol=1e-14,
+        )
+
+    def test_y_axis_modulation(self, gaussian_wrinkle):
+        """``axis='y'`` makes the scale a function of y only."""
+        d = 4.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="gaussian",
+            amplitude_profile_decay_length=d,
+            amplitude_profile_axis="y",
+        )
+        wrinkle = cfg.wrinkles[0]
+        # Independent of x.
+        for x in (-10.0, 0.0, 10.0):
+            npt.assert_allclose(
+                cfg._amplitude_scale(wrinkle, x, 0.0), 1.0, rtol=1e-14
+            )
+            npt.assert_allclose(
+                cfg._amplitude_scale(wrinkle, x, d),
+                math.exp(-1.0),
+                rtol=1e-14,
+            )
+
+
+# ----------------------------------------------------------------------
+# Linear profile -- triangular decay clipped at zero
+# ----------------------------------------------------------------------
+
+class TestLinearProfile:
+    """``A_eff(s) = A * max(0, 1 - |s|/d)``."""
+
+    def test_center_unity(self, gaussian_wrinkle):
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="linear",
+            amplitude_profile_decay_length=4.0,
+        )
+        wrinkle = cfg.wrinkles[0]
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, 0.0, 0.0), 1.0, rtol=1e-14
+        )
+
+    def test_zero_at_one_decay_length(self, gaussian_wrinkle):
+        d = 4.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="linear",
+            amplitude_profile_decay_length=d,
+        )
+        wrinkle = cfg.wrinkles[0]
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, d, 0.0), 0.0, atol=1e-15
+        )
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, -d, 0.0), 0.0, atol=1e-15
+        )
+
+    def test_clipped_beyond_decay_length(self, gaussian_wrinkle):
+        d = 2.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="linear",
+            amplitude_profile_decay_length=d,
+        )
+        wrinkle = cfg.wrinkles[0]
+        for s in (1.5 * d, 3.0 * d, 100.0 * d):
+            assert cfg._amplitude_scale(wrinkle, s, 0.0) == 0.0
+            assert cfg._amplitude_scale(wrinkle, -s, 0.0) == 0.0
+
+    def test_half_decay_length(self, gaussian_wrinkle):
+        d = 8.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="linear",
+            amplitude_profile_decay_length=d,
+        )
+        wrinkle = cfg.wrinkles[0]
+        npt.assert_allclose(
+            cfg._amplitude_scale(wrinkle, 0.5 * d, 0.0), 0.5, rtol=1e-14
+        )
+
+
+# ----------------------------------------------------------------------
+# Geometry / fibre-angle parity (#18 invariant)
+# ----------------------------------------------------------------------
+
+class TestGeometryAngleParity:
+    """Where the amplitude scale vanishes the fibre-angle deviation
+    must also vanish (the #18 invariant carried over to the new modulation)."""
+
+    def test_linear_zero_zone_vanishes_in_both_fields(self, gaussian_wrinkle):
+        # Use linear profile with d=2 so |x| >= 2 has zero amplitude.
+        d = 2.0
+        cfg = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="linear",
+            amplitude_profile_decay_length=d,
+            amplitude_profile_axis="x",
+        )
+        # Probe nodes well inside the zero zone.
+        xs = np.array([-5.0, -3.0, 3.0, 5.0])
+        nodes, ply = _strip(xs, n_plies=4)
+        out = cfg.apply_to_nodes(nodes, ply, n_plies=4)
+        dz = (out - nodes)[:, 2]
+        npt.assert_allclose(dz, 0.0, atol=1e-15)
+        # And the fibre angle field must agree at the same nodes.
+        ang = cfg.fiber_angles_at_nodes(nodes, ply, n_plies=4)
+        npt.assert_allclose(ang, 0.0, atol=1e-15)
+
+    def test_gaussian_decays_displacement_and_angle_together(
+        self, gaussian_wrinkle
+    ):
+        """Both fields share the same multiplicative scale, so their
+        ratio (relative to the unmodulated baseline at the same node)
+        must be identical."""
+        d = 4.0
+        cfg_mod = _single_config(
+            gaussian_wrinkle,
+            ply_interface=1,
+            amplitude_profile="gaussian",
+            amplitude_profile_decay_length=d,
+            amplitude_profile_axis="x",
+        )
+        cfg_base = _single_config(gaussian_wrinkle, ply_interface=1)
+
+        # Pick x stations off the crest so |slope| and |displacement| are
+        # both nonzero (slope is zero at the crest).
+        xs = np.array([1.0, 3.0, 5.0, 7.0])
+        nodes, ply = _strip(xs, n_plies=4)
+        dz_mod = (cfg_mod.apply_to_nodes(nodes, ply, n_plies=4) - nodes)[:, 2]
+        dz_base = (cfg_base.apply_to_nodes(nodes, ply, n_plies=4) - nodes)[:, 2]
+        ang_mod = cfg_mod.fiber_angles_at_nodes(nodes, ply, n_plies=4)
+        ang_base = cfg_base.fiber_angles_at_nodes(nodes, ply, n_plies=4)
+
+        # On the interface plies (p=1, p=2) the through-thickness decay
+        # is unity, so the ratio is exactly the amplitude scale.
+        mask = (ply == 1) | (ply == 2)
+        nonzero = np.abs(dz_base[mask]) > 1e-12
+        ratio_dz = dz_mod[mask][nonzero] / dz_base[mask][nonzero]
+        nonzero_ang = np.abs(ang_base[mask]) > 1e-12
+        ratio_ang = ang_mod[mask][nonzero_ang] / ang_base[mask][nonzero_ang]
+        # Both ratios must equal the Gaussian scale at the same x.
+        # Use the displacement-side ratio as ground truth and compare.
+        npt.assert_allclose(ratio_dz.mean(), ratio_ang.mean(), rtol=1e-12)
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+
+class TestValidation:
+    def test_bogus_profile_name_raises(self, gaussian_wrinkle):
+        with pytest.raises(ValueError, match="Unknown amplitude_profile"):
+            _single_config(
+                gaussian_wrinkle,
+                ply_interface=1,
+                amplitude_profile="bogus",
+            )
+
+    def test_negative_decay_length_raises(self, gaussian_wrinkle):
+        with pytest.raises(
+            ValueError, match="amplitude_profile_decay_length must be positive"
+        ):
+            _single_config(
+                gaussian_wrinkle,
+                ply_interface=1,
+                amplitude_profile="gaussian",
+                amplitude_profile_decay_length=-1.0,
+            )
+
+    def test_zero_decay_length_raises(self, gaussian_wrinkle):
+        with pytest.raises(
+            ValueError, match="amplitude_profile_decay_length must be positive"
+        ):
+            _single_config(
+                gaussian_wrinkle,
+                ply_interface=1,
+                amplitude_profile="linear",
+                amplitude_profile_decay_length=0.0,
+            )
+
+    def test_bogus_axis_raises(self, gaussian_wrinkle):
+        with pytest.raises(ValueError, match="Unknown amplitude_profile_axis"):
+            _single_config(
+                gaussian_wrinkle,
+                ply_interface=1,
+                amplitude_profile_axis="z",
+            )
+
+
+# ----------------------------------------------------------------------
+# Smoke -- apply_to_nodes runs end-to-end for every profile kind
+# ----------------------------------------------------------------------
+
+class TestSmoke:
+    @pytest.mark.parametrize("kind", ["constant", "gaussian", "linear"])
+    def test_apply_to_nodes_runs(self, gaussian_wrinkle, kind):
+        cfg = _single_config(
+            gaussian_wrinkle, ply_interface=1, amplitude_profile=kind
+        )
+        nodes, ply = _strip(np.linspace(-6.0, 6.0, 5), n_plies=4)
+        out = cfg.apply_to_nodes(nodes, ply, n_plies=4)
+        assert out.shape == nodes.shape
+        # X / Y unchanged.
+        npt.assert_array_equal(out[:, :2], nodes[:, :2])
+
+    @pytest.mark.parametrize("kind", ["constant", "gaussian", "linear"])
+    def test_fiber_angles_runs(self, gaussian_wrinkle, kind):
+        cfg = _single_config(
+            gaussian_wrinkle, ply_interface=1, amplitude_profile=kind
+        )
+        nodes, ply = _strip(np.linspace(-6.0, 6.0, 5), n_plies=4)
+        ang = cfg.fiber_angles_at_nodes(nodes, ply, n_plies=4)
+        assert ang.shape == (nodes.shape[0],)
+        assert np.all(ang >= 0.0)


### PR DESCRIPTION
Closes #3.

## Summary
Adds spatially varying wrinkle amplitude (Gaussian or linear decay envelope) at the morphology layer. Backwards-compatible: the new `amplitude_profile` kwarg defaults to `"constant"`, which is the existing behaviour exactly.

## API (additions to `WrinkleConfiguration`)
- `amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant"`
- `amplitude_profile_decay_length: Optional[float] = None` — millimetres; falls back to the wrinkle profile's own `width` when `None`.
- `amplitude_profile_axis: Literal["x", "y"] = "x"` — independent tapering on `y` for `WrinkleSurface3D`; `x` stacks on top of the wrinkle's longitudinal envelope (allowed but documented as degenerate).

## Helper
`_amplitude_scale(wrinkle, x, y) -> float` returns a **dimensionless** multiplier — the wrinkle profile already contains the absolute `A`.

| profile | formula |
|---|---|
| `"constant"` | `1.0` |
| `"gaussian"` | `exp(-(s/d)**2)` |
| `"linear"` | `max(0, 1 - |s|/d)` |

Where `s` is the coordinate along the chosen axis, relative to the wrinkle centre: `profile.center + delta_x` on `x` (preserves the phase-offset shift), `span_y/2` on `y` for a `WrinkleSurface3D`, `0.0` for a plain 1-D profile.

`_amplitude_scale` is called from **both** `apply_to_nodes` and `fiber_angles_at_nodes`, preserving the #18 invariant that displacement and fibre-angle fields share the same decay/scale.

## Tests
`tests/test_morphology_amplitude_profile.py` (23 tests, all pass):
- `TestConstantProfileBaseline` (2) — default matches legacy, scale=1 everywhere
- `TestGaussianProfile` (5) — centre, ±d (exp(-1)), 2d (exp(-4)), default→width fallback, y-axis variant
- `TestLinearProfile` (4) — centre, =0 at ±d, clipped beyond d, half-decay
- `TestGeometryAngleParity` (2) — zero-amp zone vanishes in BOTH fields; Gaussian scales displacement and angle by the same factor
- `TestValidation` (4) — bogus name, negative/zero decay length, bogus axis
- `TestSmoke` (6, parametrized) — `apply_to_nodes` + `fiber_angles_at_nodes` for each kind

## Test plan
- [x] Full suite: **975 passed, 8 skipped** in 165s
- [x] `amplitude_profile="constant"` matches existing default trajectory exactly (back-compat smoke)
- [x] No CLI / Streamlit surfacing in this PR — intentional follow-up. The capability lives at the morphology layer only; wiring through user-facing layers will be tracked as separate issues.

https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet

---
_Generated by [Claude Code](https://claude.ai/code/session_012mXdQEQdF7aX4kcgaCuDet)_