### PR TITLE
fix(larc05): stop mutating self.ply_thickness from per-call context

### DIFF
--- a/src/wrinklefe/failure/larc05.py
+++ b/src/wrinklefe/failure/larc05.py
@@ -136,12 +136,25 @@ class LaRC05Criterion(FailureCriterion):
     # ------------------------------------------------------------------
 
     def _in_situ_strengths(
-        self, material: OrthotropicMaterial
+        self,
+        material: OrthotropicMaterial,
+        ply_thickness: Optional[float] = None,
     ) -> tuple[float, float]:
         """Compute in-situ transverse tensile and shear strengths.
 
         Uses fracture-toughness-based corrections when GIc/GIIc are
         available; falls back to simplified 1.12√2 factors otherwise.
+
+        Parameters
+        ----------
+        material : OrthotropicMaterial
+            Material with elastic and fracture-toughness properties.
+        ply_thickness : float, optional
+            Effective ply thickness (mm) to use for the in-situ
+            correction.  If ``None`` (the default), falls back to the
+            instance attribute ``self.ply_thickness``.  Passing this
+            explicitly lets a per-element override be threaded through
+            ``evaluate`` without mutating instance state (see #192).
 
         Returns
         -------
@@ -150,7 +163,8 @@ class LaRC05Criterion(FailureCriterion):
         S12_is : float
             In-situ in-plane shear strength (MPa).
         """
-        is_thin = self.ply_thickness < 2.0 * self.t_ref
+        t = self.ply_thickness if ply_thickness is None else ply_thickness
+        is_thin = t < 2.0 * self.t_ref
 
         if material.GIc is not None and material.GIIc is not None and is_thin:
             # Fracture-toughness-based (Camanho et al. 2006)
@@ -159,7 +173,6 @@ class LaRC05Criterion(FailureCriterion):
             Lambda_22 = 2.0 * (1.0 / material.E2 - nu21 ** 2 / material.E1)
             Lambda_44 = 1.0 / material.G12
 
-            t = self.ply_thickness
             Yt_is = np.sqrt(8.0 * material.GIc / (np.pi * t * Lambda_22))
             S12_is = np.sqrt(8.0 * material.GIIc / (np.pi * t * Lambda_44))
 
@@ -437,15 +450,18 @@ class LaRC05Criterion(FailureCriterion):
         stress_local = np.asarray(stress_local, dtype=np.float64)
         s1 = stress_local[0]
 
-        # Extract context
+        # Extract context.  Treat the ply-thickness override as a local
+        # value so concurrent / interleaved evaluate() calls do not
+        # corrupt the instance state (see #192).
         phi_0 = 0.0
+        t_eff = self.ply_thickness
         if context is not None:
             phi_0 = context.get("misalignment_angle", 0.0)
             t_override = context.get("ply_thickness", None)
             if t_override is not None:
-                self.ply_thickness = t_override
+                t_eff = t_override
 
-        Yt_is, S12_is = self._in_situ_strengths(material)
+        Yt_is, S12_is = self._in_situ_strengths(material, t_eff)
 
         # --- Fibre failure ---
         if s1 >= 0:

--- a/tests/test_failure/test_larc05.py
+++ b/tests/test_failure/test_larc05.py
@@ -308,3 +308,94 @@ class TestLaRC05MonotonicityAndReserve:
                 assert result.reserve_factor == pytest.approx(
                     1.0 / result.index, rel=1e-12
                 )
+
+
+# ======================================================================
+# Context override must not mutate criterion state (issue #192)
+# ======================================================================
+
+class TestLaRC05PlyThicknessOverrideIsLocal:
+    """Pin the fix for #192: ``context['ply_thickness']`` must be treated
+    as a local effective value.  It must not be written onto the criterion
+    instance, otherwise the override silently leaks into subsequent calls
+    that omit the override -- a call-order-dependent bug that also makes
+    a single ``LaRC05Criterion`` instance unsafe to share across threads
+    or across an ``evaluate_field`` sweep over a thick/thin ply mix.
+    """
+
+    def test_override_does_not_mutate_instance(self, criterion, material):
+        original = criterion.ply_thickness
+        stress = np.array([0.0, 0.5 * material.Yt, 0.0, 0.0, 0.0, 0.0])
+        criterion.evaluate(stress, material, {"ply_thickness": 0.30})
+        assert criterion.ply_thickness == original
+
+    def test_override_then_no_context_matches_isolated_calls(
+        self, criterion, material
+    ):
+        """A call with an override followed by a call without context must
+        return the same FI as if each were called on a fresh criterion.
+        Before the fix the second call inherited 0.30 mm via mutated
+        ``self.ply_thickness``, so its in-situ strengths (and therefore
+        the matrix FI) silently shifted."""
+        stress = np.array([0.0, 0.5 * material.Yt, 0.0, 0.0, 0.0, 0.0])
+
+        # Reference values from *isolated* (fresh-instance) calls.
+        fi_with_override_ref = LaRC05Criterion().evaluate(
+            stress, material, {"ply_thickness": 0.30}
+        ).index
+        fi_default_ref = LaRC05Criterion().evaluate(stress, material).index
+
+        # Interleaved on a single shared instance.
+        fi_with_override = criterion.evaluate(
+            stress, material, {"ply_thickness": 0.30}
+        ).index
+        fi_default = criterion.evaluate(stress, material).index
+
+        assert fi_with_override == pytest.approx(
+            fi_with_override_ref, rel=1e-12
+        )
+        assert fi_default == pytest.approx(fi_default_ref, rel=1e-12)
+
+    def test_override_does_not_corrupt_in_situ_branch_for_thick_ply(
+        self, criterion, material
+    ):
+        """A thick-ply override (>= 2*t_ref) toggles the in-situ branch.
+        Before the fix, calling with the thick override would leave
+        ``self.ply_thickness`` thick, so a subsequent thin-ply call would
+        misread the ``is_thin`` flag and skip the in-situ correction.
+        """
+        # 2 * t_ref triggers the thick-ply (no-correction) branch.
+        t_thick = 2.0 * criterion.t_ref + 0.05
+        stress = np.array([0.0, material.Yt, 0.0, 0.0, 0.0, 0.0])
+
+        # Thick override -> uses raw Yt -> FI = 1.0 at sigma_22 = Yt.
+        fi_thick = criterion.evaluate(
+            stress, material, {"ply_thickness": t_thick}
+        ).index
+        assert fi_thick == pytest.approx(1.0, rel=1e-6)
+
+        # Same criterion, no override -> default (thin) in-situ branch
+        # must still apply -> FI strictly below 1.0 at sigma_22 = Yt.
+        fi_default = criterion.evaluate(stress, material).index
+        assert fi_default < 1.0
+
+    def test_in_situ_strengths_accepts_thickness_parameter(
+        self, criterion, material
+    ):
+        """The in-situ strengths must be derivable from an explicit
+        effective-thickness argument, not only from instance state."""
+        # Passing the instance value explicitly must reproduce the
+        # default-argument result.
+        Yt_default, S12_default = criterion._in_situ_strengths(material)
+        Yt_param, S12_param = criterion._in_situ_strengths(
+            material, criterion.ply_thickness
+        )
+        assert Yt_param == pytest.approx(Yt_default, rel=1e-12)
+        assert S12_param == pytest.approx(S12_default, rel=1e-12)
+
+        # Passing a thick override must switch off the thin-ply
+        # correction (Yt_is collapses back to raw Yt).
+        Yt_thick, _ = criterion._in_situ_strengths(
+            material, 2.0 * criterion.t_ref + 0.05
+        )
+        assert Yt_thick == pytest.approx(material.Yt, rel=1e-12)


### PR DESCRIPTION
## Summary
- `LaRC05Criterion.evaluate` no longer writes `context["ply_thickness"]` onto `self`. The override is bound to a local `t_eff` and threaded into `_in_situ_strengths` as a parameter.
- `_in_situ_strengths(material, ply_thickness=None)` accepts an optional thickness; falls back to `self.ply_thickness` when not provided (backward compatible).
- `self.ply_thickness` is now immutable after construction, making a single instance safe to share across calls / threads and unbreaking the `is_thin` in-situ-strength branch on subsequent calls.

Fixes #192

## Test plan
- [x] `pytest tests/ -k larc05 -x` &mdash; 47 passed (43 pre-existing + 4 new)
- [x] New `TestLaRC05PlyThicknessOverrideIsLocal` pins:
  - override does not mutate `criterion.ply_thickness`
  - interleaved calls on a shared instance match isolated calls
  - `is_thin` branch stays correct after a thick override followed by a default call
  - `_in_situ_strengths` accepts the new thickness parameter


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_