### PR TITLE
fix(viz): use global colorbar range for y-slice scrubber (matches 3D contour)

### DIFF
--- a/app.py
+++ b/app.py
@@ -764,6 +764,30 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             k: np.asarray(v, dtype=np.float64)
             for k, v in (result.failure_indices or {}).items()
         }
+        # Per-component global |max| stress, indexed by Voigt component.
+        # The y-slice scrubber uses these so the colorbar range matches
+        # the symmetric range the 3D contour computes. Without it the
+        # slice silently re-normalises per station and users mistakenly
+        # see the stress as uniform along y. See issue #200.
+        if stress_per_elem.size:
+            stress_vmax_per_comp = np.nanmax(
+                np.abs(stress_per_elem), axis=0
+            ).astype(float)
+        else:
+            stress_vmax_per_comp = np.zeros(
+                stress_per_elem.shape[1] if stress_per_elem.ndim == 2 else 6,
+                dtype=float,
+            )
+        # Per-criterion global max FI (FI is ≥ 0, so vmin = 0).
+        fi_vmax_per_crit: dict[str, float] = {}
+        for crit, arr in fi_per_gauss.items():
+            if arr.size:
+                vmax_c = float(np.nanmax(arr))
+                if not np.isfinite(vmax_c) or vmax_c <= 0.0:
+                    vmax_c = 1.0
+                fi_vmax_per_crit[crit] = vmax_c
+            else:
+                fi_vmax_per_crit[crit] = 1.0
         fe = {
             "modulus_retention": float(result.modulus_retention),
             "retention_factors": {
@@ -791,6 +815,10 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             "stress_per_elem": stress_per_elem,
             "element_centers": element_centers,
             "fi_per_gauss": fi_per_gauss,
+            # Precomputed global colorbar extrema for the y-slice
+            # scrubber.  See issue #200.
+            "stress_vmax_per_comp": stress_vmax_per_comp,
+            "fi_vmax_per_crit": fi_vmax_per_crit,
             # Precomputed boundary-face triangulation cached once per
             # solve so slider re-renders skip the boundary cull. See
             # issue #198.
@@ -1447,10 +1475,36 @@ with tab_results:
                             format_func=lambda t: t[1],
                             key="viz_slice_component",
                         )
+                        slice_range = st.radio(
+                            "Colorbar range",
+                            ["global (default)", "per-slice"],
+                            index=0,
+                            horizontal=True,
+                            key="viz_slice_range_mode",
+                            help=(
+                                "Default uses the global |max| of this "
+                                "stress component across the whole part, so "
+                                "the slice colorbar matches the 3D contour "
+                                "and you see real changes as you scrub y. "
+                                "'per-slice' renormalises to the visible "
+                                "station only — useful for inspecting one "
+                                "cold cross-section in detail. See #200."
+                            ),
+                        )
+                        vmax_global = float(
+                            fe["stress_vmax_per_comp"][slice_comp[0]]
+                        )
+                        if slice_range == "global (default)" and vmax_global > 0:
+                            slice_kwargs = dict(
+                                vmin=-vmax_global, vmax=vmax_global
+                            )
+                        else:
+                            slice_kwargs = {}
                         fig_slice = streamlit_viz.y_slice_figure(
                             fe["element_centers"], fe["elements"], fe["nodes"],
                             fe["stress_per_elem"], slice_comp[0], y_station,
                             component_label=slice_comp[1],
+                            **slice_kwargs,
                         )
                         if fig_slice is not None:
                             st.plotly_chart(fig_slice, width="stretch")
@@ -1500,10 +1554,41 @@ with tab_results:
                         st.markdown("**y-slice scrubber**")
                         y_station = _y_station_slider()
                         if y_station is not None:
+                            fi_slice_range = st.radio(
+                                "Colorbar range",
+                                ["global (default)", "per-slice"],
+                                index=0,
+                                horizontal=True,
+                                key="viz_fi_slice_range_mode",
+                                help=(
+                                    "Default uses the global max FI for "
+                                    "this criterion so the slice colorbar "
+                                    "matches the 3D contour and the "
+                                    "saturation tracks the real per-station "
+                                    "FI as you scrub y. 'per-slice' "
+                                    "renormalises to the visible station "
+                                    "only. See #200."
+                                ),
+                            )
+                            fi_vmax_global = float(
+                                fe.get("fi_vmax_per_crit", {}).get(
+                                    crit_for_3d, 0.0
+                                )
+                            )
+                            if (
+                                fi_slice_range == "global (default)"
+                                and fi_vmax_global > 0
+                            ):
+                                fi_slice_kwargs = dict(
+                                    vmin=0.0, vmax=fi_vmax_global
+                                )
+                            else:
+                                fi_slice_kwargs = {}
                             fig_slice = streamlit_viz.fi_y_slice_figure(
                                 fe["element_centers"], fe["elements"],
                                 fe["nodes"], fi_dict[crit_for_3d], y_station,
                                 criterion=crit_for_3d,
+                                **fi_slice_kwargs,
                             )
                             if fig_slice is not None:
                                 st.plotly_chart(fig_slice, width="stretch")

--- a/streamlit_viz.py
+++ b/streamlit_viz.py
@@ -310,6 +310,8 @@ def y_slice_figure(
     y_station: float,
     *,
     component_label: str = "σ₃₃",
+    vmin: float | None = None,
+    vmax: float | None = None,
 ) -> go.Figure | None:
     """Filter elements at the given y-station and render a 2D scatter
     in the (x, z) plane coloured by the chosen stress component.
@@ -317,6 +319,14 @@ def y_slice_figure(
     The 'slice' is the layer of elements whose y-row matches the station;
     we pick the elements whose centre-y is closest to the station to
     avoid empty slices on coarse meshes.
+
+    ``vmin`` / ``vmax`` override the colorbar range.  When both are
+    ``None`` (default), the range is computed from the slice's values
+    only — symmetric around zero — preserving the original behaviour
+    for any direct callers.  The Streamlit app passes the global stress
+    extrema so the slice colorbar matches the 3D contour above it and
+    users scrubbing through y-stations see real changes in saturation
+    rather than the colorbar silently re-normalising.  See issue #200.
     """
     yc = element_centers[:, 1]
     unique_y = np.unique(yc)
@@ -330,7 +340,23 @@ def y_slice_figure(
     xs = element_centers[mask, 0]
     zs = element_centers[mask, 2]
     vals = stress_per_elem[mask, component_index]
-    vmax = float(np.nanmax(np.abs(vals))) if vals.size else 1.0
+
+    # Resolve the colorbar range.  If the caller supplied either bound,
+    # use it; otherwise fall back to the per-slice symmetric range that
+    # the original implementation computed.
+    if vmin is None and vmax is None:
+        slice_vmax = float(np.nanmax(np.abs(vals))) if vals.size else 1.0
+        cmin, cmax = -slice_vmax, slice_vmax
+        title_suffix = ""
+    else:
+        if vmax is None:
+            vmax = float(np.nanmax(np.abs(vals))) if vals.size else 1.0
+        if vmin is None:
+            vmin = -float(vmax)
+        cmin, cmax = float(vmin), float(vmax)
+        title_suffix = (
+            f"  ·  {component_label} ∈ [{cmin:.1f}, {cmax:.1f}] (global)"
+        )
 
     # Approximate per-element x and z extents from the bounding box of
     # its 8 nodes so the rectangular markers tile cleanly.
@@ -347,8 +373,8 @@ def y_slice_figure(
                 size=14,
                 color=vals,
                 colorscale="RdBu_r",
-                cmin=-vmax,
-                cmax=vmax,
+                cmin=cmin,
+                cmax=cmax,
                 symbol="square",
                 line=dict(width=0),
                 colorbar=dict(title=f"{component_label} [MPa]"),
@@ -360,7 +386,10 @@ def y_slice_figure(
         )
     )
     fig.update_layout(
-        title=f"{component_label} at y ≈ {nearest_y:.2f} mm  ·  Δx≈{dx:.2f} mm  Δz≈{dz:.3f} mm",
+        title=(
+            f"{component_label} at y ≈ {nearest_y:.2f} mm  ·  "
+            f"Δx≈{dx:.2f} mm  Δz≈{dz:.3f} mm{title_suffix}"
+        ),
         xaxis_title="x [mm]",
         yaxis_title="z [mm]",
         height=360,
@@ -378,6 +407,8 @@ def fi_y_slice_figure(
     y_station: float,
     *,
     criterion: str = "FI",
+    vmin: float | None = None,
+    vmax: float | None = None,
 ) -> go.Figure | None:
     """Filter elements at the given y-station and render a 2D scatter in
     the (x, z) plane coloured by the per-element max failure index for
@@ -385,6 +416,11 @@ def fi_y_slice_figure(
 
     Mirrors :func:`y_slice_figure` but uses a sequential (Reds) colour
     scale starting at 0 since FI is non-negative.
+
+    ``vmin`` / ``vmax`` override the colorbar range; defaults preserve
+    the original per-slice behaviour.  The Streamlit app passes the
+    global FI extrema so dragging the y-station scrubber shows real
+    changes in saturation.  See issue #200.
     """
     yc = element_centers[:, 1]
     unique_y = np.unique(yc)
@@ -399,9 +435,25 @@ def fi_y_slice_figure(
     zs = element_centers[mask, 2]
     fi_max_per_elem = np.asarray(fi_per_gauss).max(axis=1)
     vals = fi_max_per_elem[mask]
-    vmax = float(np.nanmax(vals)) if vals.size else 1.0
-    if not np.isfinite(vmax) or vmax <= 0.0:
-        vmax = 1.0
+
+    if vmin is None and vmax is None:
+        slice_vmax = float(np.nanmax(vals)) if vals.size else 1.0
+        if not np.isfinite(slice_vmax) or slice_vmax <= 0.0:
+            slice_vmax = 1.0
+        cmin, cmax = 0.0, slice_vmax
+        title_suffix = ""
+    else:
+        if vmax is None:
+            vmax = float(np.nanmax(vals)) if vals.size else 1.0
+        if vmin is None:
+            vmin = 0.0
+        cmax = float(vmax)
+        if not np.isfinite(cmax) or cmax <= 0.0:
+            cmax = 1.0
+        cmin = float(vmin)
+        title_suffix = (
+            f"  ·  FI ∈ [{cmin:.3f}, {cmax:.3f}] (global)"
+        )
 
     elem_node_xyz = nodes[elements[mask]]
     dx = float(np.ptp(elem_node_xyz[:, :, 0], axis=1).mean()) if mask.sum() else 1.0
@@ -416,8 +468,8 @@ def fi_y_slice_figure(
                 size=14,
                 color=vals,
                 colorscale="Reds",
-                cmin=0.0,
-                cmax=vmax,
+                cmin=cmin,
+                cmax=cmax,
                 symbol="square",
                 line=dict(width=0),
                 colorbar=dict(title=f"FI ({criterion})"),
@@ -431,7 +483,7 @@ def fi_y_slice_figure(
     fig.update_layout(
         title=(
             f"FI ({criterion}) at y ≈ {nearest_y:.2f} mm  ·  "
-            f"Δx≈{dx:.2f} mm  Δz≈{dz:.3f} mm"
+            f"Δx≈{dx:.2f} mm  Δz≈{dz:.3f} mm{title_suffix}"
         ),
         xaxis_title="x [mm]",
         yaxis_title="z [mm]",

--- a/tests/test_streamlit_viz.py
+++ b/tests/test_streamlit_viz.py
@@ -335,6 +335,151 @@ def test_mesh3d_figure_precomputed_skips_boundary_faces(monkeypatch):
     assert qt_calls["n"] == 1
 
 
+# ---------------------------------------------------------------------------
+# y-slice global colorbar range (issue #200)
+# ---------------------------------------------------------------------------
+
+
+def _structured_hex_mesh_with_centers(nx: int, ny: int, nz: int):
+    """Mesh + per-element centroids, used to build per-station stress fields."""
+    nodes, elems = _structured_hex_mesh(nx, ny, nz)
+    centers = nodes[elems].mean(axis=1)
+    return nodes, elems, centers
+
+
+def test_y_slice_figure_default_is_per_slice_back_compat():
+    """Calling y_slice_figure with no vmin/vmax preserves the original
+    per-slice symmetric range — important for back-compat with any
+    direct callers outside the Streamlit app."""
+    nodes, elems, centers = _structured_hex_mesh_with_centers(3, 3, 3)
+    stress = np.zeros((elems.shape[0], 6))
+    # Make σ₃₃ vary so the slice picks up a non-trivial range.
+    stress[:, 2] = np.linspace(-100.0, 100.0, elems.shape[0])
+    y_unique = np.unique(centers[:, 1])
+    y_station = float(y_unique[0])
+
+    fig = sv.y_slice_figure(
+        centers, elems, nodes, stress, component_index=2, y_station=y_station,
+    )
+    assert fig is not None
+    marker = fig.data[0].marker
+    # Symmetric around zero, computed from the slice's own values.
+    mask = centers[:, 1] == y_station
+    expected = float(np.nanmax(np.abs(stress[mask, 2])))
+    assert marker.cmin == pytest.approx(-expected)
+    assert marker.cmax == pytest.approx(expected)
+
+
+def test_y_slice_figure_global_vmax_matches_across_stations():
+    """The whole point of issue #200: two stations with very different
+    stress magnitudes must end up with the SAME colorbar range when the
+    caller passes a global vmax, so the user can compare them by eye."""
+    nodes, elems, centers = _structured_hex_mesh_with_centers(3, 3, 3)
+    stress = np.zeros((elems.shape[0], 6))
+    yc = centers[:, 1]
+    y_unique = np.unique(yc)
+    cold_y = float(y_unique[0])
+    hot_y = float(y_unique[-1])
+    # Build a stress field with a "hot" station and a "cold" station so
+    # per-slice normalisation WOULD give them different cmin/cmax — but
+    # the global override must wash that out.
+    stress[yc == cold_y, 2] = 10.0
+    stress[yc == hot_y, 2] = 500.0
+
+    global_vmax = float(np.nanmax(np.abs(stress[:, 2])))
+    assert global_vmax == pytest.approx(500.0)
+
+    fig_cold = sv.y_slice_figure(
+        centers, elems, nodes, stress,
+        component_index=2, y_station=cold_y,
+        vmin=-global_vmax, vmax=global_vmax,
+    )
+    fig_hot = sv.y_slice_figure(
+        centers, elems, nodes, stress,
+        component_index=2, y_station=hot_y,
+        vmin=-global_vmax, vmax=global_vmax,
+    )
+    assert fig_cold is not None and fig_hot is not None
+    m_cold, m_hot = fig_cold.data[0].marker, fig_hot.data[0].marker
+    assert m_cold.cmin == m_hot.cmin == pytest.approx(-global_vmax)
+    assert m_cold.cmax == m_hot.cmax == pytest.approx(global_vmax)
+    # And the title advertises the global range so the user knows.
+    assert "global" in fig_cold.layout.title.text
+    assert "global" in fig_hot.layout.title.text
+
+
+def test_y_slice_figure_global_vmax_matches_3d_contour():
+    """A saturated cell on the 3D contour must use the same cmin/cmax
+    as the same cell on the 2D slice; otherwise red on one plot means
+    a different stress than red on the other.  See issue #200."""
+    nodes, elems, centers = _structured_hex_mesh_with_centers(3, 3, 3)
+    stress = np.zeros((elems.shape[0], 6))
+    stress[:, 2] = np.linspace(-100.0, 100.0, elems.shape[0])
+
+    fig_3d = sv.stress_contour_figure(nodes, elems, stress, component_index=2)
+    mesh = fig_3d.data[0]
+    contour_cmin, contour_cmax = float(mesh.cmin), float(mesh.cmax)
+
+    y_station = float(np.unique(centers[:, 1])[len(np.unique(centers[:, 1])) // 2])
+    fig_slice = sv.y_slice_figure(
+        centers, elems, nodes, stress,
+        component_index=2, y_station=y_station,
+        vmin=contour_cmin, vmax=contour_cmax,
+    )
+    assert fig_slice is not None
+    marker = fig_slice.data[0].marker
+    assert marker.cmin == pytest.approx(contour_cmin)
+    assert marker.cmax == pytest.approx(contour_cmax)
+
+
+def test_fi_y_slice_figure_global_vmax_matches_across_stations():
+    """Same regression for the failure-index slice: per-station hot/cold
+    contrast must survive when the caller passes a global vmax."""
+    nodes, elems, centers = _structured_hex_mesh_with_centers(3, 3, 3)
+    yc = centers[:, 1]
+    y_unique = np.unique(yc)
+    cold_y = float(y_unique[0])
+    hot_y = float(y_unique[-1])
+    fi = np.zeros((elems.shape[0], 8))
+    fi[yc == cold_y, :] = 0.05
+    fi[yc == hot_y, :] = 1.5
+
+    global_vmax = float(np.nanmax(fi))
+    assert global_vmax == pytest.approx(1.5)
+
+    fig_cold = sv.fi_y_slice_figure(
+        centers, elems, nodes, fi, y_station=cold_y,
+        criterion="MaxStress", vmin=0.0, vmax=global_vmax,
+    )
+    fig_hot = sv.fi_y_slice_figure(
+        centers, elems, nodes, fi, y_station=hot_y,
+        criterion="MaxStress", vmin=0.0, vmax=global_vmax,
+    )
+    assert fig_cold is not None and fig_hot is not None
+    m_cold, m_hot = fig_cold.data[0].marker, fig_hot.data[0].marker
+    assert m_cold.cmin == m_hot.cmin == pytest.approx(0.0)
+    assert m_cold.cmax == m_hot.cmax == pytest.approx(global_vmax)
+    assert "global" in fig_cold.layout.title.text
+
+
+def test_fi_y_slice_figure_default_is_per_slice_back_compat():
+    """No-vmax call must keep the original per-slice [0, max(slice)]
+    range so any direct callers don't see a silent behaviour change."""
+    nodes, elems, centers = _structured_hex_mesh_with_centers(3, 3, 3)
+    fi = np.random.RandomState(0).rand(elems.shape[0], 8)
+    y_station = float(np.unique(centers[:, 1])[0])
+
+    fig = sv.fi_y_slice_figure(
+        centers, elems, nodes, fi, y_station=y_station, criterion="MaxStress",
+    )
+    assert fig is not None
+    marker = fig.data[0].marker
+    mask = centers[:, 1] == y_station
+    expected = float(np.nanmax(fi.max(axis=1)[mask]))
+    assert marker.cmin == pytest.approx(0.0)
+    assert marker.cmax == pytest.approx(expected)
+
+
 def test_precomputed_geometry_threaded_through_wrappers():
     """The 3 high-level figure helpers must forward
     ``precomputed_geometry`` down to ``mesh3d_figure``; otherwise the


### PR DESCRIPTION
## Summary
- `y_slice_figure` and `fi_y_slice_figure` previously computed `vmax` from the values **inside the current slice only**. Dragging the y-scrubber gave the same red/blue saturation at a cold station as at the peak-stress station, so the colour pattern stayed similar across stations and users mistakenly concluded stress was uniform along y. The 3D contour view above the slice used its own global `symmetric=True` vmax, so the two views silently disagreed.
- Both slice functions now accept `vmin` / `vmax` kwargs (default `None` preserves the old per-slice behaviour for direct callers). When supplied, the colorbar overrides apply and the title appends a `... &isin; [-A, +A] (global)` suffix for context.
- `app.py` computes `stress_vmax_per_comp` (per-Voigt-component `|max|`) and `fi_vmax_per_crit` (per-criterion max) once per FE solve and stashes them in `st.session_state["results"]["fe"]` alongside the `mesh3d_geometry` from #223.
- New `st.radio("Colorbar range", ["global (default)", "per-slice"])` next to each scrubber lets users opt back into per-slice normalisation when investigating one station.
- Stress slices use symmetric `vmin=-vmax_global` (matching `stress_contour_figure`'s `symmetric=True` path); FI slices use `vmin=0` (FI is &ge; 0).

Fixes #200

## Test plan
- `pytest tests/test_streamlit_viz.py -x` &mdash; **26 passed** (5 new)
- `pytest tests/test_viz/ -x` &mdash; 19 passed
- Full unit suite (excl. integration) &mdash; 1011 passed
- New regression tests pin:
  - Default no-vmax call preserves original symmetric per-slice range (stress + FI back-compat)
  - Hot/cold y-stations get identical `cmin / cmax` when global `vmax` passed (stress + FI)
  - Slice `cmin / cmax` matches what `stress_contour_figure` produces for the same component


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_