### PR TITLE
docs: fix ARCHITECTURE.md drift (material count + missing module rows)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,7 +59,7 @@ from wrinklefe.failure.evaluator import FailureEvaluator
 
 | Module | Description |
 |--------|-------------|
-| `core/material.py` | `OrthotropicMaterial` dataclass + `MaterialLibrary` (4 built-in presets) |
+| `core/material.py` | `OrthotropicMaterial` dataclass + `MaterialLibrary` (9 built-in presets) |
 | `core/laminate.py` | `Laminate`, `Ply`, `LoadState`; Classical Lamination Theory ABD matrices |
 | `core/wrinkle.py` | `GaussianSinusoidal` wrinkle profile: z(x) = A exp(-x^2/w^2) cos(2pi x/lam) |
 | `core/morphology.py` | `WrinkleConfiguration`, `MorphologyFactor`, `MORPHOLOGY_PHASES`; phase-to-Mf mapping |
@@ -79,6 +79,9 @@ from wrinklefe.failure.evaluator import FailureEvaluator
 | `viz/plots_3d.py` | 3D PyVista plots (mesh, damage contours) |
 | `viz/style.py` | Publication styling constants and helpers |
 | `sweep/parametric_sweep.py` | Parametric sweep over amplitude/wavelength/morphology; CSV output |
+| `analysis.py` | Top-level orchestrator: `WrinkleAnalysis`, `AnalysisConfig`, `compare_morphologies`, `parametric_sweep` |
+| `cli.py` | Entry point referenced by `[project.scripts]` (the `wrinklefe` command) |
+| `io/export.py` | meshio-backed mesh/field export, gated by the `export` extra |
 
 ## Confinement Model
 


### PR DESCRIPTION
## Summary
Two drift fixes in `ARCHITECTURE.md`:

1. **Material count:** corrected `MaterialLibrary` description from "4 built-in presets" &rarr; "9 built-in presets". Verified via `MaterialLibrary().list_names()`: `AC318_S6C10`, `AS4_3501_6`, `IM10_8552`, `IM7_8552`, `KEVLAR49_EPOXY`, `S2_GLASS_EPOXY`, `T300_914`, `T700_2510`, `T800S_M21`. Matches the README.

2. **Missing module rows:** appended three rows to the module table:
   - `analysis.py` &rarr; top-level orchestrator (`WrinkleAnalysis`, `AnalysisConfig`, `compare_morphologies`, `parametric_sweep`)
   - `cli.py` &rarr; entry point referenced by `[project.scripts]` (the `wrinklefe` command)
   - `io/export.py` &rarr; meshio-backed mesh/field export, gated by the `export` extra

Fixes #204

## Test plan
- [x] Docs-only change (+4 / -1 in `ARCHITECTURE.md`); no code touched.
- [x] Material count cross-checked against `src/wrinklefe/core/material.py` &mdash; not just `README.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_