### PR TITLE
fix(solver): stop StaticSolver from keeping a full K copy after solve()

### DIFF
--- a/src/wrinklefe/solver/static.py
+++ b/src/wrinklefe/solver/static.py
@@ -93,6 +93,7 @@ class StaticSolver:
         boundary_conditions: list[BoundaryCondition],
         solver: str = "direct",
         verbose: bool = False,
+        keep_stiffness: bool = False,
     ) -> FieldResults:
         """Solve the static problem.
 
@@ -113,6 +114,14 @@ class StaticSolver:
             ILU preconditioner. Default is ``'direct'``.
         verbose : bool, optional
             Print progress information. Default is ``False``.
+        keep_stiffness : bool, optional
+            If True, retain a copy of the unmodified (pre-penalty) global
+            stiffness matrix on ``self._K`` after solve. Default is False,
+            which avoids the memory cost of holding a full sparse matrix
+            copy on every solver instance (relevant for parametric sweeps
+            and analyses that keep multiple solvers alive). Enable only
+            when callers need post-solve access to K (e.g., to compute
+            reaction forces without re-assembly).
 
         Returns
         -------
@@ -133,7 +142,9 @@ class StaticSolver:
             print("Assembling global stiffness matrix...")
         with _suppress_assembly_warnings():
             K = self.assembler.assemble_stiffness(verbose=verbose)
-        self._K = K.copy()  # Store unmodified K for reaction forces
+        # Opt-in retention of the unmodified K (see ``keep_stiffness``).
+        # Default: do not store a copy to avoid doubling peak FE memory.
+        self._K = K.copy() if keep_stiffness else None
 
         if verbose:
             t1 = time.perf_counter()

--- a/tests/test_solver/test_static.py
+++ b/tests/test_solver/test_static.py
@@ -981,7 +981,8 @@ class TestFieldResults:
         # Solve a small compression problem to get a real K, u, and BC set.
         solver = StaticSolver(bar_mesh, single_ply_iso_laminate)
         bcs = BoundaryHandler.compression_bcs(bar_mesh, applied_strain=-0.005)
-        results = solver.solve(bcs, solver="direct")
+        # Opt in to keeping K so we can verify reaction_forces below.
+        results = solver.solve(bcs, solver="direct", keep_stiffness=True)
 
         # Reach into the solver's stored K and constrained DOFs map.
         K = solver._K
@@ -1168,3 +1169,56 @@ class TestCGSolverScipyRtolKwarg:
 
         assert info == 0
         np.testing.assert_allclose(u, np.ones(n), atol=1e-8)
+
+
+# ======================================================================
+# Regression tests for issue #189: opt-in retention of stiffness matrix
+# ======================================================================
+
+class TestKeepStiffnessKwarg:
+    """Issue #189: ``StaticSolver.solve`` must not retain a copy of K
+    by default, since nothing in the codebase reads ``solver._K`` and
+    holding it doubles peak FE memory in sweeps.
+    """
+
+    def test_default_does_not_retain_stiffness(
+        self, bar_mesh, single_ply_iso_laminate
+    ):
+        """Default solve() leaves solver._K as None (no copy retained)."""
+        solver = StaticSolver(bar_mesh, single_ply_iso_laminate)
+        bcs = BoundaryHandler.compression_bcs(bar_mesh, applied_strain=-0.005)
+        solver.solve(bcs, solver="direct")
+
+        # _K should not be retained by default.
+        assert getattr(solver, "_K", None) is None
+
+        # And the solver's dict footprint should be far smaller than K
+        # itself (a rough but cheap proxy for "no sparse matrix kept").
+        # We compare against the assembled K's nnz-based memory footprint.
+        K = solver.assembler.assemble_stiffness()
+        k_bytes = K.data.nbytes + K.indices.nbytes + K.indptr.nbytes
+        dict_bytes = sys_getsizeof(solver.__dict__)
+        assert dict_bytes < k_bytes, (
+            f"solver.__dict__ ({dict_bytes} B) should be well below the "
+            f"size of K ({k_bytes} B) when _K is not retained."
+        )
+
+    def test_keep_stiffness_true_retains_copy(
+        self, bar_mesh, single_ply_iso_laminate
+    ):
+        """With keep_stiffness=True, solver._K matches assembled K's nnz."""
+        solver = StaticSolver(bar_mesh, single_ply_iso_laminate)
+        bcs = BoundaryHandler.compression_bcs(bar_mesh, applied_strain=-0.005)
+        solver.solve(bcs, solver="direct", keep_stiffness=True)
+
+        assert solver._K is not None
+        # The retained matrix should match the freshly assembled K's nnz.
+        K_ref = solver.assembler.assemble_stiffness()
+        assert solver._K.nnz == K_ref.nnz
+        assert solver._K.shape == K_ref.shape
+
+
+def sys_getsizeof(obj):
+    """Module-local alias so the test reads top-down without an import."""
+    import sys
+    return sys.getsizeof(obj)


### PR DESCRIPTION
## Summary
- `StaticSolver.solve()` previously stashed `self._K = K.copy()` unconditionally with a comment claiming it was "for reaction forces" &mdash; but `FieldResults.reaction_forces` takes `K_global` as an argument, and `grep` confirms `solver._K` is never read anywhere in `src/`. The copy was pure memory waste: for a 50-point `parametric_sweep` with 10k-DOF meshes that's hundreds of MB of redundant sparse data kept alive through every accumulated `AnalysisResults`.
- New behaviour: `solve(self, ..., keep_stiffness: bool = False)`. Default no copy. Opt in with `keep_stiffness=True` and `self._K` holds the (copied) unmodified CSC matrix.
- The only test in the repo that touched `solver._K` (`TestFieldResults.test_reaction_forces_shape_and_equilibrium`) was updated to pass `keep_stiffness=True` explicitly.

Fixes #189

## Test plan
- [x] `pytest tests/test_solver/ -x` &mdash; 98 passed
- [x] `pytest tests/ -k "static or solver or analysis" -x` &mdash; 202 passed
- [x] New regression tests in `TestKeepStiffnessKwarg`:
  - `test_default_does_not_retain_stiffness`: solves with defaults, asserts `getattr(solver, "_K", None) is None`, asserts `sys.getsizeof(solver.__dict__) < (K.data.nbytes + K.indices.nbytes + K.indptr.nbytes)`
  - `test_keep_stiffness_true_retains_copy`: opts in, asserts `solver._K.nnz == K_ref.nnz` and `.shape` matches


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_