### PR TITLE
docs: clarify amplitude is half-amplitude (mm), pin via behavioural test

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ result = WrinkleAnalysis(config).run()
 print(result.summary())
 ```
 
-`amplitude` (`A`) is the peak displacement of the wrinkled mid-surface
-from the flat reference (crest height, **not** peak-to-peak). For a
-measured wrinkle (e.g. from a cross-section micrograph or CT slice),
-`A = (z_max − z_min) / 2`. The peak fibre misalignment angle scales as
-`θ_max ≈ arctan(2πA/λ)`, which drives the Budiansky-Fleck compressive
-knockdown.
+`amplitude` (`A`) is the **half-amplitude** [mm]: the peak displacement
+of the wrinkled mid-surface from the flat (unwrinkled) reference plane,
+so `z(x) = A·cos(2πx/λ)` (modulated by the envelope) and the
+peak-to-trough height is `2A`. For a measured wrinkle (e.g. from a
+cross-section micrograph or CT slice), `A = (z_max − z_min) / 2`. The
+peak fibre misalignment angle scales as `θ_max ≈ arctan(2πA/λ)`, which
+drives the Budiansky-Fleck compressive knockdown.
 
 ### Wrinkle geometry parameters
 
@@ -104,7 +105,7 @@ direction; out-of-plane displacement `z(x)` is measured from the flat
 
 | Parameter | Symbol | Definition | Units |
 |-----------|--------|------------|-------|
-| `amplitude` | A | Peak crest height from the flat mid-surface to the wrinkle crest (peak-to-midplane, **not** peak-to-peak; `A = (z_max − z_min)/2` for a measured wrinkle). Must be ≥ 0. | mm |
+| `amplitude` | A | Half-amplitude: peak displacement of the wrinkled mid-surface from the flat reference, with `z(x) = A·cos(2πx/λ)` (modulated by the envelope) and peak-to-trough height `2A`. For a measured wrinkle, `A = (z_max − z_min)/2`. Must be ≥ 0. | mm |
 | `wavelength` | λ | Period of the `cos(2πx/λ)` carrier along the longitudinal x-direction (crest-to-crest distance). Must be > 0. Wavenumber `k = 2π/λ`. | mm |
 | `width` | w | Longitudinal envelope decay length about the centre. Exact meaning is profile-dependent: Gaussian length scale `exp(−(x−x₀)²/w²)`, tapered flat-top extent (`\|x−x₀\| < w/2`), or triangular half-base (`\|x−x₀\| < w`). Must be > 0. | mm |
 | `center` | x₀ | Longitudinal position of the wrinkle crest / envelope peak, in the global x coordinate. Default 0.0. | mm |

--- a/app.py
+++ b/app.py
@@ -486,9 +486,11 @@ with st.sidebar:
         value=DEFAULT_AMPLITUDE, step=0.01,
         key="sb_amplitude",
         help=(
-            "Peak displacement of the wrinkled mid-surface from the flat "
-            "reference (crest height, NOT peak-to-peak). Measure as "
-            "A = (z_max − z_min) / 2 from a cross-section micrograph."
+            "Half-amplitude A [mm]: peak displacement of the wrinkled "
+            "mid-surface from the flat reference, so "
+            "z(x) = A·cos(2π x / λ) and the peak-to-trough height is 2A. "
+            "Measure from a cross-section micrograph as "
+            "A = (z_max − z_min) / 2."
         ),
     )
     wavelength = st.number_input(

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -267,23 +267,12 @@ class AnalysisConfig:
     Parameters
     ----------
     amplitude : float
-        Wrinkle amplitude A [mm].  Default 0.366 (2 ply thicknesses).
-
-        Physical meaning: A is the peak out-of-plane displacement of the
+        Wrinkle half-amplitude *A* [mm]: the peak displacement of the
         wrinkled mid-surface from the flat (unwrinkled) reference plane,
-        measured normal to the laminate.  The mid-surface profile is
-        ``z(x) = A * exp(-(x-x0)^2 / w^2) * cos(2*pi*(x-x0)/lambda)``,
-        so the crest sits at +A, the trough at -A, and the peak-to-peak
-        amplitude is 2A.  A is **not** half-amplitude and **not**
-        peak-to-peak.
-
-        Measuring A in practice (e.g. from a polished cross-section
-        micrograph or a CT slice taken normal to the wrinkle axis):
-
-            A = (z_max - z_min) / 2
-
-        where ``z_max`` and ``z_min`` are the crest and trough of the
-        wrinkled mid-surface measured normal to the unwrinkled laminate.
+        so ``z(x) = A * cos(2*pi*(x - x0) / lambda)`` (modulated by the
+        envelope) and the peak-to-trough height is ``2A``. For a
+        measured wrinkle, ``A = (z_max - z_min) / 2``. Units: mm.
+        Default 0.366 (two ply thicknesses).
 
         Effect on knockdown: A enters the maximum fibre misalignment
         angle through the closed-form ``theta_max = arctan(2*pi*A /

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -60,7 +60,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_analyze.add_argument(
         "--amplitude", type=float, default=0.366,
-        help="Wrinkle amplitude A in mm (default: 0.366)",
+        help=(
+            "Wrinkle half-amplitude A in mm: peak displacement of the "
+            "wrinkled mid-surface from the flat reference, so "
+            "z(x) = A*cos(2*pi*x/lambda) and the peak-to-trough height "
+            "is 2A (default: 0.366)"
+        ),
     )
     p_analyze.add_argument(
         "--wavelength", type=float, default=16.0,
@@ -161,7 +166,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_compare.add_argument(
         "--amplitude", type=float, default=0.366,
-        help="Wrinkle amplitude A in mm (default: 0.366)",
+        help=(
+            "Wrinkle half-amplitude A in mm: peak displacement of the "
+            "wrinkled mid-surface from the flat reference, so "
+            "z(x) = A*cos(2*pi*x/lambda) and the peak-to-trough height "
+            "is 2A (default: 0.366)"
+        ),
     )
     p_compare.add_argument(
         "--wavelength", type=float, default=16.0,

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -195,6 +195,16 @@ class WrinkleConfiguration:
         If the wrinkle list is empty, the amplitude profile name is
         unknown, or the decay length is non-positive.
 
+    Notes
+    -----
+    The wrinkle ``amplitude`` carried by each placement's
+    :class:`~wrinklefe.core.wrinkle.WrinkleProfile` is the
+    **half-amplitude** *A* (mm): the peak displacement of the wrinkled
+    mid-surface from the flat reference, so
+    ``z(x) = A * cos(2*pi*(x - x0) / lambda)`` (modulated by the
+    envelope) and the peak-to-trough height is ``2A``. For a measured
+    wrinkle, ``A = (z_max - z_min) / 2``.
+
     Examples
     --------
     Create a dual-wrinkle concave configuration::

--- a/src/wrinklefe/core/wrinkle.py
+++ b/src/wrinklefe/core/wrinkle.py
@@ -54,8 +54,11 @@ class WrinkleProfile(ABC):
 
     - Profiles are *crest-referenced*: at ``x = center`` the cosine is at
       a maximum, so ``z(center) = amplitude`` (a positive +z crest).
-    - ``amplitude`` is the peak-to-midplane height, **not** peak-to-peak.
-      For a measured wrinkle, ``A = (z_max - z_min) / 2``.
+    - ``amplitude`` is the **half-amplitude** *A* (mm): the peak
+      displacement of the wrinkled mid-surface from the flat reference,
+      so ``z(x) = A * cos(2*pi*(x - x0) / lambda)`` (modulated by the
+      envelope) and the peak-to-trough height is ``2A``. For a measured
+      wrinkle, ``A = (z_max - z_min) / 2``.
     - The peak fibre misalignment angle scales as
       ``theta_max ~= arctan(2*pi*A/lambda)`` (exact for a pure cosine);
       this is dimensionless precisely because *A* and *lambda* share the
@@ -64,10 +67,13 @@ class WrinkleProfile(ABC):
     Parameters
     ----------
     amplitude : float
-        Peak out-of-plane crest height *A* (mm), measured from the flat
-        mid-surface to the wrinkle crest (peak-to-midplane, not
-        peak-to-peak).  Must be non-negative.  Larger *A* increases the
-        fibre misalignment angle and the strength knockdown.
+        Half-amplitude *A* (mm): peak displacement of the wrinkled
+        mid-surface from the flat reference, so
+        ``z(x) = A * cos(2*pi*(x - x0) / lambda)`` (modulated by the
+        envelope) and the peak-to-trough height is ``2A``. For a
+        measured wrinkle, ``A = (z_max - z_min) / 2``. Must be
+        non-negative. Larger *A* increases the fibre misalignment angle
+        and the strength knockdown.
     wavelength : float
         Sinusoidal wavelength *lambda* (mm) along the longitudinal
         *x*-direction: the period of the underlying ``cos(2*pi*x/lambda)``

--- a/tests/test_amplitude_definition.py
+++ b/tests/test_amplitude_definition.py
@@ -1,0 +1,96 @@
+"""Pin the canonical definition of the wrinkle ``amplitude`` parameter (issue #181).
+
+The canonical contract documented in ``WrinkleProfile``,
+``AnalysisConfig.amplitude``, the CLI ``--amplitude`` help, the
+Streamlit ``Amplitude A`` slider, the README parameter table, and the
+``WrinkleConfiguration`` class docstring is:
+
+    ``amplitude`` is the half-amplitude *A* (mm): the peak displacement
+    of the wrinkled mid-surface from the flat reference, so
+    ``z(x) = A * cos(2*pi*(x - x0) / lambda)`` (modulated by the
+    envelope) and the peak-to-trough height is ``2A``.
+
+These tests fix that convention in the math itself: if the formula ever
+switches to the full peak-to-trough convention
+(``z = 0.5 * amplitude * cos(...)``) the assertions below will fail and
+force the documentation to be updated in lockstep.
+"""
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.wrinkle import (
+    GaussianBump,
+    GaussianSinusoidal,
+    PureSinusoidal,
+    RectangularSinusoidal,
+    TriangularSinusoidal,
+)
+
+
+# Canonical test point: A = 1.0 mm, lambda = 10.0 mm.
+# Under the half-amplitude convention the peak |z| of the displaced
+# surface equals exactly 1.0 (the full peak-to-trough height is 2.0).
+_AMPLITUDE = 1.0
+_WAVELENGTH = 10.0
+_WIDTH = 50.0  # >> wavelength so the envelope is essentially flat near x0
+
+
+def test_pure_sinusoidal_peak_equals_half_amplitude() -> None:
+    """``PureSinusoidal`` peak |z| equals the half-amplitude A exactly."""
+    profile = PureSinusoidal(
+        amplitude=_AMPLITUDE, wavelength=_WAVELENGTH, width=_WIDTH
+    )
+    # At the centre the cosine is at its maximum, so z(0) = A.
+    assert profile.displacement(np.array([0.0]))[0] == pytest.approx(_AMPLITUDE)
+    # Half a wavelength away the cosine is at its minimum, so z = -A.
+    assert profile.displacement(np.array([_WAVELENGTH / 2.0]))[0] == pytest.approx(
+        -_AMPLITUDE
+    )
+    # The peak-to-trough height is 2A.
+    xs = np.linspace(-_WAVELENGTH, _WAVELENGTH, 4001)
+    zs = profile.displacement(xs)
+    assert (zs.max() - zs.min()) == pytest.approx(2.0 * _AMPLITUDE)
+
+
+def test_pure_sinusoidal_with_amplitude_one_peak_is_one() -> None:
+    """Behavioural pin for issue #181: peak |z| == 1.0 for A=1.0, lambda=10.0."""
+    profile = PureSinusoidal(amplitude=1.0, wavelength=10.0, width=50.0)
+    xs = np.linspace(-20.0, 20.0, 8001)
+    peak = float(np.max(np.abs(profile.displacement(xs))))
+    # If the formula were z = 0.5 * A * cos(...), this would be 0.5.
+    assert peak == pytest.approx(1.0)
+
+
+def test_gaussian_sinusoidal_peak_at_centre_equals_half_amplitude() -> None:
+    """``GaussianSinusoidal`` at the crest equals A (envelope = 1 at centre)."""
+    profile = GaussianSinusoidal(
+        amplitude=_AMPLITUDE, wavelength=_WAVELENGTH, width=_WIDTH
+    )
+    # At x = center the envelope and cosine are both 1, so z = A exactly.
+    assert profile.displacement(np.array([0.0]))[0] == pytest.approx(_AMPLITUDE)
+
+
+def test_gaussian_bump_peak_equals_half_amplitude() -> None:
+    """``GaussianBump`` peak (at x = centre) equals A."""
+    profile = GaussianBump(
+        amplitude=_AMPLITUDE, wavelength=_WAVELENGTH, width=_WIDTH
+    )
+    assert profile.displacement(np.array([0.0]))[0] == pytest.approx(_AMPLITUDE)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [PureSinusoidal, GaussianSinusoidal, RectangularSinusoidal, TriangularSinusoidal],
+)
+def test_amplitude_scales_displacement_linearly(cls) -> None:
+    """Doubling A doubles the peak displacement (linear-in-A contract)."""
+    profile_a = cls(amplitude=1.0, wavelength=_WAVELENGTH, width=_WIDTH)
+    profile_b = cls(amplitude=2.0, wavelength=_WAVELENGTH, width=_WIDTH)
+    # At the centre x = 0 (= profile.center), both the envelope and the
+    # cosine are at their maxima, so z(0) = A * 1 * 1 = A.
+    z_a = profile_a.displacement(np.array([0.0]))[0]
+    z_b = profile_b.displacement(np.array([0.0]))[0]
+    assert z_a == pytest.approx(1.0)
+    assert z_b == pytest.approx(2.0)
+    assert z_b == pytest.approx(2.0 * z_a)


### PR DESCRIPTION
## Summary
The wrinkle `amplitude` parameter was used throughout the codebase without a clear geometric definition &mdash; users couldn't tell if it was the full peak-to-trough height, the half-amplitude, or peak displacement. The `AnalysisConfig.amplitude` docstring even asserted *"A is **not** half-amplitude and **not** peak-to-peak"*, contradicting both the actual math and every other doc.

Math verified by reading `src/wrinklefe/core/wrinkle.py`: every concrete profile uses `A * cos(...)`, never `0.5 * A * cos(...)`. So `amplitude` is the **half-amplitude** (peak displacement from the flat reference plane).

Canonical definition propagated identically to 6 locations:

> `amplitude` is the **half-amplitude** A (mm): the peak displacement of the wrinkled mid-surface from the flat (unwrinkled) reference plane, so `z(x) = A &middot; cos(2&pi;(x &minus; x&#x2080;) / &lambda;)` (modulated by the envelope) and the peak-to-trough height is `2A`. For a measured wrinkle, `A = (z_max &minus; z_min) / 2`.

Fixes #181

## Locations updated
- `src/wrinklefe/analysis.py` &mdash; `AnalysisConfig.amplitude` docstring (the contradiction)
- `src/wrinklefe/cli.py` &mdash; `--amplitude` help for both `analyze` and `compare` subcommands
- `app.py` &mdash; Streamlit `Amplitude A [mm]` `number_input` `help=` text
- `README.md` &mdash; narrative paragraph + wrinkle-geometry parameter table
- `src/wrinklefe/core/morphology.py` &mdash; `WrinkleConfiguration` docstring (added a `Notes` section)
- `src/wrinklefe/core/wrinkle.py` &mdash; `WrinkleProfile` sign-convention notes and `amplitude` parameter description

## Test plan
- [x] New `tests/test_amplitude_definition.py` pins the half-amplitude convention behaviourally: for `amplitude=1.0`, `wavelength=10.0`, the peak `|z|` of the displaced surface equals exactly `1.0` (would be `0.5` under peak-to-trough)
- [x] Coverage extends to all profile types (`PureSinusoidal`, `GaussianSinusoidal`, `RectangularSinusoidal`, `TriangularSinusoidal`, `GaussianBump`) and linear-in-A scaling
- [x] `pytest tests/ -k "morphology or amplitude" -x` &mdash; 167 passed

## Schematic check
The Streamlit `_morphology_schematic` is a stylised cartoon (its docstring says "decorative line drawing of the morphology, not a data plot"). It uses a scaled visual amplitude and does not label `amplitude` &mdash; no mismatch to flag.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_