### PR TITLE
fix(tests): remove 11 internal pytest.skip calls that masked coverage gaps

### DIFF
--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -36,7 +36,13 @@ from wrinklefe.io.export import (
 
 @pytest.fixture(scope="module")
 def analysis_result():
-    """Run a small WrinkleAnalysis once for the entire module."""
+    """Run a small WrinkleAnalysis once for the entire module.
+
+    The fixture runs the full FE pipeline (``analytical_only=False``) so a
+    mesh is always populated on the result. Tests in this module assume
+    ``result.mesh is not None`` -- the fixture asserts this so the export
+    tests below can use hard assertions instead of internal skips.
+    """
     mat = MaterialLibrary().get("IM7_8552")
     # NOTE: amplitude kept below the inversion threshold for this 1-element-
     # per-ply mesh; the original 0.366 mm value produced inverted hex
@@ -55,11 +61,19 @@ def analysis_result():
         domain_length=20.0,
         domain_width=8.0,
         applied_strain=-0.005,
+        analytical_only=False,
         verbose=False,
     )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        return WrinkleAnalysis(cfg).run()
+        result = WrinkleAnalysis(cfg).run()
+    # Guard: fixture must produce an FE mesh; otherwise the export tests
+    # below would degenerate into trivially-passing checks. See issue #205.
+    assert result.mesh is not None, (
+        "analysis_result fixture must produce a mesh "
+        "(analytical_only=False); export tests depend on it."
+    )
+    return result
 
 
 # ======================================================================
@@ -114,15 +128,14 @@ class TestJSONExport:
         assert 0.0 < kd <= 1.0
 
     def test_mesh_summary_present(self, analysis_result, tmp_path):
-        """Mesh summary is present when mesh was generated."""
+        """Mesh summary is present (fixture is run with FE assembly on)."""
         out = tmp_path / "results.json"
         export_results_json(analysis_result, out)
         data = json.loads(out.read_text())
-        if analysis_result.mesh is not None:
-            assert "mesh" in data
-            mesh_data = data["mesh"]
-            assert mesh_data["n_nodes"] > 0
-            assert mesh_data["n_elements"] > 0
+        assert "mesh" in data
+        mesh_data = data["mesh"]
+        assert mesh_data["n_nodes"] > 0
+        assert mesh_data["n_elements"] > 0
 
     def test_roundtrip_values(self, analysis_result, tmp_path):
         """Export and reload: values match the original result."""
@@ -157,8 +170,6 @@ class TestAbaqusExport:
 
     def test_file_created(self, analysis_result, tmp_path):
         """Abaqus file is created."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "model.inp"
         laminate = analysis_result.laminate
         export_abaqus_inp(analysis_result.mesh, laminate, out)
@@ -166,8 +177,6 @@ class TestAbaqusExport:
 
     def test_has_heading(self, analysis_result, tmp_path):
         """File starts with *HEADING section."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "model.inp"
         export_abaqus_inp(analysis_result.mesh, analysis_result.laminate, out)
         content = out.read_text()
@@ -175,8 +184,6 @@ class TestAbaqusExport:
 
     def test_has_node_section(self, analysis_result, tmp_path):
         """File contains *NODE section with correct count."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "model.inp"
         export_abaqus_inp(analysis_result.mesh, analysis_result.laminate, out)
         content = out.read_text()
@@ -196,8 +203,6 @@ class TestAbaqusExport:
 
     def test_has_element_section(self, analysis_result, tmp_path):
         """File contains *ELEMENT sections."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "model.inp"
         export_abaqus_inp(analysis_result.mesh, analysis_result.laminate, out)
         content = out.read_text()
@@ -205,8 +210,6 @@ class TestAbaqusExport:
 
     def test_has_boundary_nsets(self, analysis_result, tmp_path):
         """File contains boundary node sets."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "model.inp"
         export_abaqus_inp(analysis_result.mesh, analysis_result.laminate, out)
         content = out.read_text()
@@ -215,8 +218,6 @@ class TestAbaqusExport:
 
     def test_node_ids_one_based(self, analysis_result, tmp_path):
         """Node IDs start at 1 (Abaqus convention)."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "model.inp"
         export_abaqus_inp(analysis_result.mesh, analysis_result.laminate, out)
         content = out.read_text()
@@ -240,16 +241,12 @@ class TestVTKExport:
 
     def test_file_created(self, analysis_result, tmp_path):
         """VTK file is created."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh.vtk"
         export_vtk(analysis_result.mesh, analysis_result.field_results, out)
         assert out.exists()
 
     def test_has_vtk_header(self, analysis_result, tmp_path):
         """File has proper VTK header."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh.vtk"
         export_vtk(analysis_result.mesh, analysis_result.field_results, out)
         content = out.read_text()
@@ -258,8 +255,6 @@ class TestVTKExport:
 
     def test_correct_point_count(self, analysis_result, tmp_path):
         """POINTS count matches mesh."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh.vtk"
         export_vtk(analysis_result.mesh, analysis_result.field_results, out)
         content = out.read_text()
@@ -268,8 +263,6 @@ class TestVTKExport:
 
     def test_correct_cell_count(self, analysis_result, tmp_path):
         """CELLS count matches mesh."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh.vtk"
         export_vtk(analysis_result.mesh, analysis_result.field_results, out)
         content = out.read_text()
@@ -278,8 +271,6 @@ class TestVTKExport:
 
     def test_has_fiber_angle_data(self, analysis_result, tmp_path):
         """File contains fiber_angle point data."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh.vtk"
         export_vtk(analysis_result.mesh, analysis_result.field_results, out)
         content = out.read_text()
@@ -287,8 +278,6 @@ class TestVTKExport:
 
     def test_has_ply_id_data(self, analysis_result, tmp_path):
         """File contains ply_id cell data."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh.vtk"
         export_vtk(analysis_result.mesh, analysis_result.field_results, out)
         content = out.read_text()
@@ -296,8 +285,6 @@ class TestVTKExport:
 
     def test_vtk_without_field_results(self, analysis_result, tmp_path):
         """VTK export works with field_results=None."""
-        if analysis_result.mesh is None:
-            pytest.skip("No mesh in result")
         out = tmp_path / "mesh_no_fields.vtk"
         export_vtk(analysis_result.mesh, None, out)
         content = out.read_text()

--- a/tests/test_morphology_apply_nodes.py
+++ b/tests/test_morphology_apply_nodes.py
@@ -536,6 +536,24 @@ def test_partial_ply_ids_decay_stays_synced():
 # fibre-angle fields share the same default-mode decay.
 # ----------------------------------------------------------------------
 
+# Valid (k, n_plies) pairs for the parametrize below: ``k`` is a ply-
+# interface index and must satisfy ``k < n_plies - 1`` so that both
+# interface plies (k, k+1) exist and the upper outer surface (n_plies-1)
+# sits strictly above them. Filtering at collection time means the test
+# count reflects real coverage instead of being inflated by skipped
+# combinations (issue #205).
+_K_VALUES_OUTER = [1, 2, 3, 5, 8]
+_K_VALUES_INTERFACE = [1, 2, 3, 5]
+_N_PLIES_VALUES = [4, 8, 12]
+
+_VALID_K_N_OUTER = [
+    (k, n) for n in _N_PLIES_VALUES for k in _K_VALUES_OUTER if k < n - 1
+]
+_VALID_K_N_INTERFACE = [
+    (k, n) for n in _N_PLIES_VALUES for k in _K_VALUES_INTERFACE if k < n - 1
+]
+
+
 class TestIssue17_18DefaultDecayBC:
     """Regression tests pinning the contract from issues #17 and #18.
 
@@ -548,12 +566,9 @@ class TestIssue17_18DefaultDecayBC:
     displacement is zero must also see zero misalignment-angle decay.
     """
 
-    @pytest.mark.parametrize("k", [1, 2, 3, 5, 8])
-    @pytest.mark.parametrize("n_plies", [4, 8, 12])
+    @pytest.mark.parametrize("k,n_plies", _VALID_K_N_OUTER)
     def test_outer_surfaces_zero_decay(self, k, n_plies):
         """#17: bottom (p=0) and top (p=n-1) outer surfaces -> decay=0."""
-        if k >= n_plies - 1:
-            pytest.skip(f"k={k} invalid for n_plies={n_plies}")
         prof = GaussianSinusoidal(
             amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
         )
@@ -568,12 +583,9 @@ class TestIssue17_18DefaultDecayBC:
         if k + 1 < n_plies - 1:
             npt.assert_allclose(dz[ply == n_plies - 1], 0.0, atol=1e-15)
 
-    @pytest.mark.parametrize("k", [1, 2, 3, 5])
-    @pytest.mark.parametrize("n_plies", [4, 8, 12])
+    @pytest.mark.parametrize("k,n_plies", _VALID_K_N_INTERFACE)
     def test_interface_plies_unit_decay(self, k, n_plies):
         """#17: interface plies (p=k and p=k+1) carry the full profile."""
-        if k >= n_plies - 1:
-            pytest.skip(f"k={k} invalid for n_plies={n_plies}")
         prof = GaussianSinusoidal(
             amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
         )
@@ -585,8 +597,7 @@ class TestIssue17_18DefaultDecayBC:
         npt.assert_allclose(dz[ply == k][0], amp, rtol=1e-12)
         npt.assert_allclose(dz[ply == k + 1][0], amp, rtol=1e-12)
 
-    @pytest.mark.parametrize("k", [1, 2, 3, 5])
-    @pytest.mark.parametrize("n_plies", [4, 8, 12])
+    @pytest.mark.parametrize("k,n_plies", _VALID_K_N_INTERFACE)
     def test_displacement_and_angle_share_decay_default_mode(
         self, k, n_plies
     ):
@@ -594,8 +605,6 @@ class TestIssue17_18DefaultDecayBC:
         must equal decay extracted from the fibre-angle field. In
         particular: the outer-surface plies that get zero displacement
         must also get zero angle (no inflated misalignment downstream)."""
-        if k >= n_plies - 1:
-            pytest.skip(f"k={k} invalid for n_plies={n_plies}")
         prof = GaussianSinusoidal(
             amplitude=0.366, wavelength=16.0, width=12.0, center=0.0
         )


### PR DESCRIPTION
## Summary
- Removes test-internal `pytest.skip(...)` calls that masked real coverage gaps.
- `tests/test_io/test_export.py`: the `analysis_result` fixture now explicitly sets `analytical_only=False` and asserts `result.mesh is not None`, so the 13 `if mesh is None: pytest.skip("No mesh in result")` guards are removed. `test_mesh_summary_present` is tightened to assert unconditionally.
- `tests/test_morphology_apply_nodes.py`: invalid `(k, n_plies)` combinations are now filtered at collection time via two module-level lists `_VALID_K_N_OUTER` / `_VALID_K_N_INTERFACE` (consumed by `@pytest.mark.parametrize("k,n_plies", ...)`). The three per-test `pytest.skip(f"k={k} invalid ...")` calls are gone.

Fixes #205

## Test plan
- [x] `pytest tests/test_io/test_export.py tests/test_morphology_apply_nodes.py` &mdash; **115 passed, 0 skipped** (down from 115 passed, 8 skipped)
- [x] Same tests still cover the same export branches and morphology-apply paths &mdash; no assertions were removed, only the skip guards.
- [x] No production code changed (test-only diff: +42 / -46).

## Notes
- The issue mentioned 13 mesh-skip occurrences in `test_io/test_export.py`. With the default `analytical_only=False`, those branches were already unreachable in practice (the fixture reported 0 mesh-skips). The 8 observed skips came entirely from the morphology parametrize. The guards are still removed for both cases so a future regression that drops the mesh would now produce a hard test failure instead of a silent skip.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_