### PR TITLE
docs(ci): note stale Windows release pipeline (refs #10, #121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      # Note: Windows is intentionally not in the matrix. The desktop build
+      # pipeline (PyInstaller spec + build-windows.yml) was removed in #121;
+      # releases are now source-only (PyPI / source tarball). See issue #10.
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]


### PR DESCRIPTION
## Summary
- The Windows release pipeline was intentionally deleted in PR #121 ("Remove desktop build pipeline (Windows/macOS PyInstaller) (Refs #117)", commit `612d578`). Future releases are source-only (PyPI / source tarball).
- Nothing in `main` references `wrinklefe_windows.spec` or `.github/workflows/build-windows.yml` anymore &mdash; there is no broken state to fix.
- This PR adds a 3-line comment to `.github/workflows/ci.yml` explaining why Windows is not in the CI matrix and pointing at #10 / PR #121, so the same false-positive audit isn't re-filed.

Recommend closing issue #10 as stale/resolved.

Fixes #10

## Test plan
- [x] Confirmed via `git log --diff-filter=D` that PR #121 deleted `wrinklefe_windows.spec`, `.github/workflows/build-windows.yml`, and the `scripts/build_*` helpers in a single commit.
- [x] `grep -rn "wrinklefe_windows\.spec\|build-windows" .github tools scripts . 2>/dev/null` returns nothing in `main`.
- [x] YAML still parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_