### PR TITLE
fix(packaging): add py.typed marker so downstream type checkers use shipped hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ wrinklefe = "wrinklefe.cli:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+wrinklefe = ["py.typed"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
## Summary
- Added `src/wrinklefe/py.typed` (empty PEP 561 marker file).
- Added `[tool.setuptools.package-data] wrinklefe = ["py.typed"]` to `pyproject.toml` so setuptools ships the marker in the built wheel.
- Without this, downstream consumers running `mypy` against `import wrinklefe` silently fall back to `Any`, negating the value of the in-repo type hints that `CONTRIBUTING.md` already mandates.

Fixes #202

## Test plan
- [x] `pip wheel . --no-deps -w /tmp/wheelcheck` &rarr; `unzip -l` confirms the wheel contains `wrinklefe/py.typed`
- [x] `pytest tests/ -x --collect-only` &mdash; collection unchanged by this metadata-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_