### PR TITLE
fix(packaging): add streamlit extra so plotly/streamlit tests run in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,18 @@ dependencies = [
 # requirements.txt for the rationale.
 [project.optional-dependencies]
 export = ["meshio>=5.3"]
+# Streamlit web app deps — keep versions in sync with requirements.txt.
+streamlit = [
+    "streamlit>=1.57",
+    "plotly>=6.7",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.1",
     "mypy>=1.5",
 ]
-all = ["wrinklefe[export,dev]"]
+all = ["wrinklefe[export,streamlit,dev]"]
 
 [project.scripts]
 wrinklefe = "wrinklefe.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ scipy>=1.14,<2
 matplotlib>=3.9,<4
 
 # --- Web app ---
+# Keep versions in sync with the `streamlit` extra in pyproject.toml.
 streamlit>=1.57.0
 plotly>=6.7.0


### PR DESCRIPTION
## Summary
- Added a `streamlit` extra to `pyproject.toml` with `streamlit>=1.57` and `plotly>=6.7` (matching `requirements.txt` minimums) and folded it into the `[all]` self-reference (`wrinklefe[export,streamlit,dev]`).
- Previously `pip install -e ".[all,dev]"` did **not** install streamlit/plotly, so `pytest.importorskip("plotly")` at `tests/test_streamlit_viz.py:23` silently skipped the entire module on every CI run &mdash; uncovered surface area on the perf-critical 3D hot path.
- Added a one-line "keep in sync with `pyproject.toml`" comment in `requirements.txt`.

Fixes #201

## Test plan
- Before: `pytest tests/test_streamlit_viz.py` in CI &mdash; **0 tests executed** (module-level skip)
- After: 21 tests collected, **21 passed** (verified locally with `pip install -e ".[all,dev]"`)
- `ci.yml` did not need to change &mdash; `[all]` now transitively pulls in the new extra


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_