### PR TITLE
fix(viz): preserve x:y:z aspect ratio in 3D matplotlib plots via set_box_aspect

### DIFF
--- a/src/wrinklefe/viz/__init__.py
+++ b/src/wrinklefe/viz/__init__.py
@@ -31,6 +31,7 @@ from wrinklefe.viz.style import (
     figure_context,
     get_morphology_style,
     save_figure,
+    set_axes_equal_aspect,
     set_publication_style,
 )
 
@@ -72,6 +73,7 @@ __all__ = [
     "save_figure",
     "figure_context",
     "get_morphology_style",
+    "set_axes_equal_aspect",
     # 2D plots
     "plot_wrinkle_profile",
     "plot_dual_wrinkle_profiles",

--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -46,6 +46,7 @@ from wrinklefe.viz.style import (
     FIGSIZE_DOUBLE_COLUMN,
     colorbar_setup,
     ensure_axes,
+    set_axes_equal_aspect,
     set_publication_style,
 )
 
@@ -329,6 +330,7 @@ def plot_mesh_3d(
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
     ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
@@ -434,6 +436,7 @@ def plot_displacement_3d(
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
     ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
@@ -556,6 +559,7 @@ def plot_stress_contour_3d(
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
     ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
@@ -680,6 +684,7 @@ def plot_buckling_mode(
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
     ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -250,6 +250,40 @@ def ensure_axes(
     return fig.add_subplot(111)
 
 
+def set_axes_equal_aspect(
+    ax: Axes,
+    mins: "np.ndarray",
+    maxs: "np.ndarray",
+) -> None:
+    """Set a 3D axes box aspect to match physical data extents.
+
+    Matplotlib's default 3D layout stretches the data to fill a roughly
+    cubical viewport, which visually distorts thin / tall objects (e.g.
+    a wrinkled laminate that is ~24 mm x ~12 mm x ~1-2 mm). Calling
+    :meth:`~mpl_toolkits.mplot3d.axes3d.Axes3D.set_box_aspect` with the
+    per-axis extents preserves the true x:y:z ratio, matching the Plotly
+    ``aspectmode="data"`` behaviour used elsewhere.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        A 3D axes (``projection='3d'``). Available in matplotlib >= 3.3.
+    mins, maxs : numpy.ndarray
+        Length-3 arrays of the per-axis minimum and maximum coordinates
+        of the data (typically ``nodes.min(axis=0)`` / ``nodes.max(axis=0)``).
+
+    Notes
+    -----
+    Any zero-extent axis is replaced with ``1.0`` to avoid a degenerate
+    box-aspect that would otherwise cause ``set_box_aspect`` to fail.
+    """
+    extents = np.asarray(maxs, dtype=float) - np.asarray(mins, dtype=float)
+    # Guard against zero (or negative due to numerical noise) extents that
+    # would make set_box_aspect crash.
+    safe = np.where(extents > 0, extents, 1.0)
+    ax.set_box_aspect(tuple(safe))
+
+
 def save_figure(
     ax_or_fig: Union[Axes, Figure],
     path: Union[str, "os.PathLike[str]"],

--- a/tests/test_viz/test_plots_3d_box_aspect.py
+++ b/tests/test_viz/test_plots_3d_box_aspect.py
@@ -1,0 +1,116 @@
+"""Regression tests for issue #194: 3D matplotlib plots distort aspect ratio.
+
+The four 3D plot helpers in :mod:`wrinklefe.viz.plots_3d` previously set
+``xlim``/``ylim``/``zlim`` from the node-bounding box but never called
+``ax.set_box_aspect(...)``. Matplotlib's default behaviour stretches data
+into a roughly cubical viewport, so a thin laminate (~24 mm x ~12 mm x
+~1 mm) appeared with its through-thickness axis blown up ~10x relative
+to in-plane.
+
+These tests render a tall-thin mesh (20 x 10 x 1 mm) and assert the
+returned axes' ``get_box_aspect()`` is proportional to the physical
+extents.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.core.mesh import MeshData, WrinkleMesh
+from wrinklefe.viz import plot_mesh_3d
+from wrinklefe.viz.style import set_axes_equal_aspect
+
+
+@pytest.fixture(autouse=True)
+def _clean_figures():
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def _build_tall_thin_mesh() -> MeshData:
+    """Build a 20 mm x 10 mm x ~1 mm structured hex mesh.
+
+    Uses the real ``WrinkleMesh`` factory so the returned object is a
+    valid :class:`MeshData` with sane node coordinates.
+    """
+    mat = OrthotropicMaterial()
+    # 10 plies of 0.1 mm each => total z extent ~1.0 mm.
+    laminate = Laminate.symmetric([0] * 5, material=mat, ply_thickness=0.1)
+    gen = WrinkleMesh(
+        laminate=laminate,
+        wrinkle_config=None,
+        Lx=20.0,
+        Ly=10.0,
+        nx=4,
+        ny=3,
+        nz_per_ply=1,
+    )
+    return gen.generate()
+
+
+def _assert_proportional(observed, expected, *, rtol=1e-6):
+    """Assert ``observed`` is a positive scalar multiple of ``expected``."""
+    observed = np.asarray(observed, dtype=float)
+    expected = np.asarray(expected, dtype=float)
+    assert observed.shape == expected.shape
+    # Both must be strictly positive so the ratio is well-defined.
+    assert np.all(observed > 0)
+    assert np.all(expected > 0)
+    ratios = observed / expected
+    np.testing.assert_allclose(ratios, ratios[0] * np.ones_like(ratios), rtol=rtol)
+
+
+def test_set_axes_equal_aspect_matches_extents():
+    """The helper sets ``get_box_aspect`` proportional to ``maxs - mins``."""
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    mins = np.array([0.0, 0.0, 0.0])
+    maxs = np.array([20.0, 10.0, 1.0])
+    set_axes_equal_aspect(ax, mins, maxs)
+    box = np.asarray(ax.get_box_aspect(), dtype=float)
+    _assert_proportional(box, maxs - mins)
+    plt.close(fig)
+
+
+def test_set_axes_equal_aspect_handles_zero_extent():
+    """A zero-extent axis must not crash and must yield a positive aspect."""
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    mins = np.array([0.0, 0.0, 0.0])
+    maxs = np.array([20.0, 10.0, 0.0])  # degenerate z
+    # Must not raise.
+    set_axes_equal_aspect(ax, mins, maxs)
+    box = np.asarray(ax.get_box_aspect(), dtype=float)
+    # All entries strictly positive (zero extent substituted by 1.0).
+    assert np.all(box > 0)
+    # In-plane (x, y) must still preserve their ratio.
+    _assert_proportional(box[:2], np.array([20.0, 10.0]))
+    plt.close(fig)
+
+
+def test_plot_mesh_3d_preserves_aspect_on_tall_thin_mesh():
+    """plot_mesh_3d's axes box aspect is proportional to physical extents."""
+    mesh = _build_tall_thin_mesh()
+    extents = mesh.nodes.max(axis=0) - mesh.nodes.min(axis=0)
+
+    # Sanity: this mesh really is tall-thin (~20 x 10 x 1).
+    assert extents[0] > 5 * extents[2]
+    assert extents[1] > 5 * extents[2]
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    out_ax = plot_mesh_3d(mesh, ax=ax)
+    assert out_ax is ax
+
+    box = np.asarray(ax.get_box_aspect(), dtype=float)
+    _assert_proportional(box, extents)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- All four 3D matplotlib plot helpers (`plot_mesh_3d`, `plot_displacement_3d`, `plot_stress_contour_3d`, `plot_buckling_mode`) previously set `xlim/ylim/zlim` but never called `ax.set_box_aspect`, so matplotlib stretched everything into a roughly-cubical viewport. A typical wrinkled laminate (~24 &times; 12 &times; 1.5 mm) rendered with the thickness axis blown up ~10&times; relative to in-plane, making a subtle ply ripple look like a corrugated roof &mdash; and the matplotlib PNGs disagreed visually with the Streamlit Plotly `mesh3d_figure` (which already uses `aspectmode="data"`).
- Added `set_axes_equal_aspect(ax, mins, maxs)` to `viz/style.py` that calls `ax.set_box_aspect(extents)`, with a guard substituting `1.0` for zero-extent axes so degenerate meshes don't crash.
- All four helpers now call it once, after the existing `set_xlim/ylim/zlim` block.
- Re-exported the helper as `wrinklefe.viz.set_axes_equal_aspect`.

Fixes #194

## Test plan
- [x] `pytest tests/ -k "plot_3d or plots_3d or viz" -x` &mdash; 36 passed (33 existing + 3 new)
- [x] New `tests/test_viz/test_plots_3d_box_aspect.py` pins:
  - Helper sets `ax.get_box_aspect()` proportional to `maxs - mins`
  - Zero-extent axis is handled (substituted by `1.0`) without crashing, remaining axes keep their ratio
  - `plot_mesh_3d` on a 20 &times; 10 &times; ~1 mm tall-thin mesh yields a `box_aspect` proportional to the physical extents


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_