### PR TITLE
fix(ci): add coverage reporting and concurrency cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -32,7 +36,14 @@ jobs:
           pip install -e ".[all,dev]"
 
       - name: Run tests
-        run: pytest --tb=short -q
+        run: pytest --tb=short -q --cov=wrinklefe --cov-report=xml --cov-report=term
 
       - name: Check import
         run: python -c "import wrinklefe; print(f'WrinkleFE {wrinklefe.__version__} imported successfully')"
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Three independent CI improvements:

1. **Concurrency cancel-in-progress** — both `ci.yml` and `lint.yml` now declare:
   ```yaml
   concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
   ```
   so a new push supersedes any in-flight run on the same branch instead of doubling-up the 2 OS &times; 3 Python matrix.

2. **Coverage reporting** — `ci.yml` now invokes pytest with `--cov=wrinklefe --cov-report=xml --cov-report=term`. Every CI run prints a terminal coverage summary.

3. **Codecov upload** (ubuntu/3.11 only) — uses `codecov/codecov-action@v5` with `fail_ci_if_error: false`, gated on `matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'`, so a Codecov outage cannot break CI.

Fixes #199

## Test plan
- [x] YAML validated: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/lint.yml'))"`
- [x] Local `pytest --cov=wrinklefe --cov-report=term --cov-report=xml -q` produces the expected `coverage.xml` and terminal summary
- [x] No changes to the test matrix (OS / Python versions) &mdash; this is a workflow-config-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_