### PR TITLE
fix(analysis): default interface_1/interface_2 to midplane instead of hardcoded 11/12

### DIFF
--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -313,10 +313,16 @@ class AnalysisConfig:
     angles : list[float] or None
         Ply angles in degrees.  ``None`` uses a quasi-isotropic
         ``[0/45/-45/90]_3s`` layup (24 plies).
-    interface_1 : int
-        Ply interface for the first wrinkle.  Default 11.
-    interface_2 : int
-        Ply interface for the second wrinkle.  Default 12.
+    interface_1 : int or None
+        Ply interface for the first wrinkle.  ``None`` (default) resolves
+        to the midplane, ``(n_plies // 2) - 1``, so the wrinkle sits just
+        below the midplane regardless of layup length.  For the default
+        24-ply layup this is 11.
+    interface_2 : int or None
+        Ply interface for the second wrinkle.  ``None`` (default) resolves
+        to the midplane, ``n_plies // 2``, so the wrinkle sits just above
+        the midplane regardless of layup length.  For the default 24-ply
+        layup this is 12.
     nx : int
         Mesh divisions in x.  Default 12.
     ny : int
@@ -371,8 +377,12 @@ class AnalysisConfig:
     ply_thickness: float = 0.183  # mm (1 ply thickness for CYCOM X850/T800)
 
     # Wrinkle placement
-    interface_1: int = 11
-    interface_2: int = 12
+    # None → midplane (resolved in __post_init__ once `angles` is known),
+    # so the defaults track the layup length instead of being pinned to
+    # the 24-ply quasi-isotropic default.  Explicit ints are validated
+    # against the layup as before.
+    interface_1: Optional[int] = None
+    interface_2: Optional[int] = None
 
     # Mesh
     nx: int = 12
@@ -409,6 +419,16 @@ class AnalysisConfig:
             # Quasi-isotropic [0/45/-45/90]_3s → 24 plies
             base = [0, 45, -45, 90]
             self.angles = (base * 3) + list(reversed(base * 3))
+
+        # Interface defaults: straddle the midplane of the resolved layup
+        # so users who override `angles` with a shorter stack don't trip
+        # the validator below.  For the default 24-ply layup this still
+        # gives (11, 12), matching the previous hard-coded defaults.
+        n_plies = len(self.angles)
+        if self.interface_1 is None:
+            self.interface_1 = (n_plies // 2) - 1
+        if self.interface_2 is None:
+            self.interface_2 = n_plies // 2
 
         self._validate()
 

--- a/tests/test_analysis_config_interface_defaults.py
+++ b/tests/test_analysis_config_interface_defaults.py
@@ -1,0 +1,65 @@
+"""Regression tests for issue #190: interface_1/interface_2 defaults.
+
+Previously ``AnalysisConfig.interface_1`` / ``interface_2`` defaulted to
+the literals ``11`` / ``12``, which are only valid for the default
+24-ply quasi-isotropic layup.  Any user-supplied ``angles`` shorter
+than 13 plies (e.g. the canonical ``[0, 90]`` smoke-test layup) raised
+``ValueError`` during ``__post_init__`` even though the user had not
+touched the interface fields at all.
+
+The fix uses the same sentinel pattern as ``domain_length``: the
+defaults are ``None`` and resolve to the midplane pair
+``((n_plies // 2) - 1, n_plies // 2)`` once ``angles`` is known.
+Explicit out-of-range integers must still raise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig
+
+
+def test_short_layup_constructs_without_explicit_interfaces():
+    """Two-ply layup must construct cleanly and pick midplane interfaces."""
+    cfg = AnalysisConfig(angles=[0, 90])
+    # For n_plies=2: (2 // 2) - 1 = 0, 2 // 2 = 1 → straddle the midplane.
+    assert cfg.interface_1 == 0
+    assert cfg.interface_2 == 1
+
+
+def test_eight_ply_ud_layup_picks_midplane_defaults():
+    """UD [0]*8 must construct and place wrinkles around the midplane."""
+    cfg = AnalysisConfig(angles=[0] * 8)
+    assert cfg.interface_1 == 3
+    assert cfg.interface_2 == 4
+
+
+def test_default_24_ply_layup_keeps_11_and_12():
+    """The default 24-ply layup must keep the legacy (11, 12) defaults so
+    existing fixtures and saved results don't shift."""
+    cfg = AnalysisConfig()
+    assert len(cfg.angles) == 24
+    assert cfg.interface_1 == 11
+    assert cfg.interface_2 == 12
+
+
+def test_explicit_interface_values_still_honoured():
+    """User-supplied in-range values must override the midplane defaults."""
+    cfg = AnalysisConfig(angles=[0, 90, 0, 90], interface_1=1, interface_2=2)
+    assert cfg.interface_1 == 1
+    assert cfg.interface_2 == 2
+
+
+def test_explicit_out_of_range_interface_still_raises():
+    """Explicit out-of-range integers must still fail validation."""
+    with pytest.raises(ValueError, match=r"interface_1 must be in \[0, 2\)"):
+        AnalysisConfig(angles=[0, 90], interface_1=11)
+    with pytest.raises(ValueError, match=r"interface_2 must be in \[0, 2\)"):
+        AnalysisConfig(angles=[0, 90], interface_2=12)
+
+
+def test_explicit_negative_interface_still_raises():
+    """Negative explicit indices must still fail validation."""
+    with pytest.raises(ValueError, match=r"interface_1 must be in \[0, 4\)"):
+        AnalysisConfig(angles=[0, 90, 0, 90], interface_1=-1)


### PR DESCRIPTION
## Summary
- `AnalysisConfig.interface_1` / `interface_2` defaults of `11` / `12` were tied to the default 24-ply layup. Any user-supplied `angles` shorter than 13 plies (e.g. `[0, 90]`, `[0]*8`) raised `ValueError` from `__post_init__` before any analysis could run, breaking `compare_morphologies` / `parametric_sweep` users with custom `base_config`.
- Defaults changed to `Optional[int] = None`. `__post_init__` now resolves `None` to `(n_plies // 2) - 1` and `n_plies // 2` after `angles` is resolved (mirrors the existing sentinel pattern used by `domain_length`).
- For the default 24-ply layup the resolved values are still `(11, 12)` &mdash; no fixture drift.
- Explicit user values still go through the strict range check unchanged.

Fixes #190

## Test plan
- [x] `pytest tests/ -k "analysis_config or analysis" -x` &mdash; 95 passed
- [x] New `tests/test_analysis_config_interface_defaults.py` pins:
  - `AnalysisConfig(angles=[0, 90])` constructs with interfaces `(0, 1)`
  - `AnalysisConfig(angles=[0]*8)` gets `(3, 4)`
  - Default 24-ply config still resolves to `(11, 12)`
  - Explicit in-range values are honoured
  - Explicit out-of-range / negative values still raise `ValueError`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_