### PR TITLE
perf(failure): vectorise evaluate_field for 5 cheap criteria (~15x speedup)

### DIFF
--- a/src/wrinklefe/failure/base.py
+++ b/src/wrinklefe/failure/base.py
@@ -125,11 +125,16 @@ class FailureCriterion(ABC):
         stress_field: np.ndarray,
         material: OrthotropicMaterial,
         contexts: Optional[list] = None,
-    ) -> list[FailureResult]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Evaluate the failure criterion over an array of stress states.
 
-        This default implementation loops over rows of *stress_field*.
-        Subclasses may override with a vectorised version for performance.
+        This default implementation loops over rows of *stress_field*,
+        calling :meth:`evaluate` on each point.  Subclasses should override
+        with a vectorised NumPy implementation when the underlying maths is
+        elementwise — see e.g. :class:`MaxStressCriterion.evaluate_field`.
+        The :class:`~wrinklefe.failure.evaluator.FailureEvaluator` calls this
+        method once per (criterion, material) pair, so a vectorised override
+        eliminates the Python-level per-Gauss-point loop entirely.
 
         Parameters
         ----------
@@ -143,11 +148,24 @@ class FailureCriterion(ABC):
 
         Returns
         -------
-        list[FailureResult]
-            One :class:`FailureResult` per row of *stress_field*.
+        indices : np.ndarray
+            Shape ``(N,)`` array of failure index values, one per row.
+        modes : np.ndarray
+            Shape ``(N,)`` string array of dominant failure mode labels.
+        reserve_factors : np.ndarray
+            Shape ``(N,)`` array of reserve factors (1/FI for linear-in-load
+            criteria; the quadratic-root reserve factor for criteria whose
+            FI is nonlinear in the applied load).
         """
-        results: list[FailureResult] = []
-        for i in range(stress_field.shape[0]):
+        stress_field = np.asarray(stress_field, dtype=np.float64)
+        n = stress_field.shape[0]
+        indices = np.empty(n, dtype=np.float64)
+        modes = np.empty(n, dtype="U32")
+        reserve_factors = np.empty(n, dtype=np.float64)
+        for i in range(n):
             ctx = contexts[i] if contexts is not None else None
-            results.append(self.evaluate(stress_field[i], material, ctx))
-        return results
+            r = self.evaluate(stress_field[i], material, ctx)
+            indices[i] = r.index
+            modes[i] = r.mode
+            reserve_factors[i] = r.reserve_factor
+        return indices, modes, reserve_factors

--- a/src/wrinklefe/failure/evaluator.py
+++ b/src/wrinklefe/failure/evaluator.py
@@ -378,22 +378,53 @@ class FailureEvaluator:
             for c in self.criteria
         }
         mode_fields: dict[str, np.ndarray] = {
-            c.name: np.empty((n_elements, n_gauss), dtype="U20")
+            c.name: np.empty((n_elements, n_gauss), dtype="U32")
             for c in self.criteria
         }
 
-        for e in range(n_elements):
-            mat = materials[ply_ids[e]]
-            # Build context for physics-based criteria (LaRC05)
-            ctx = None
+        # Group elements by ply (material) id so each criterion can be
+        # evaluated with a single vectorised call per (criterion, material)
+        # pair.  This routes through ``FailureCriterion.evaluate_field``,
+        # which scalar criteria implement as a Python loop and vectorised
+        # criteria (max_stress, max_strain, hashin, tsai_wu, tsai_hill)
+        # implement with NumPy broadcasting.
+        unique_ply_ids = np.unique(ply_ids)
+
+        for pid in unique_ply_ids:
+            mat = materials[int(pid)]
+            elem_mask = ply_ids == pid
+            n_e_group = int(elem_mask.sum())
+            if n_e_group == 0:
+                continue
+
+            # Slice stress for this material group and flatten over
+            # (elements_in_group, gauss) -> (n_e_group * n_gauss, 6)
+            group_stress = stress_local_field[elem_mask]  # (n_e_g, n_gauss, 6)
+            stress_flat = group_stress.reshape(n_e_group * n_gauss, 6)
+
+            # Per-point contexts: misalignment angle is per-element, so
+            # repeat each element's value n_gauss times to align with the
+            # flattened (element, gauss) ordering.
             if fiber_angles is not None:
-                ctx = {"misalignment_angle": float(fiber_angles[e])}
-            for g in range(n_gauss):
-                stress = stress_local_field[e, g, :]
-                for criterion in self.criteria:
-                    result = criterion.evaluate(stress, mat, ctx)
-                    fi_fields[criterion.name][e, g] = result.index
-                    mode_fields[criterion.name][e, g] = result.mode
+                angles_group = np.asarray(fiber_angles, dtype=np.float64)[elem_mask]
+                # Repeat each element's angle across its Gauss points
+                angles_flat = np.repeat(angles_group, n_gauss)
+                contexts: list | None = [
+                    {"misalignment_angle": float(a)} for a in angles_flat
+                ]
+            else:
+                contexts = None
+
+            for criterion in self.criteria:
+                indices, modes, _rf = criterion.evaluate_field(
+                    stress_flat, mat, contexts
+                )
+                fi_fields[criterion.name][elem_mask] = indices.reshape(
+                    n_e_group, n_gauss
+                )
+                mode_fields[criterion.name][elem_mask] = modes.reshape(
+                    n_e_group, n_gauss
+                )
 
         return fi_fields, mode_fields
 

--- a/src/wrinklefe/failure/hashin.py
+++ b/src/wrinklefe/failure/hashin.py
@@ -208,6 +208,149 @@ class HashinCriterion(FailureCriterion):
             criterion_name=self.name,
         )
 
+    # ------------------------------------------------------------------
+    # Vectorised field evaluation
+    # ------------------------------------------------------------------
+
+    _HASHIN_MODE_LABELS = np.array(
+        ["fiber_tension", "fiber_compression",
+         "matrix_tension", "matrix_compression"],
+        dtype="U32",
+    )
+
+    def evaluate_field(
+        self,
+        stress_field: np.ndarray,
+        material: OrthotropicMaterial,
+        contexts=None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Vectorised Hashin 3D evaluation across an array of stress states.
+
+        Identical maths to :meth:`evaluate` but computed on ``N`` points at
+        once with NumPy broadcasting.  See the module docstring for the
+        per-mode failure surfaces.
+
+        Parameters
+        ----------
+        stress_field : np.ndarray
+            Shape ``(N, 6)`` array of local stress vectors.
+        material : OrthotropicMaterial
+            Material with strength allowables (shared by all N points).
+        contexts : list, optional
+            Ignored — Hashin has no context dependence.
+
+        Returns
+        -------
+        indices, modes, reserve_factors : np.ndarray, np.ndarray, np.ndarray
+            Each of shape ``(N,)``.  ``reserve_factors`` uses the closed-form
+            quadratic root for the matrix-compression branch (see
+            :func:`_quadratic_reserve_factor`).
+        """
+        s = np.asarray(stress_field, dtype=np.float64)
+        if s.ndim != 2 or s.shape[1] != 6:
+            raise ValueError(
+                f"stress_field must have shape (N, 6), got {s.shape}"
+            )
+
+        s11, s22, s33 = s[:, 0], s[:, 1], s[:, 2]
+        t23, t13, t12 = s[:, 3], s[:, 4], s[:, 5]
+
+        Xt, Xc = material.Xt, material.Xc
+        Yt, Yc = material.Yt, material.Yc
+        S12, S23 = material.S12, material.S23
+
+        # --- Fibre tension (active when s11 >= 0) ---
+        ft_sq = (s11 / Xt) ** 2 + (t12 ** 2 + t13 ** 2) / S12 ** 2
+        fi_ft = np.where(s11 >= 0, np.sqrt(np.maximum(ft_sq, 0.0)), 0.0)
+
+        # --- Fibre compression (active when s11 < 0) ---
+        fi_fc = np.where(s11 < 0, -s11 / Xc, 0.0)
+
+        # --- Matrix branches (depend on sign of s22 + s33) ---
+        sig_t = s22 + s33
+        shear_term_23 = (t23 ** 2 - s22 * s33) / S23 ** 2
+        shear_term_12 = (t12 ** 2 + t13 ** 2) / S12 ** 2
+
+        # Matrix tension (sig_t >= 0)
+        mt_sq = (sig_t / Yt) ** 2 + shear_term_23 + shear_term_12
+        fi_mt = np.where(sig_t >= 0, np.sqrt(np.maximum(mt_sq, 0.0)), 0.0)
+
+        # Matrix compression (sig_t < 0)
+        A_mc = (
+            sig_t ** 2 / (4.0 * S23 ** 2)
+            + shear_term_23
+            + shear_term_12
+        )
+        B_mc = ((Yc / (2.0 * S23)) ** 2 - 1.0) * sig_t / Yc
+        mc_sq = A_mc + B_mc
+        fi_mc = np.where(sig_t < 0, np.sqrt(np.maximum(mc_sq, 0.0)), 0.0)
+
+        # --- Stack and pick dominant mode by FI value ---
+        all_fi = np.vstack([fi_ft, fi_fc, fi_mt, fi_mc])  # (4, N)
+        idx = np.argmax(all_fi, axis=0)
+        fi_max = all_fi[idx, np.arange(s.shape[0])]
+        modes = self._HASHIN_MODE_LABELS[idx]
+
+        # --- Reserve factor ---
+        # For ft/fc/mt branches the FI is a pure quadratic in load, so
+        # RF = 1/FI.  For mc, solve A*R^2 + B*R = 1 elementwise.
+        rf = np.full_like(fi_max, np.inf)
+
+        # mc branch via vectorised quadratic roots, then mask in
+        rf_mc = _quadratic_reserve_factor_vec(A_mc, B_mc)
+
+        # Default: 1/FI; override for the mc-dominant points.
+        nonzero = fi_max > 0
+        rf[nonzero] = 1.0 / fi_max[nonzero]
+        mc_dominant = (idx == 3) & nonzero
+        rf[mc_dominant] = rf_mc[mc_dominant]
+
+        return fi_max, modes, rf
+
+
+def _quadratic_reserve_factor_vec(A: np.ndarray, B: np.ndarray) -> np.ndarray:
+    """Vectorised version of :func:`_quadratic_reserve_factor`.
+
+    Smallest positive root of ``A*R^2 + B*R - 1 = 0`` for each elementwise
+    pair ``(A[i], B[i])``.  Returns ``inf`` where no positive root exists or
+    where ``A == 0`` and ``B <= 0`` (degenerate).
+
+    Parameters
+    ----------
+    A, B : np.ndarray
+        Same-shape arrays of polynomial coefficients.
+
+    Returns
+    -------
+    np.ndarray
+        Same shape as inputs; smallest positive root of ``A*R^2 + B*R = 1``.
+    """
+    A = np.asarray(A, dtype=np.float64)
+    B = np.asarray(B, dtype=np.float64)
+    rf = np.full(A.shape, np.inf, dtype=np.float64)
+
+    # Quadratic branch: A > 0.  Smallest positive root of A*R^2 + B*R - 1 = 0
+    # is r_plus = (-B + sqrt(B^2 + 4A)) / (2A) (which is always >= 0 because
+    # sqrt(B^2 + 4A) >= |B|).
+    quad = A > 0.0
+    if np.any(quad):
+        Aq = A[quad]
+        Bq = B[quad]
+        disc = Bq * Bq + 4.0 * Aq
+        # disc >= B^2 >= 0 for A > 0, so sqrt is safe.
+        sqrt_disc = np.sqrt(np.maximum(disc, 0.0))
+        r_plus = (-Bq + sqrt_disc) / (2.0 * Aq)
+        rf_quad = np.where(r_plus > 0.0, r_plus, np.inf)
+        rf[quad] = rf_quad
+
+    # Degenerate branch: A == 0, B > 0  =>  R = 1/B
+    lin = (A == 0.0) & (B > 0.0)
+    if np.any(lin):
+        rf[lin] = 1.0 / B[lin]
+
+    # All other cases (A < 0 or A == 0 & B <= 0): leave as inf.
+    return rf
+
 
 def _quadratic_reserve_factor(A: float, B: float) -> float:
     """Smallest positive root of ``A*R^2 + B*R - 1 = 0``.

--- a/src/wrinklefe/failure/max_strain.py
+++ b/src/wrinklefe/failure/max_strain.py
@@ -169,3 +169,82 @@ class MaxStrainCriterion(FailureCriterion):
             reserve_factor=rf,
             criterion_name=self.name,
         )
+
+    # ------------------------------------------------------------------
+    # Vectorised field evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate_field(
+        self,
+        stress_field: np.ndarray,
+        material: OrthotropicMaterial,
+        contexts=None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Vectorised Max-Strain evaluation across an array of stress states.
+
+        Computes the same failure index and dominant mode as :meth:`evaluate`
+        for ``N`` stress vectors at once using NumPy broadcasting.
+
+        Parameters
+        ----------
+        stress_field : np.ndarray
+            Shape ``(N, 6)`` array of local stress vectors.
+        material : OrthotropicMaterial
+            Material with elastic and strength properties (shared by all N).
+        contexts : list, optional
+            Ignored — Max-Strain has no context dependence.
+
+        Returns
+        -------
+        indices : np.ndarray
+            Shape ``(N,)`` failure indices.
+        modes : np.ndarray
+            Shape ``(N,)`` dominant-mode string labels.
+        reserve_factors : np.ndarray
+            Shape ``(N,)`` reserve factors (``1/FI``; ``inf`` where FI == 0).
+        """
+        s = np.asarray(stress_field, dtype=np.float64)
+        if s.ndim != 2 or s.shape[1] != 6:
+            raise ValueError(
+                f"stress_field must have shape (N, 6), got {s.shape}"
+            )
+
+        n = s.shape[0]
+
+        # Uncoupled engineering strains (matches scalar evaluate exactly).
+        eps11 = s[:, 0] / material.E1
+        eps22 = s[:, 1] / material.E2
+        eps33 = s[:, 2] / material.E3
+        g23 = s[:, 3] / material.G23
+        g13 = s[:, 4] / material.G13
+        g12 = s[:, 5] / material.G12
+
+        # Ultimate strain magnitudes (scalars)
+        eps1t = material.Xt / material.E1
+        eps1c = material.Xc / material.E1
+        eps2t = material.Yt / material.E2
+        eps2c = material.Yc / material.E2
+        eps3t = material.Zt / material.E3
+        eps3c = material.Zc / material.E3
+        gamma23_ult = material.S23 / material.G23
+        gamma13_ult = material.S13 / material.G13
+        gamma12_ult = material.S12 / material.G12
+
+        ratios = np.zeros((9, n), dtype=np.float64)
+        ratios[0] = np.where(eps11 >= 0,  eps11 / eps1t,  0.0)   # fiber_tension
+        ratios[1] = np.where(eps11 <  0, -eps11 / eps1c,  0.0)   # fiber_compression
+        ratios[2] = np.where(eps22 >= 0,  eps22 / eps2t,  0.0)   # matrix_transverse_tension
+        ratios[3] = np.where(eps22 <  0, -eps22 / eps2c,  0.0)   # matrix_transverse_compression
+        ratios[4] = np.where(eps33 >= 0,  eps33 / eps3t,  0.0)   # matrix_thickness_tension
+        ratios[5] = np.where(eps33 <  0, -eps33 / eps3c,  0.0)   # matrix_thickness_compression
+        ratios[6] = np.abs(g23) / gamma23_ult                    # shear_23
+        ratios[7] = np.abs(g13) / gamma13_ult                    # shear_13
+        ratios[8] = np.abs(g12) / gamma12_ult                    # shear_12
+
+        idx = np.argmax(ratios, axis=0)
+        fi = ratios[idx, np.arange(n)]
+        labels = np.asarray(self._MODE_LABELS, dtype="U32")
+        modes = labels[idx]
+
+        rf = np.where(fi > 0, 1.0 / np.where(fi > 0, fi, 1.0), np.inf)
+        return fi, modes, rf

--- a/src/wrinklefe/failure/max_stress.py
+++ b/src/wrinklefe/failure/max_stress.py
@@ -156,3 +156,84 @@ class MaxStressCriterion(FailureCriterion):
             reserve_factor=1.0 / fi_max if fi_max > 0 else float("inf"),
             criterion_name=self.name,
         )
+
+    # ------------------------------------------------------------------
+    # Vectorised field evaluation
+    # ------------------------------------------------------------------
+
+    _MODE_LABELS_FIELD = np.array(
+        [
+            "fiber_tension",         # idx 0: sigma_11 >= 0
+            "fiber_compression",     # idx 1: sigma_11 <  0
+            "matrix_tension",        # idx 2: sigma_22 >= 0
+            "matrix_compression",    # idx 3: sigma_22 <  0
+            "through_thickness_tension",      # idx 4: sigma_33 >= 0
+            "through_thickness_compression",  # idx 5: sigma_33 <  0
+            "shear_23",                       # idx 6
+            "shear_13",                       # idx 7
+            "shear_12",                       # idx 8
+        ],
+        dtype="U32",
+    )
+
+    def evaluate_field(
+        self,
+        stress_field: np.ndarray,
+        material: OrthotropicMaterial,
+        contexts=None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Vectorised Max-Stress evaluation across an array of stress states.
+
+        Computes the same failure index and dominant mode as :meth:`evaluate`
+        but for ``N`` stress vectors at once using NumPy broadcasting.
+
+        Parameters
+        ----------
+        stress_field : np.ndarray
+            Shape ``(N, 6)`` array of local stress vectors.
+        material : OrthotropicMaterial
+            Material with strength allowables.  All N points share the
+            same material (callers group by ply id beforehand).
+        contexts : list, optional
+            Ignored — Max-Stress has no context dependence.
+
+        Returns
+        -------
+        indices : np.ndarray
+            Shape ``(N,)`` failure indices.
+        modes : np.ndarray
+            Shape ``(N,)`` dominant-mode string labels.
+        reserve_factors : np.ndarray
+            Shape ``(N,)`` reserve factors (``1/FI``; ``inf`` where FI == 0).
+        """
+        s = np.asarray(stress_field, dtype=np.float64)
+        if s.ndim != 2 or s.shape[1] != 6:
+            raise ValueError(
+                f"stress_field must have shape (N, 6), got {s.shape}"
+            )
+
+        s11, s22, s33 = s[:, 0], s[:, 1], s[:, 2]
+        t23, t13, t12 = s[:, 3], s[:, 4], s[:, 5]
+
+        # Stack the nine non-negative component ratios.  For sign-dependent
+        # normals, the inactive branch is left at zero so it never wins the
+        # argmax.
+        ratios = np.zeros((9, s.shape[0]), dtype=np.float64)
+        ratios[0] = np.where(s11 >= 0, s11 / material.Xt, 0.0)
+        ratios[1] = np.where(s11 < 0, -s11 / material.Xc, 0.0)
+        ratios[2] = np.where(s22 >= 0, s22 / material.Yt, 0.0)
+        ratios[3] = np.where(s22 < 0, -s22 / material.Yc, 0.0)
+        ratios[4] = np.where(s33 >= 0, s33 / material.Zt, 0.0)
+        ratios[5] = np.where(s33 < 0, -s33 / material.Zc, 0.0)
+        ratios[6] = np.abs(t23) / material.S23
+        ratios[7] = np.abs(t13) / material.S13
+        ratios[8] = np.abs(t12) / material.S12
+
+        idx = np.argmax(ratios, axis=0)
+        fi = ratios[idx, np.arange(s.shape[0])]
+        modes = self._MODE_LABELS_FIELD[idx]
+
+        with np.errstate(divide="ignore"):
+            rf = np.where(fi > 0, 1.0 / np.where(fi > 0, fi, 1.0), np.inf)
+
+        return fi, modes, rf

--- a/src/wrinklefe/failure/tsai_hill.py
+++ b/src/wrinklefe/failure/tsai_hill.py
@@ -124,3 +124,93 @@ class TsaiHillCriterion(FailureCriterion):
             reserve_factor=rf,
             criterion_name=self.name,
         )
+
+    # ------------------------------------------------------------------
+    # Vectorised field evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate_field(
+        self,
+        stress_field: np.ndarray,
+        material: OrthotropicMaterial,
+        contexts=None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Vectorised Tsai-Hill evaluation across an array of stress states.
+
+        Same maths as :meth:`evaluate` on ``N`` points at once via NumPy
+        broadcasting; sign-dependent strengths are selected with
+        :func:`numpy.where`.
+
+        Parameters
+        ----------
+        stress_field : np.ndarray
+            Shape ``(N, 6)`` stress array.
+        material : OrthotropicMaterial
+            Material with strength allowables (shared across all N).
+        contexts : list, optional
+            Ignored — Tsai-Hill has no context dependence.
+
+        Returns
+        -------
+        indices, modes, reserve_factors : np.ndarray, np.ndarray, np.ndarray
+            Each of shape ``(N,)``.  ``reserve_factors = 1/sqrt(FI)`` for the
+            purely quadratic Tsai-Hill index.
+        """
+        s = np.asarray(stress_field, dtype=np.float64)
+        if s.ndim != 2 or s.shape[1] != 6:
+            raise ValueError(
+                f"stress_field must have shape (N, 6), got {s.shape}"
+            )
+
+        s1 = s[:, 0]
+        s2 = s[:, 1]
+        s3 = s[:, 2]
+        t23 = s[:, 3]
+        t13 = s[:, 4]
+        t12 = s[:, 5]
+
+        X = np.where(s1 >= 0, material.Xt, material.Xc)
+        Y = np.where(s2 >= 0, material.Yt, material.Yc)
+        Z = np.where(s3 >= 0, material.Zt, material.Zc)
+
+        term_11 = (s1 / X) ** 2
+        term_22 = (s2 / Y) ** 2
+        term_33 = (s3 / Z) ** 2
+        term_s12 = (t12 / material.S12) ** 2
+        term_s13 = (t13 / material.S13) ** 2
+        term_s23 = (t23 / material.S23) ** 2
+
+        term_12 = -s1 * s2 / X ** 2
+        term_23 = -s2 * s3 / Y ** 2
+        term_13 = -s1 * s3 / X ** 2
+
+        fi = (term_11 + term_22 + term_33
+              + term_12 + term_23 + term_13
+              + term_s12 + term_s13 + term_s23)
+
+        # --- Dominant mode by largest positive (non-interaction) term ---
+        positive_terms = np.vstack([
+            term_11, term_22, term_33, term_s12, term_s13, term_s23
+        ])  # (6, N)
+        idx = np.argmax(positive_terms, axis=0)
+
+        # Build mode array.  Mode strings for normal terms depend on stress
+        # sign; shear modes are unconditional.
+        modes = np.empty(s.shape[0], dtype="U32")
+        is_11 = idx == 0
+        modes[is_11 & (s1 >= 0)] = "fiber_tension"
+        modes[is_11 & (s1 < 0)] = "fiber_compression"
+        is_22 = idx == 1
+        modes[is_22 & (s2 >= 0)] = "matrix_transverse_tension"
+        modes[is_22 & (s2 < 0)] = "matrix_transverse_compression"
+        is_33 = idx == 2
+        modes[is_33 & (s3 >= 0)] = "matrix_thickness_tension"
+        modes[is_33 & (s3 < 0)] = "matrix_thickness_compression"
+        modes[idx == 3] = "shear_12"
+        modes[idx == 4] = "shear_13"
+        modes[idx == 5] = "shear_23"
+
+        # --- Reserve factor = 1/sqrt(FI) ---
+        rf = np.where(fi > 0.0, 1.0 / np.sqrt(np.where(fi > 0.0, fi, 1.0)), np.inf)
+
+        return fi.astype(np.float64), modes, rf

--- a/src/wrinklefe/failure/tsai_wu.py
+++ b/src/wrinklefe/failure/tsai_wu.py
@@ -251,3 +251,133 @@ class TsaiWuCriterion(FailureCriterion):
             reserve_factor=reserve_factor,
             criterion_name=self.name,
         )
+
+    # ------------------------------------------------------------------
+    # Vectorised field evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate_field(
+        self,
+        stress_field: np.ndarray,
+        material: OrthotropicMaterial,
+        contexts=None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Vectorised Tsai-Wu evaluation across an array of stress states.
+
+        Identical maths to :meth:`evaluate` but computed on ``N`` points at
+        once with NumPy broadcasting.
+
+        Parameters
+        ----------
+        stress_field : np.ndarray
+            Shape ``(N, 6)`` array of local stress vectors.
+        material : OrthotropicMaterial
+            Material with strength allowables (shared by all N points).
+        contexts : list, optional
+            Ignored — Tsai-Wu has no context dependence.
+
+        Returns
+        -------
+        indices, modes, reserve_factors : np.ndarray, np.ndarray, np.ndarray
+            Each of shape ``(N,)``.  ``reserve_factors`` is the positive root
+            of ``R^2 Q + R L = 1`` (the strength ratio).
+        """
+        s = np.asarray(stress_field, dtype=np.float64)
+        if s.ndim != 2 or s.shape[1] != 6:
+            raise ValueError(
+                f"stress_field must have shape (N, 6), got {s.shape}"
+            )
+
+        s11, s22, s33 = s[:, 0], s[:, 1], s[:, 2]
+        t23, t13, t12 = s[:, 3], s[:, 4], s[:, 5]
+
+        Xt, Xc = material.Xt, material.Xc
+        Yt, Yc = material.Yt, material.Yc
+        Zt, Zc = material.Zt, material.Zc
+        S12, S13, S23 = material.S12, material.S13, material.S23
+
+        F1 = 1.0 / Xt - 1.0 / Xc
+        F2 = 1.0 / Yt - 1.0 / Yc
+        F3 = 1.0 / Zt - 1.0 / Zc
+        F11 = 1.0 / (Xt * Xc)
+        F22 = 1.0 / (Yt * Yc)
+        F33 = 1.0 / (Zt * Zc)
+        F44 = 1.0 / S23 ** 2
+        F55 = 1.0 / S13 ** 2
+        F66 = 1.0 / S12 ** 2
+        F12 = self.f12_star * np.sqrt(F11 * F22)
+        F13 = self.f12_star * np.sqrt(F11 * F33)
+        F23 = self.f12_star * np.sqrt(F22 * F33)
+
+        L = F1 * s11 + F2 * s22 + F3 * s33
+        Q = (
+            F11 * s11 ** 2
+            + F22 * s22 ** 2
+            + F33 * s33 ** 2
+            + 2.0 * F12 * s11 * s22
+            + 2.0 * F13 * s11 * s33
+            + 2.0 * F23 * s22 * s33
+            + F44 * t23 ** 2
+            + F55 * t13 ** 2
+            + F66 * t12 ** 2
+        )
+        fi = L + Q
+
+        # --- Reserve factor: smallest positive R with R^2 Q + R L = 1 ---
+        # Three branches, matching the scalar evaluate path.
+        rf = np.full_like(fi, np.inf)
+
+        # Q > 0: closed surface, take r_plus = (-L + sqrt(L^2 + 4Q)) / (2Q).
+        qp = Q > 0.0
+        if np.any(qp):
+            Lp = L[qp]
+            Qp = Q[qp]
+            disc = Lp * Lp + 4.0 * Qp
+            sqrt_disc = np.sqrt(np.maximum(disc, 0.0))
+            r_plus = (-Lp + sqrt_disc) / (2.0 * Qp)
+            rf_qp = np.where(r_plus > 0.0, r_plus, np.inf)
+            rf[qp] = rf_qp
+
+        # Q == 0, L > 0  =>  R = 1/L
+        qz = (Q == 0.0) & (L > 0.0)
+        if np.any(qz):
+            rf[qz] = 1.0 / L[qz]
+
+        # Q < 0: unusual open surface; take smallest positive root if any.
+        qn = Q < 0.0
+        if np.any(qn):
+            Ln = L[qn]
+            Qn = Q[qn]
+            disc = Ln * Ln + 4.0 * Qn
+            valid = disc >= 0.0
+            if np.any(valid):
+                Lv = Ln[valid]
+                Qv = Qn[valid]
+                sqrt_disc = np.sqrt(disc[valid])
+                r1 = (-Lv + sqrt_disc) / (2.0 * Qv)
+                r2 = (-Lv - sqrt_disc) / (2.0 * Qv)
+                pos1 = np.where(r1 > 0.0, r1, np.inf)
+                pos2 = np.where(r2 > 0.0, r2, np.inf)
+                rf_qn = np.minimum(pos1, pos2)
+                # rf_qn already +inf where no positive root.
+                # Write back to rf via composed mask.
+                qn_idx = np.where(qn)[0][valid]
+                rf[qn_idx] = rf_qn
+
+        # --- Approximate mode identification ---
+        fiber_contrib = np.abs(F1 * s11) + F11 * s11 ** 2
+        matrix_contrib = np.abs(F2 * s22) + F22 * s22 ** 2
+        shear_contrib = F66 * t12 ** 2
+
+        modes = np.empty(s.shape[0], dtype="U32")
+        is_fiber = (fiber_contrib >= matrix_contrib) & (fiber_contrib >= shear_contrib)
+        is_matrix = (~is_fiber) & (matrix_contrib >= shear_contrib)
+        is_shear = ~(is_fiber | is_matrix)
+
+        modes[is_fiber & (s11 >= 0)] = "fiber_tension"
+        modes[is_fiber & (s11 < 0)] = "fiber_compression"
+        modes[is_matrix & (s22 >= 0)] = "matrix_tension"
+        modes[is_matrix & (s22 < 0)] = "matrix_compression"
+        modes[is_shear] = "shear"
+
+        return fi, modes, rf

--- a/tests/test_failure/test_evaluate_field_vectorised.py
+++ b/tests/test_failure/test_evaluate_field_vectorised.py
@@ -1,0 +1,166 @@
+"""Vectorised ``evaluate_field`` regression tests.
+
+For each criterion that provides a vectorised ``evaluate_field`` override,
+this test suite generates a random ``(N, 6)`` stress field and asserts that
+the vectorised path produces failure index, mode, and reserve-factor values
+identical (within float tolerance) to the scalar ``evaluate`` path.
+
+It also exercises the :class:`FailureEvaluator.evaluate_field` plumbing to
+confirm that material grouping + per-criterion vectorised dispatch returns
+the same field arrays as the original triple-loop implementation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.failure.evaluator import FailureEvaluator
+from wrinklefe.failure.hashin import HashinCriterion
+from wrinklefe.failure.max_strain import MaxStrainCriterion
+from wrinklefe.failure.max_stress import MaxStressCriterion
+from wrinklefe.failure.tsai_hill import TsaiHillCriterion
+from wrinklefe.failure.tsai_wu import TsaiWuCriterion
+
+
+@pytest.fixture
+def material() -> OrthotropicMaterial:
+    """Default IM7/8552 material."""
+    return OrthotropicMaterial()
+
+
+@pytest.fixture
+def stress_field() -> np.ndarray:
+    """Random ``(N, 6)`` stress field used by every vectorised check."""
+    rng = np.random.default_rng(20260521)
+    # Realistic-magnitude stresses for IM7/8552: scale to a few hundred MPa
+    # so all branches (tension/compression, matrix/fibre) are exercised.
+    return rng.normal(0.0, 200.0, size=(256, 6))
+
+
+# ----------------------------------------------------------------------
+# Per-criterion vectorised-vs-scalar equivalence
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "criterion_cls",
+    [MaxStressCriterion, MaxStrainCriterion, HashinCriterion,
+     TsaiWuCriterion, TsaiHillCriterion],
+)
+def test_vectorised_matches_scalar(criterion_cls, material, stress_field):
+    """Vectorised ``evaluate_field`` matches the scalar loop elementwise."""
+    crit = criterion_cls()
+
+    # Scalar reference path
+    scalar_idx = np.empty(stress_field.shape[0], dtype=np.float64)
+    scalar_modes = np.empty(stress_field.shape[0], dtype=object)
+    scalar_rf = np.empty(stress_field.shape[0], dtype=np.float64)
+    for i in range(stress_field.shape[0]):
+        r = crit.evaluate(stress_field[i], material)
+        scalar_idx[i] = r.index
+        scalar_modes[i] = r.mode
+        scalar_rf[i] = r.reserve_factor
+
+    # Vectorised path
+    vec_idx, vec_modes, vec_rf = crit.evaluate_field(stress_field, material)
+
+    assert vec_idx.shape == (stress_field.shape[0],)
+    assert vec_modes.shape == (stress_field.shape[0],)
+    assert vec_rf.shape == (stress_field.shape[0],)
+
+    assert_allclose(vec_idx, scalar_idx, rtol=1e-10, atol=1e-12)
+    # Modes must match exactly (string equality).
+    assert_array_equal(vec_modes.astype(str), scalar_modes.astype(str))
+    # Reserve factors may include +inf for zero-stress branches; allow that.
+    finite = np.isfinite(scalar_rf) & np.isfinite(vec_rf)
+    assert_allclose(vec_rf[finite], scalar_rf[finite], rtol=1e-10, atol=1e-12)
+    # Where one is inf, the other must be too.
+    assert np.array_equal(np.isfinite(scalar_rf), np.isfinite(vec_rf))
+
+
+def test_max_stress_pure_fibre_tension(material):
+    """Spot check: pure fibre tension at Xt should yield FI = 1.0."""
+    crit = MaxStressCriterion()
+    s = np.zeros((1, 6))
+    s[0, 0] = material.Xt
+    fi, modes, rf = crit.evaluate_field(s, material)
+    assert_allclose(fi, [1.0])
+    assert modes[0] == "fiber_tension"
+    assert_allclose(rf, [1.0])
+
+
+def test_hashin_pure_fibre_compression(material):
+    """Spot check: pure fibre compression at half Xc yields FI = 0.5."""
+    crit = HashinCriterion()
+    s = np.zeros((1, 6))
+    s[0, 0] = -0.5 * material.Xc
+    fi, modes, rf = crit.evaluate_field(s, material)
+    assert_allclose(fi, [0.5])
+    assert modes[0] == "fiber_compression"
+    assert_allclose(rf, [2.0])
+
+
+# ----------------------------------------------------------------------
+# FailureEvaluator: vectorised dispatch produces identical field arrays
+# ----------------------------------------------------------------------
+
+def test_evaluator_field_matches_legacy_triple_loop(material):
+    """``FailureEvaluator.evaluate_field`` matches a hand-rolled triple loop."""
+    n_elem, n_gauss = 64, 4
+    rng = np.random.default_rng(0xC0FFEE)
+    stress = rng.normal(0.0, 150.0, size=(n_elem, n_gauss, 6))
+    materials = [material]
+    ply_ids = np.zeros(n_elem, dtype=int)
+
+    ev = FailureEvaluator([
+        MaxStressCriterion(),
+        MaxStrainCriterion(),
+        HashinCriterion(),
+        TsaiWuCriterion(),
+        TsaiHillCriterion(),
+    ])
+    fi_fields, mode_fields = ev.evaluate_field(stress, materials, ply_ids)
+
+    # Reference: scalar triple loop, criterion-by-criterion
+    for crit in ev.criteria:
+        ref_fi = np.zeros((n_elem, n_gauss), dtype=np.float64)
+        ref_modes = np.empty((n_elem, n_gauss), dtype="U32")
+        for e in range(n_elem):
+            for g in range(n_gauss):
+                r = crit.evaluate(stress[e, g], material)
+                ref_fi[e, g] = r.index
+                ref_modes[e, g] = r.mode
+
+        assert_allclose(fi_fields[crit.name], ref_fi, rtol=1e-10, atol=1e-12)
+        assert_array_equal(mode_fields[crit.name], ref_modes)
+
+
+def test_evaluator_field_multi_material(material):
+    """Material grouping: distinct ply ids select distinct materials."""
+    # Two materials with different Xt so that the same stress produces
+    # different failure indices in each group.
+    mat_a = material  # default
+    mat_b = OrthotropicMaterial(name="weak", Xt=500.0)
+
+    n_elem, n_gauss = 12, 2
+    rng = np.random.default_rng(7)
+    stress = rng.normal(0.0, 100.0, size=(n_elem, n_gauss, 6))
+    # Half the elements use mat_a, half mat_b.
+    ply_ids = np.array([0] * (n_elem // 2) + [1] * (n_elem - n_elem // 2),
+                       dtype=int)
+
+    ev = FailureEvaluator([MaxStressCriterion()])
+    fi_fields, _ = ev.evaluate_field(stress, [mat_a, mat_b], ply_ids)
+
+    # Reference triple loop using the correct material per element.
+    crit = MaxStressCriterion()
+    ref_fi = np.zeros((n_elem, n_gauss), dtype=np.float64)
+    for e in range(n_elem):
+        mat = mat_a if ply_ids[e] == 0 else mat_b
+        for g in range(n_gauss):
+            r = crit.evaluate(stress[e, g], mat)
+            ref_fi[e, g] = r.index
+
+    assert_allclose(fi_fields["max_stress"], ref_fi, rtol=1e-10, atol=1e-12)


### PR DESCRIPTION
## Summary
- `FailureEvaluator.evaluate_field` previously ran a pure-Python triple loop `for e in elements: for g in gauss: for criterion: criterion.evaluate(...)`, calling the scalar `evaluate` per Gauss point. For a 10k-element &times; 4-Gauss-point mesh that's 40k Python calls per criterion &mdash; the dominant cost of post-processing.
- The evaluator now groups elements by `ply_id` (so each criterion sees a homogeneous material) and calls `criterion.evaluate_field(stress_flat, material, contexts)` once per (criterion, material) pair. Misalignment angles are broadcast per Gauss point.
- Added vectorised `evaluate_field` overrides to five cheap criteria: `MaxStress`, `MaxStrain`, `Hashin`, `TsaiWu`, `TsaiHill`. Each uses NumPy broadcasting &mdash; no Python loop over N.
- `Hashin` gains a vectorised `_quadratic_reserve_factor_vec` mirroring the closed-form quadratic root introduced in #211.
- `TsaiHill` uses `np.where` for sign-dependent strength selection.
- LaRC05 and Puck are intentionally **untouched** &mdash; they fall through to the default scalar-loop `evaluate_field` in `base.py` until their inner fracture-plane / IFF search can be batched.

Fixes #197

## Test plan
- [x] `pytest tests/test_failure/` &mdash; 197 passed (188 prior + 9 new)
- [x] New `tests/test_failure/test_evaluate_field_vectorised.py` pins per-criterion parity (vectorised vs scalar) on random `(N>=100, 6)` stress fields, multi-material grouping, and full evaluator-vs-scalar equivalence on a fixed seed
- [x] Full `tests/` (minus `test_streamlit_viz.py`) &mdash; 995 passed, 8 skipped

## Benchmark (10 000 elements &times; 4 Gauss points, MaxStress + Hashin, IM7/8552)
| | Wall-clock |
|---|---|
| main (triple loop) | 0.3601 s |
| this PR (vectorised) | **0.0241 s** |
| **Speedup** | **~15&times;** |

LaRC05 alone (default scalar loop, unchanged): ~6.0 s &mdash; confirmed untouched.

## API notes
- `FailureEvaluator.evaluate_field` return type unchanged (`(fi_fields, mode_fields)` dicts of ndarrays).
- `FailureCriterion.evaluate_field` return type changed from `list[FailureResult]` &rarr; `tuple[ndarray, ndarray, ndarray]` (`indices`, `modes`, `reserve_factors`). Verified no in-tree callers used the prior list form. The default base-class implementation still works for criteria without an override.
- Output dtype for mode names widened to `U32` so longer mode names (e.g. Hashin's `matrix_compression`) round-trip cleanly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_