### PR TITLE
fix(analysis,cli): remove dead run_buckling/run_montecarlo/mc_* fields and CLI flags

### DIFF
--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -339,16 +339,6 @@ class AnalysisConfig:
         Default ``-0.01`` (1 % compression).
     solver : str
         Linear solver: ``'direct'`` or ``'iterative'``.  Default ``'direct'``.
-    run_buckling : bool
-        Whether to perform buckling analysis.  Default ``False``.
-    n_buckling_modes : int
-        Number of buckling modes to extract.  Default 5.
-    run_montecarlo : bool
-        Whether to perform Monte Carlo analysis.  Default ``False``.
-    mc_samples : int
-        Number of Monte Carlo samples.  Default 5000.
-    mc_seed : int or None
-        Random seed for Monte Carlo reproducibility.  Default 42.
     verbose : bool
         Print progress information.  Default ``False``.
     """
@@ -396,13 +386,6 @@ class AnalysisConfig:
 
     # Solver
     solver: str = "direct"
-
-    # Optional analyses
-    run_buckling: bool = False
-    n_buckling_modes: int = 5
-    run_montecarlo: bool = False
-    mc_samples: int = 5000
-    mc_seed: Optional[int] = 42
 
     # Analytical-only mode (skip FE assembly)
     analytical_only: bool = False
@@ -562,35 +545,6 @@ class AnalysisConfig:
             raise ValueError(
                 f"AnalysisConfig.solver must be one of "
                 f"{list(valid_solvers)}, got {self.solver!r}"
-            )
-
-        # --- Optional analyses ---------------------------------------
-        if not isinstance(self.n_buckling_modes, int) or isinstance(
-            self.n_buckling_modes, bool
-        ):
-            raise ValueError(
-                f"AnalysisConfig.n_buckling_modes must be an int, "
-                f"got {self.n_buckling_modes!r}"
-            )
-        if self.n_buckling_modes < 1:
-            raise ValueError(
-                f"AnalysisConfig.n_buckling_modes must be >= 1, "
-                f"got {self.n_buckling_modes}"
-            )
-        # mc_samples must be a usable sample count.  Both issues ask for
-        # mc_samples >= 1; reject <= 0 unconditionally (a clearly-invalid
-        # value) and require a valid int whenever Monte Carlo will run.
-        if not isinstance(self.mc_samples, int) or isinstance(
-            self.mc_samples, bool
-        ):
-            raise ValueError(
-                f"AnalysisConfig.mc_samples must be an int, "
-                f"got {self.mc_samples!r}"
-            )
-        if self.mc_samples < 1:
-            raise ValueError(
-                f"AnalysisConfig.mc_samples must be >= 1, "
-                f"got {self.mc_samples}"
             )
 
 
@@ -780,8 +734,6 @@ class WrinkleAnalysis:
         4. Generate mesh with wrinkle deformation.
         5. Run static FE analysis.
         6. Evaluate failure criteria on the FE stress field.
-        7. (Optional) Run buckling analysis.
-        8. (Optional) Run Monte Carlo + Jensen gap analysis.
 
         Returns
         -------

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -130,30 +130,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Linear solver type (default: direct)",
     )
     p_analyze.add_argument(
-        "--buckling", action="store_true", default=False,
-        help="Run linear buckling analysis (implies full FE solve)",
-    )
-    p_analyze.add_argument(
-        "--montecarlo", action="store_true", default=False,
-        help="Run Monte Carlo simulation (implies full FE solve)",
-    )
-    p_analyze.add_argument(
-        "--mc-samples", type=int, default=5000,
-        help="Number of Monte Carlo samples (default: 5000)",
-    )
-    p_analyze.add_argument(
         "--fe", action=argparse.BooleanOptionalAction, default=None,
         help=(
             "Force a full FE solve (--fe) or skip it (--no-fe). "
-            "Default: FE on unless overridden. --buckling/--montecarlo "
-            "imply --fe."
+            "Default: FE on unless overridden."
         ),
     )
     p_analyze.add_argument(
         "--analytical-only", action="store_true", default=False,
         help=(
-            "Run analytical predictions only, skipping the FE solve, "
-            "buckling, and Monte Carlo branches."
+            "Run analytical predictions only, skipping the FE solve."
         ),
     )
     p_analyze.add_argument(
@@ -293,21 +279,13 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     # Resolve analytical-only vs. full FE intent.
     #
     # Precedence (highest first):
-    #   1. --analytical-only       -> skip FE / buckling / MC
-    #   2. --buckling / --montecarlo / --fe -> full FE solve
-    #   3. --no-fe                 -> analytical-only
-    #   4. default                 -> full FE solve
+    #   1. --analytical-only -> skip FE
+    #   2. --fe              -> full FE solve
+    #   3. --no-fe           -> analytical-only
+    #   4. default           -> full FE solve
     if args.analytical_only:
-        if args.buckling or args.montecarlo:
-            print(
-                "error: --analytical-only is incompatible with "
-                "--buckling/--montecarlo (those flags require a full "
-                "FE solve).",
-                file=sys.stderr,
-            )
-            sys.exit(2)
         analytical_only = True
-    elif args.buckling or args.montecarlo or args.fe is True:
+    elif args.fe is True:
         analytical_only = False
     elif args.fe is False:
         analytical_only = True
@@ -328,9 +306,6 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         ny=args.ny,
         applied_strain=args.strain,
         solver=args.solver,
-        run_buckling=args.buckling,
-        run_montecarlo=args.montecarlo,
-        mc_samples=args.mc_samples,
         analytical_only=analytical_only,
         verbose=args.verbose,
     )

--- a/tests/test_analysis_config.py
+++ b/tests/test_analysis_config.py
@@ -3,11 +3,11 @@
 Verifies the fix for issues #39 / #29: ``AnalysisConfig.__post_init__``
 previously performed zero validation, so physically invalid inputs
 (negative amplitude, non-positive wavelength/width, unknown morphology,
-non-positive ``mc_samples``, etc.) were silently accepted and surfaced
-only as obscure tracebacks deep in the solver/mesh path.  Construction
-must now fail fast with a clear :class:`ValueError` naming the field and
-the offending value, while every valid configuration (including boundary
-values) still constructs unchanged.
+etc.) were silently accepted and surfaced only as obscure tracebacks
+deep in the solver/mesh path.  Construction must now fail fast with a
+clear :class:`ValueError` naming the field and the offending value,
+while every valid configuration (including boundary values) still
+constructs unchanged.
 """
 
 from __future__ import annotations
@@ -48,8 +48,6 @@ def test_fully_specified_valid_config_constructs():
         nz_per_ply=1,
         domain_width=10.0,
         applied_strain=-0.005,
-        run_montecarlo=True,
-        mc_samples=100,
     )
     assert cfg.morphology == "concave"
 
@@ -92,8 +90,7 @@ def test_boundary_valid_values_accepted():
     AnalysisConfig(decay_floor=0.0)
     AnalysisConfig(decay_floor=1.0)
     # Smallest valid structural integers / counts.
-    AnalysisConfig(nx=1, ny=1, nz_per_ply=1, n_buckling_modes=1,
-                   mc_samples=1)
+    AnalysisConfig(nx=1, ny=1, nz_per_ply=1)
     # interface indices at the inclusive lower / exclusive upper bound.
     AnalysisConfig(angles=[0, 90, 0, 90], interface_1=0, interface_2=3)
     # explicit numeric phase must not require a dual-wrinkle name and
@@ -138,21 +135,11 @@ def test_boundary_valid_values_accepted():
         ({"nx": 0}, r"nx must be >= 1.*got 0"),
         ({"ny": 0}, r"ny must be >= 1.*got 0"),
         ({"nz_per_ply": -2}, r"nz_per_ply must be >= 1.*got -2"),
-        ({"n_buckling_modes": 0}, r"n_buckling_modes must be >= 1.*got 0"),
-        ({"mc_samples": 0}, r"mc_samples must be >= 1.*got 0"),
-        ({"mc_samples": -10}, r"mc_samples must be >= 1.*got -10"),
     ],
 )
 def test_invalid_config_raises_value_error(kwargs, match):
     with pytest.raises(ValueError, match=match):
         AnalysisConfig(**kwargs)
-
-
-def test_negative_mc_samples_rejected_even_when_montecarlo_off():
-    """A clearly-invalid mc_samples (<= 0) is rejected regardless of
-    whether Monte Carlo will actually run (matches the issue ask)."""
-    with pytest.raises(ValueError, match=r"mc_samples must be >= 1"):
-        AnalysisConfig(run_montecarlo=False, mc_samples=0)
 
 
 def test_explicit_phase_does_not_require_dual_wrinkle_name():

--- a/tests/test_analysis_config_no_dead_fields.py
+++ b/tests/test_analysis_config_no_dead_fields.py
@@ -1,0 +1,110 @@
+"""Regression tests for issue #186: remove dead buckling / Monte Carlo
+configuration fields from :class:`AnalysisConfig`.
+
+The fields ``run_buckling``, ``n_buckling_modes``, ``run_montecarlo``,
+``mc_samples``, and ``mc_seed`` (along with the matching CLI flags
+``--buckling``, ``--montecarlo``, ``--mc-samples``) were declared,
+validated, and plumbed through the CLI but never read by
+:meth:`WrinkleAnalysis.run`.  The docstring promised optional buckling
+and Monte Carlo steps that did not exist.
+
+Option 1 of the issue (remove the dead fields) was chosen over option 2
+(wire them up), as wiring them up would require a much larger scope
+(buckling extraction, MC distribution choices, Jensen gap analysis,
+testing).  This file pins the removal so the silent no-op cannot
+regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig
+
+
+# --------------------------------------------------------------------------- #
+# AnalysisConfig: removed kwargs now raise TypeError
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "kwarg, value",
+    [
+        ("run_buckling", True),
+        ("n_buckling_modes", 5),
+        ("run_montecarlo", True),
+        ("mc_samples", 1000),
+        ("mc_seed", 42),
+    ],
+)
+def test_removed_kwargs_raise_type_error(kwarg, value):
+    """Constructing ``AnalysisConfig`` with any of the five removed
+    kwargs must raise ``TypeError`` — not silently succeed.
+
+    This is the core acceptance criterion of issue #186: the fields are
+    gone, so a user who still passes them gets a loud failure rather
+    than a paid-for-but-ignored construction-time validator."""
+    with pytest.raises(TypeError):
+        AnalysisConfig(**{kwarg: value})
+
+
+def test_removed_fields_absent_from_dataclass():
+    """Belt-and-braces: the dataclass must not carry the removed fields
+    as attributes either (so reflection / `dataclasses.fields` users
+    don't see them)."""
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(AnalysisConfig)}
+    for dead in (
+        "run_buckling",
+        "n_buckling_modes",
+        "run_montecarlo",
+        "mc_samples",
+        "mc_seed",
+    ):
+        assert dead not in field_names, (
+            f"AnalysisConfig still declares dead field {dead!r}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# CLI: removed argparse flags no longer parse
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("flag", ["--buckling", "--montecarlo", "--mc-samples"])
+def test_removed_cli_flags_rejected(flag):
+    """The CLI no longer advertises ``--buckling``, ``--montecarlo``, or
+    ``--mc-samples``; argparse must therefore reject them with the
+    standard exit code 2 (CLI usage error)."""
+    from wrinklefe.cli import main as cli_main
+
+    # ``--mc-samples`` takes a value; the rest are flags.
+    args = ["analyze", flag]
+    if flag == "--mc-samples":
+        args.append("100")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(args)
+    assert exc_info.value.code == 2
+
+
+# --------------------------------------------------------------------------- #
+# WrinkleAnalysis.run() docstring no longer promises buckling/MC steps
+# --------------------------------------------------------------------------- #
+
+
+def test_run_docstring_does_not_mention_buckling_or_montecarlo():
+    """The ``run()`` docstring used to list optional buckling and Monte
+    Carlo steps that ``run()`` never actually performed.  Removing the
+    promise is part of issue #186."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    doc = WrinkleAnalysis.run.__doc__ or ""
+    lower = doc.lower()
+    assert "buckling" not in lower, (
+        "run() docstring still mentions buckling after #186"
+    )
+    assert "monte carlo" not in lower, (
+        "run() docstring still mentions Monte Carlo after #186"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,49 +82,10 @@ def test_analyze_default_runs_full_fe_solve():
         cli_main(["analyze"])
 
     cfg = captured["config"]
-    assert cfg.run_buckling is False
-    assert cfg.run_montecarlo is False
     # The CLI used to hard-code analytical_only=True. Default is now
     # full FE.
     assert captured["analytical_only"] is False
     assert cfg.analytical_only is False
-
-
-def test_analyze_buckling_flag_propagates():
-    """--buckling must set run_buckling and force a full FE solve."""
-    captured, patcher = _stub_analysis_run()
-    with patcher:
-        cli_main(["analyze", "--buckling"])
-
-    cfg = captured["config"]
-    assert cfg.run_buckling is True
-    assert cfg.run_montecarlo is False
-    assert captured["analytical_only"] is False
-    assert cfg.analytical_only is False
-
-
-def test_analyze_montecarlo_flag_propagates():
-    """--montecarlo must set run_montecarlo + mc_samples and run full FE."""
-    captured, patcher = _stub_analysis_run()
-    with patcher:
-        cli_main(["analyze", "--montecarlo", "--mc-samples", "37"])
-
-    cfg = captured["config"]
-    assert cfg.run_buckling is False
-    assert cfg.run_montecarlo is True
-    assert cfg.mc_samples == 37
-    assert captured["analytical_only"] is False
-
-
-def test_analyze_buckling_and_montecarlo_together():
-    captured, patcher = _stub_analysis_run()
-    with patcher:
-        cli_main(["analyze", "--buckling", "--montecarlo"])
-
-    cfg = captured["config"]
-    assert cfg.run_buckling is True
-    assert cfg.run_montecarlo is True
-    assert captured["analytical_only"] is False
 
 
 def test_analyze_analytical_only_flag_skips_fe():
@@ -133,8 +94,6 @@ def test_analyze_analytical_only_flag_skips_fe():
         cli_main(["analyze", "--analytical-only"])
 
     cfg = captured["config"]
-    assert cfg.run_buckling is False
-    assert cfg.run_montecarlo is False
     assert captured["analytical_only"] is True
     assert cfg.analytical_only is True
 
@@ -153,17 +112,6 @@ def test_analyze_fe_flag_runs_full_fe():
         cli_main(["analyze", "--fe"])
 
     assert captured["analytical_only"] is False
-
-
-def test_analyze_analytical_only_with_buckling_errors(capsys):
-    """--analytical-only conflicts with --buckling and must exit 2."""
-    captured, patcher = _stub_analysis_run()
-    with patcher, pytest.raises(SystemExit) as exc_info:
-        cli_main(["analyze", "--analytical-only", "--buckling"])
-
-    assert exc_info.value.code == 2
-    err = capsys.readouterr().err
-    assert "analytical-only" in err.lower()
 
 
 def test_analyze_passes_solver_and_mesh_options():

--- a/tests/test_cli_issues_7_8_9.py
+++ b/tests/test_cli_issues_7_8_9.py
@@ -5,7 +5,9 @@ caused ``wrinklefe analyze``/``compare``/``sweep`` to crash with cascading
 ``TypeError``/``AttributeError`` errors.  The fixes were:
 
 * #7: ``AnalysisConfig`` accepts ``run_buckling``, ``run_montecarlo``,
-  and ``mc_samples`` (the docstring already documented them).
+  and ``mc_samples`` (the docstring already documented them).  Those
+  fields were later removed entirely as dead code in issue #186; the
+  test below now pins the *removal*.
 * #8: ``WrinkleAnalysis.run`` accepts ``analytical_only=True`` and
   short-circuits past the FE assembly / static solve / failure /
   retention steps.
@@ -21,6 +23,7 @@ would have caught each crash; broader plumbing behaviour is covered in
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from wrinklefe.analysis import (
     AnalysisConfig,
@@ -30,21 +33,23 @@ from wrinklefe.analysis import (
 
 
 # --------------------------------------------------------------------------- #
-# Issue #7: AnalysisConfig accepts run_buckling / run_montecarlo / mc_samples
+# Issue #186 supersedes #7: the run_buckling / run_montecarlo / mc_samples
+# fields were silent no-ops and have been removed from ``AnalysisConfig``.
 # --------------------------------------------------------------------------- #
 
 
-def test_issue_7_analysis_config_accepts_buckling_and_mc_kwargs():
-    """Issue #7: constructing AnalysisConfig with the kwargs the CLI
-    forwards must not raise ``TypeError``."""
-    cfg = AnalysisConfig(
-        run_buckling=True,
-        run_montecarlo=True,
-        mc_samples=50,
-    )
-    assert cfg.run_buckling is True
-    assert cfg.run_montecarlo is True
-    assert cfg.mc_samples == 50
+@pytest.mark.parametrize(
+    "kwarg",
+    ["run_buckling", "run_montecarlo", "mc_samples", "n_buckling_modes",
+     "mc_seed"],
+)
+def test_issue_186_dead_buckling_mc_fields_removed(kwarg):
+    """Issue #186: the never-wired buckling/Monte Carlo fields were
+    removed from ``AnalysisConfig`` (the docstring promised behaviour
+    that ``run()`` never delivered).  Passing them must now raise
+    ``TypeError`` rather than silently succeed."""
+    with pytest.raises(TypeError):
+        AnalysisConfig(**{kwarg: 1})
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- Removes five dataclass fields from `AnalysisConfig` that were never read by `WrinkleAnalysis.run()`: `run_buckling`, `n_buckling_modes`, `run_montecarlo`, `mc_samples`, `mc_seed`.
- Removes the corresponding CLI flags from `cli.py`: `--buckling`, `--montecarlo`, `--mc-samples`. Also removes the unreachable `--analytical-only`/`--buckling` conflict check and refreshes the `--fe`/`--no-fe`/`--analytical-only` help text.
- Drops steps 7 ("(Optional) Run buckling analysis") and 8 ("(Optional) Run Monte Carlo + Jensen gap analysis") from `WrinkleAnalysis.run()`'s docstring (these never happened).
- Wiring up buckling + Monte Carlo is a much larger scope &mdash; this PR chooses removal (option 1 in the issue) to eliminate the silent no-op and the documentation lie.

Fixes #186

## Test plan
- [x] `pytest tests/ -x --tb=short -q` &mdash; **1009 passed, 8 skipped** (skips are pre-existing, unrelated)
- [x] New `tests/test_analysis_config_no_dead_fields.py` pins:
  - `AnalysisConfig(run_buckling=True)` raises `TypeError`
  - argparse rejects `--buckling`/`--montecarlo`/`--mc-samples`
  - `AnalysisConfig` docstring no longer references the removed fields
- [x] Pre-existing `test_cli_issues_7_8_9.py` test inverted to pin removal instead of presence

## Notes
- No shell completion files or other docs reference the removed flags (verified by `grep` across `*.py`, `*.md`, `*.toml`, `*.txt`, `*.sh`, `*.cfg`, `*.yaml`, `*.yml`).
- This is a small but user-visible CLI change. If anyone was scripting `wrinklefe analyze --buckling` they'll now get an `argparse` error &mdash; but the flag was a silent no-op, so no behaviour is actually being removed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_