### PR TITLE
fix(tsai_hill): reserve factor is 1/sqrt(FI), not 1/FI

### DIFF
--- a/src/wrinklefe/failure/tsai_hill.py
+++ b/src/wrinklefe/failure/tsai_hill.py
@@ -112,7 +112,11 @@ class TsaiHillCriterion(FailureCriterion):
         }
         mode = max(mode_terms, key=mode_terms.get)
 
-        rf = 1.0 / fi if fi > 0 else float("inf")
+        # ``fi`` is the quadratic Tsai-Hill invariant (FI=1 at failure, paper
+        # convention).  Every contributing term is purely quadratic in stress,
+        # so under proportional load scaling R the index scales as R^2 * FI(1).
+        # The linear-in-load strength ratio is therefore 1/sqrt(FI), not 1/FI.
+        rf = 1.0 / np.sqrt(fi) if fi > 0 else float("inf")
 
         return FailureResult(
             index=float(fi),

--- a/tests/test_failure/test_tsai_hill.py
+++ b/tests/test_failure/test_tsai_hill.py
@@ -102,10 +102,37 @@ class TestTsaiHillMixed:
         result = criterion.evaluate(stress, material)
         assert result.index == pytest.approx(expected, rel=1e-10)
 
-    def test_reserve_factor_is_inverse_of_index(self, criterion, material):
+    def test_reserve_factor_is_inverse_sqrt_of_index(self, criterion, material):
+        """Tsai-Hill index is quadratic in stress, so RF = 1/sqrt(FI).
+
+        With sigma_11 = Xt/2, FI = 0.25 and the correct strength ratio
+        (load multiplier to failure) is 2.0.
+        """
         stress = np.array([0.5 * material.Xt, 0.0, 0.0, 0.0, 0.0, 0.0])
         result = criterion.evaluate(stress, material)
-        assert result.reserve_factor == pytest.approx(1.0 / result.index, rel=1e-12)
+        assert result.index == pytest.approx(0.25, rel=1e-12)
+        assert result.reserve_factor == pytest.approx(2.0, rel=1e-12)
+        assert result.reserve_factor == pytest.approx(
+            1.0 / np.sqrt(result.index), rel=1e-12
+        )
+
+    def test_reserve_factor_unity_at_failure_surface(self, criterion, material):
+        """At sigma_11 = Xt the stress state is on the failure surface:
+        FI = 1 and RF = 1."""
+        stress = np.array([material.Xt, 0.0, 0.0, 0.0, 0.0, 0.0])
+        result = criterion.evaluate(stress, material)
+        assert result.index == pytest.approx(1.0, rel=1e-12)
+        assert result.reserve_factor == pytest.approx(1.0, rel=1e-12)
+
+    def test_reserve_factor_scales_linearly_with_load(self, criterion, material):
+        """For any quadratic FI(R) = R^2 * FI(1), RF(R) = RF(1)/R."""
+        base_stress = np.array(
+            [0.3 * material.Xt, 0.2 * material.Yt, 0.0, 0.0, 0.0, 0.1 * material.S12]
+        )
+        scale = 3.0
+        rf_base = criterion.evaluate(base_stress, material).reserve_factor
+        rf_scaled = criterion.evaluate(scale * base_stress, material).reserve_factor
+        assert rf_scaled == pytest.approx(rf_base / scale, rel=1e-12)
 
     def test_criterion_name(self, criterion, material):
         result = criterion.evaluate(np.zeros(6), material)


### PR DESCRIPTION
## Summary
- The Tsai-Hill failure index is a pure-quadratic invariant in stress (six squared terms + three bilinear interaction terms, no linear/constant terms), so under proportional load scaling `R`, `FI(R) = R^2 * FI(1)`.
- Reserve factor now returns `1/sqrt(FI)` (the true linear-in-load strength ratio) instead of `1/FI`. `index` still equals `FI` (paper convention; FI=1 at failure).
- `mode` identification logic untouched.

Fixes #191

## Test plan
- [x] `pytest tests/ -k "tsai_hill or tsai"` &mdash; 21 passed
- [x] `pytest tests/test_failure/` &mdash; 175 passed
- [x] `pytest tests/test_integration/test_analysis.py` &mdash; 23 passed
- [x] Replaced the obsolete `test_reserve_factor_is_inverse_of_index` (which pinned the buggy `1/FI` behavior) with three new tests:
  - `s1 = Xt/2` &rarr; `FI = 0.25`, `RF = 2.0`
  - `s1 = Xt` &rarr; `FI = 1`, `RF = 1`
  - Under proportional scaling `R`, `RF(R) = RF(1)/R`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_