### PR TITLE
perf(viz): cache mesh3d geometry across slider re-renders (~7x speedup)

### DIFF
--- a/app.py
+++ b/app.py
@@ -789,6 +789,12 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             "stress_per_elem": stress_per_elem,
             "element_centers": element_centers,
             "fi_per_gauss": fi_per_gauss,
+            # Precomputed boundary-face triangulation cached once per
+            # solve so slider re-renders skip the boundary cull. See
+            # issue #198.
+            "mesh3d_geometry": streamlit_viz.compute_mesh3d_geometry(
+                elements_arr
+            ),
         }
 
     return {
@@ -1425,6 +1431,7 @@ with tab_results:
                         fe["nodes"], fe["elements"], fe["stress_per_elem"],
                         component_index=comp[0],
                         component_label=comp[1],
+                        precomputed_geometry=fe.get("mesh3d_geometry"),
                     )
                     st.plotly_chart(fig_3d, width="stretch")
 
@@ -1459,6 +1466,7 @@ with tab_results:
                     fig_3d = streamlit_viz.deformed_mesh_figure(
                         fe["nodes"], fe["elements"], fe["displacement"],
                         scale=scale,
+                        precomputed_geometry=fe.get("mesh3d_geometry"),
                     )
                     st.plotly_chart(fig_3d, width="stretch")
                     # No y-slice for the deformed-mesh view: a stress
@@ -1483,6 +1491,7 @@ with tab_results:
                         fig_3d = streamlit_viz.fi_3d_figure(
                             fe["nodes"], fe["elements"],
                             fi_dict[crit_for_3d], crit_for_3d,
+                            precomputed_geometry=fe.get("mesh3d_geometry"),
                         )
                         st.plotly_chart(fig_3d, width="stretch")
 

--- a/streamlit_viz.py
+++ b/streamlit_viz.py
@@ -114,6 +114,40 @@ def _scene_layout() -> dict:
     )
 
 
+def compute_mesh3d_geometry(elements: np.ndarray) -> dict:
+    """Precompute the connectivity-derived geometry used by Mesh3d plots.
+
+    The expensive parts of building a Plotly Mesh3d for a hex mesh
+    (``boundary_faces`` + ``quads_to_triangles`` + the boundary-node
+    ``np.unique`` remap) depend only on the connectivity, not on the
+    nodal coordinates.  Streamlit slider re-renders keep ``elements``
+    constant between solves, so the FE app can call this once after
+    each solve and pass the result back into :func:`mesh3d_figure` via
+    ``precomputed_geometry=`` to skip the boundary cull on every redraw.
+
+    Returns a dict with:
+
+    - ``tri``: ``(n_tri, 4)`` array of [na, nb, nc, parent_elem_id]
+      from :func:`quads_to_triangles`. Owners (column 3) drive per-cell
+      intensity broadcasting.
+    - ``kept_nodes``: ``(n_kept,)`` unique global node ids referenced by
+      the boundary triangles, in ascending order.  Used to slice the
+      ``vertices`` / ``vertex_scalar`` arrays down to the surface.
+    - ``tri_ijk``: ``(n_tri, 3)`` triangle node indices remapped into
+      the compact ``kept_nodes`` index space — the i/j/k Plotly Mesh3d
+      expects.
+    """
+    bf = boundary_faces(elements)
+    tri = quads_to_triangles(bf)
+    if tri.shape[0] > 0:
+        kept_nodes, remap = np.unique(tri[:, :3].ravel(), return_inverse=True)
+        tri_ijk = remap.reshape(-1, 3).astype(np.int64, copy=False)
+    else:
+        kept_nodes = np.empty(0, dtype=np.int64)
+        tri_ijk = np.empty((0, 3), dtype=np.int64)
+    return {"tri": tri, "kept_nodes": kept_nodes, "tri_ijk": tri_ijk}
+
+
 def mesh3d_figure(
     vertices: np.ndarray,
     elements: np.ndarray,
@@ -125,28 +159,35 @@ def mesh3d_figure(
     title: str = "",
     symmetric: bool = False,
     height: int = 480,
+    precomputed_geometry: dict | None = None,
 ) -> go.Figure:
     """Render the boundary surface of a hex mesh as a Plotly Mesh3d.
 
     Pass ``cell_scalar`` (one value per element) for FE field data like
     sigma_33 or max FI; pass ``vertex_scalar`` (one value per node) for
     per-node fields like displacement magnitude.
-    """
-    bf = boundary_faces(elements)
-    tri = quads_to_triangles(bf)
 
-    # Trim the vertex payload so Plotly receives ONLY nodes that the
-    # boundary triangles reference; on a structured hex brick this is
-    # O(surface) instead of O(volume).  Re-index the triangle node ids
-    # to point into the compact vertex array.
-    if tri.shape[0] > 0:
-        kept_nodes, remap = np.unique(tri[:, :3].ravel(), return_inverse=True)
+    ``precomputed_geometry`` is the dict returned by
+    :func:`compute_mesh3d_geometry`.  When provided, the (expensive)
+    boundary cull + triangulation are skipped — this is the hot path for
+    Streamlit slider re-renders where ``elements`` is unchanged between
+    calls.  When ``None`` (default), the geometry is computed inline,
+    preserving the original single-argument API.
+    """
+    if precomputed_geometry is None:
+        precomputed_geometry = compute_mesh3d_geometry(elements)
+    tri = precomputed_geometry["tri"]
+    kept_nodes = precomputed_geometry["kept_nodes"]
+    tri_ijk = precomputed_geometry["tri_ijk"]
+
+    # Slice the vertex payload to the surface nodes.  ``vertices`` can
+    # change every call (e.g. deformed-mesh view re-applies the scaled
+    # displacement) so this lookup stays per-call even when the
+    # connectivity-derived geometry is cached.
+    if kept_nodes.size:
         verts = np.asarray(vertices)[kept_nodes]
-        tri_ijk = remap.reshape(-1, 3).astype(np.int64, copy=False)
     else:
-        kept_nodes = np.empty(0, dtype=np.int64)
         verts = np.asarray(vertices)[:0]
-        tri_ijk = np.empty((0, 3), dtype=np.int64)
 
     kwargs: dict = dict(
         x=verts[:, 0],
@@ -201,6 +242,7 @@ def stress_contour_figure(
     *,
     component_label: str = "σ₃₃",
     title: str | None = None,
+    precomputed_geometry: dict | None = None,
 ) -> go.Figure:
     """3D surface mesh coloured by a single Voigt stress component."""
     scalar = stress_per_elem[:, component_index]
@@ -212,6 +254,7 @@ def stress_contour_figure(
         colorbar_title=f"{component_label} [MPa]",
         title=title or f"{component_label} surface contour",
         symmetric=True,
+        precomputed_geometry=precomputed_geometry,
     )
 
 
@@ -221,6 +264,7 @@ def deformed_mesh_figure(
     displacement: np.ndarray,
     *,
     scale: float = 10.0,
+    precomputed_geometry: dict | None = None,
 ) -> go.Figure:
     """3D deformed mesh coloured by displacement magnitude."""
     deformed = nodes + scale * displacement
@@ -232,6 +276,7 @@ def deformed_mesh_figure(
         colorscale="Viridis",
         colorbar_title="|u| [mm]",
         title=f"Deformed mesh (×{scale:g} exaggeration)",
+        precomputed_geometry=precomputed_geometry,
     )
 
 
@@ -240,6 +285,8 @@ def fi_3d_figure(
     elements: np.ndarray,
     fi_per_gauss: np.ndarray,
     criterion: str,
+    *,
+    precomputed_geometry: dict | None = None,
 ) -> go.Figure:
     """3D surface mesh coloured by per-element max failure index."""
     fi_max = np.asarray(fi_per_gauss).max(axis=1)
@@ -250,6 +297,7 @@ def fi_3d_figure(
         colorscale="Reds",
         colorbar_title=f"FI ({criterion})",
         title=f"Failure index — {criterion}",
+        precomputed_geometry=precomputed_geometry,
     )
 
 

--- a/tests/test_streamlit_viz.py
+++ b/tests/test_streamlit_viz.py
@@ -257,3 +257,106 @@ def test_fi_3d_figure_smoke():
     fi = np.random.RandomState(0).rand(elems.shape[0], 8)
     fig = sv.fi_3d_figure(nodes, elems, fi, criterion="MaxStress")
     assert fig is not None
+
+
+# ---------------------------------------------------------------------------
+# precomputed_geometry cache (issue #198)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_mesh3d_geometry_shape_invariants():
+    """The connectivity-derived geometry has the shapes the figure
+    helpers expect: ``tri`` is (n_tri, 4), ``tri_ijk`` is (n_tri, 3),
+    and ``kept_nodes`` indexes into the full node array."""
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    geom = sv.compute_mesh3d_geometry(elems)
+    assert geom["tri"].shape[1] == 4
+    assert geom["tri_ijk"].shape == (geom["tri"].shape[0], 3)
+    # tri_ijk indices must address the kept-nodes axis.
+    assert geom["tri_ijk"].max() < geom["kept_nodes"].size
+    # kept_nodes references real global node ids.
+    assert geom["kept_nodes"].max() < nodes.shape[0]
+
+
+def test_mesh3d_figure_precomputed_matches_uncached():
+    """Passing ``precomputed_geometry=`` must produce a figure
+    bit-identical to the uncached call."""
+    nodes, elems = _structured_hex_mesh(4, 3, 3)
+    cell_scalar = np.arange(elems.shape[0], dtype=float)
+
+    fig_a = sv.mesh3d_figure(nodes, elems, cell_scalar=cell_scalar)
+    geom = sv.compute_mesh3d_geometry(elems)
+    fig_b = sv.mesh3d_figure(
+        nodes, elems, cell_scalar=cell_scalar, precomputed_geometry=geom
+    )
+
+    for attr in ("x", "y", "z", "i", "j", "k", "intensity"):
+        a = np.asarray(getattr(fig_a.data[0], attr))
+        b = np.asarray(getattr(fig_b.data[0], attr))
+        assert a.shape == b.shape, f"{attr} shape mismatch"
+        assert np.array_equal(a, b), f"{attr} values differ"
+
+
+def test_mesh3d_figure_precomputed_skips_boundary_faces(monkeypatch):
+    """When ``precomputed_geometry`` is supplied, the expensive
+    ``boundary_faces`` + ``quads_to_triangles`` calls must NOT run —
+    the whole point of the cache."""
+    nodes, elems = _structured_hex_mesh(4, 3, 3)
+    geom = sv.compute_mesh3d_geometry(elems)
+
+    bf_calls = {"n": 0}
+    qt_calls = {"n": 0}
+
+    real_bf = sv.boundary_faces
+    real_qt = sv.quads_to_triangles
+
+    def _counted_bf(e):
+        bf_calls["n"] += 1
+        return real_bf(e)
+
+    def _counted_qt(q):
+        qt_calls["n"] += 1
+        return real_qt(q)
+
+    monkeypatch.setattr(sv, "boundary_faces", _counted_bf)
+    monkeypatch.setattr(sv, "quads_to_triangles", _counted_qt)
+
+    sv.mesh3d_figure(
+        nodes, elems,
+        cell_scalar=np.arange(elems.shape[0], dtype=float),
+        precomputed_geometry=geom,
+    )
+    assert bf_calls["n"] == 0, "boundary_faces ran despite cache hit"
+    assert qt_calls["n"] == 0, "quads_to_triangles ran despite cache hit"
+
+    # Sanity check: without the cache, both helpers DO run.
+    sv.mesh3d_figure(nodes, elems)
+    assert bf_calls["n"] == 1
+    assert qt_calls["n"] == 1
+
+
+def test_precomputed_geometry_threaded_through_wrappers():
+    """The 3 high-level figure helpers must forward
+    ``precomputed_geometry`` down to ``mesh3d_figure``; otherwise the
+    app.py call sites silently pay the boundary-cull cost on every
+    slider move."""
+    nodes, elems = _structured_hex_mesh(3, 3, 3)
+    geom = sv.compute_mesh3d_geometry(elems)
+    stress = np.zeros((elems.shape[0], 6))
+    stress[:, 2] = np.linspace(-100.0, 100.0, elems.shape[0])
+    disp = np.zeros_like(nodes)
+    fi = np.random.RandomState(0).rand(elems.shape[0], 8)
+
+    # Each wrapper accepts the kwarg (it would raise TypeError if not).
+    f1 = sv.stress_contour_figure(
+        nodes, elems, stress, component_index=2, precomputed_geometry=geom,
+    )
+    f2 = sv.deformed_mesh_figure(
+        nodes, elems, disp, scale=10.0, precomputed_geometry=geom,
+    )
+    f3 = sv.fi_3d_figure(
+        nodes, elems, fi, criterion="MaxStress", precomputed_geometry=geom,
+    )
+    for fig in (f1, f2, f3):
+        assert fig is not None
+        assert len(fig.data) == 1


### PR DESCRIPTION
## Summary
- `mesh3d_figure`, `stress_contour_figure`, `deformed_mesh_figure`, and `fi_3d_figure` previously re-ran `boundary_faces(elements)` + `quads_to_triangles(bf)` on every slider tick, even though `elements` is identical between solves and `boundary_faces` does an `np.unique` over `(6 &times; n_elements, 4)` rows.
- New helper `compute_mesh3d_geometry(elements) -> dict` returns the cached `tri`, `kept_nodes`, `tri_ijk`. Each figure function now takes a backwards-compatible `precomputed_geometry=None` kwarg: when supplied, the figure skips the boundary cull and reuses the cached arrays. The vertex slice `vertices[kept_nodes]` still happens per-call so the deformed-mesh view (which mutates `vertices` per slider tick) keeps working.
- `app.py` stashes the geometry in `fe["mesh3d_geometry"]` once per FE solve (lives inside `st.session_state["results"]`), and forwards it via `precomputed_geometry=fe.get("mesh3d_geometry")` at every figure call site. Cache invalidates naturally when a new solve replaces `st.session_state["results"]`.

Fixes #198

## Test plan
- [x] `pytest tests/test_streamlit_viz.py tests/test_viz/ -x` &mdash; **40 passed** (4 new + 36 existing, zero regressions)
- [x] New regression tests pin:
  - Bit-equality vs. uncached figure (verts/i/j/k/intensity all `array_equal`)
  - `monkeypatch` counter confirms `boundary_faces` is called 0 times on the precomputed path and 1 time on the uncached fallback
  - All three wrapper helpers accept the kwarg

## Micro-benchmark (24 &times; 12 &times; 24 hex8 = 6,912 elements, 8,125 nodes)
| | Wall-clock |
|---|---|
| Uncached `mesh3d_figure` | 33.00 ms / call |
| Cached (`precomputed_geometry`) | **4.72 ms / call** |
| **Speedup** | **~7&times;** |

## Notes
- The `_strip_arrays` JSON export filter in `app.py` recurses into dicts and drops numpy arrays, so the new `mesh3d_geometry` entry becomes an empty dict `{}` in the exported JSON &mdash; harmless, no schema break.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_