### PR TITLE
feat(io): schema-versioned CSV / JSON export for AnalysisResults (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,34 @@ print(result.analytical_knockdown)
 wrinklefe --help
 ```
 
+### Exporting results to CSV / JSON
+
+Numeric outputs (load factor, per-ply failure index, knockdown factors,
+stress-field summary) can be written to a schema-versioned JSON or a
+Pandas-friendly per-ply CSV for downstream comparison and plotting in
+Excel, Pandas, or shared Jupyter notebooks:
+
+```python
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.io.results import export_results_csv, export_results_json
+
+result = WrinkleAnalysis(AnalysisConfig()).run()
+
+export_results_json(result, "results.json")  # schema-versioned JSON
+export_results_csv(result, "per_ply.csv")    # per-ply tabular CSV
+```
+
+The JSON output is deterministic (`sort_keys=True`), pins a top-level
+`schema_version` field, and reduces large numpy arrays (e.g.
+per-Gauss-point stress fields) to summary statistics so the file stays
+compact. The CSV is one row per ply with columns `ply_index,
+angle_deg, max_FI, min_RF, critical_mode, critical_criterion`, suitable
+for `pandas.read_csv` or `csv.DictReader`.
+
+The Streamlit web app exposes the same exports as **Download results as
+JSON** and **Download per-ply results as CSV** buttons on the Export
+tab.
+
 ## Validation
 
 ### What the in-repo tests check

--- a/app.py
+++ b/app.py
@@ -1587,6 +1587,56 @@ with tab_export:
                 mime="text/csv",
             )
 
+        # Per-ply CSV — Pandas-friendly tabular dump matching the
+        # wrinklefe.io.results.export_results_csv schema (issue #2).
+        _angles_export = list(
+            dict(st.session_state["cfg_payload"])["angles_tuple"]
+        )
+        _per_ply_buf = io.StringIO()
+        _per_ply_writer = csv.writer(_per_ply_buf)
+        _per_ply_writer.writerow([
+            "ply_index", "angle_deg",
+            "max_FI", "min_RF", "critical_mode", "critical_criterion",
+        ])
+        _ply_fi = (fe or {}).get("ply_failure_indices") or {}
+        for _k, _ang in enumerate(_angles_export):
+            _row_fi = -float("inf")
+            _row_crit: Optional[str] = None
+            for _crit_name, _arr in _ply_fi.items():
+                if _k < len(_arr) and _arr[_k] > _row_fi:
+                    _row_fi = float(_arr[_k])
+                    _row_crit = _crit_name
+            if _row_crit is None or not np.isfinite(_row_fi):
+                _per_ply_writer.writerow([_k, _ang, "", "", "", ""])
+                continue
+            _row_rf = (1.0 / _row_fi) if _row_fi > 0 else ""
+            _mode = ""
+            if (
+                _row_crit
+                and fe
+                and fe.get("critical_criterion") == _row_crit
+                and fe.get("critical_ply") == _k
+            ):
+                _mode = fe.get("critical_mode") or ""
+            _per_ply_writer.writerow([
+                _k,
+                _ang,
+                f"{_row_fi:.10g}",
+                (f"{_row_rf:.10g}" if isinstance(_row_rf, float) else ""),
+                _mode,
+                _row_crit,
+            ])
+        st.download_button(
+            "Download per-ply results as CSV",
+            data=_per_ply_buf.getvalue().encode(),
+            file_name="wrinklefe_per_ply.csv",
+            mime="text/csv",
+            help=(
+                "Per-ply tabular summary (one row per ply). Schema matches "
+                "wrinklefe.io.results.export_results_csv."
+            ),
+        )
+
         st.caption(
             f"WrinkleFE {_wrinklefe_version} · "
             f"export timestamp {payload['meta']['timestamp_utc']}"

--- a/src/wrinklefe/io/__init__.py
+++ b/src/wrinklefe/io/__init__.py
@@ -10,6 +10,17 @@ Public API
 .. autofunction:: render_summary_markdown
 .. autofunction:: render_summary_pdf
 .. autofunction:: export_summary
+.. autofunction:: export_results_csv
+.. autofunction:: results_to_dict
+
+The legacy ``export_results_json`` (in :mod:`wrinklefe.io.export`) and
+the schema-versioned, tabular pair in :mod:`wrinklefe.io.results`
+(:func:`export_results_json`, :func:`export_results_csv`,
+:func:`results_to_dict`) coexist. The legacy entry remains the default
+under ``wrinklefe.io.export_results_json`` so existing callers do not
+break; consumers who want the v1.0 schema (with ``per_ply`` table,
+``first_ply_failure``, ``knockdown_factors``, ``schema_version``) should
+import directly from :mod:`wrinklefe.io.results`.
 """
 
 from wrinklefe.io.export import (
@@ -22,9 +33,17 @@ from wrinklefe.io.export import (
     render_summary_markdown,
     render_summary_pdf,
 )
+from wrinklefe.io.results import (
+    SCHEMA_VERSION,
+    export_results_csv,
+    results_to_dict,
+)
 
 __all__ = [
     "export_results_json",
+    "export_results_csv",
+    "results_to_dict",
+    "SCHEMA_VERSION",
     "export_abaqus_inp",
     "export_vtk",
     "build_analysis_summary",

--- a/src/wrinklefe/io/results.py
+++ b/src/wrinklefe/io/results.py
@@ -1,0 +1,443 @@
+"""Tabular / structured export of :class:`AnalysisResults` to CSV and JSON.
+
+This module complements :mod:`wrinklefe.io.export` (which already provides
+the legacy ``export_results_json`` and the mesh-oriented Abaqus/VTK
+writers).  The exporters here are designed for downstream comparison and
+plotting in Excel, Pandas or Jupyter:
+
+- :func:`export_results_json` writes a *structured*, schema-versioned
+  JSON document.  Numeric scalars and short 1D arrays are serialised in
+  full; larger arrays (e.g. per-Gauss-point stress fields) are reduced
+  to summary statistics so the file stays a few-KB artefact rather than
+  a multi-MB dump.
+- :func:`export_results_csv` writes a per-ply, Pandas-friendly CSV table
+  with one row per ply.
+- :func:`results_to_dict` returns the same JSON-shaped dict in-memory,
+  so callers (CLI, Streamlit, tests) can post-process the structure
+  without round-tripping through a file.
+
+The JSON output is deterministic (``sort_keys=True``) and all numeric
+values are plain Python ``float`` / ``int`` so the file round-trips
+cleanly through :func:`json.load`.
+
+A schema version field is embedded so future evolutions don't silently
+break consumers — bump :data:`SCHEMA_VERSION` whenever the public shape
+changes.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Union
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from wrinklefe.analysis import AnalysisConfig, AnalysisResults
+
+
+# ----------------------------------------------------------------------
+# Schema
+# ----------------------------------------------------------------------
+
+#: Bump this when the public JSON layout changes in a non-additive way.
+SCHEMA_VERSION = "1.0"
+
+#: 1D arrays at or below this length are serialised in full; longer
+#: arrays are reduced to {min, max, mean, p95}.  A few-hundred-element
+#: ceiling keeps the JSON small without truncating per-ply data for
+#: realistic layups.
+_ARRAY_INLINE_LIMIT = 256
+
+
+# ----------------------------------------------------------------------
+# JSON-friendly conversion helpers
+# ----------------------------------------------------------------------
+
+def _to_jsonable(obj: Any) -> Any:
+    """Coerce numpy / dataclass / set values into JSON-native types.
+
+    Used as ``json.dumps(..., default=_to_jsonable)`` for anything the
+    inline conversion missed.  Raises ``TypeError`` for genuinely
+    unsupported types so silent data loss is impossible.
+    """
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (set, frozenset, tuple)):
+        return list(obj)
+    if isinstance(obj, Path):
+        return str(obj)
+    if is_dataclass(obj):
+        return {f.name: _to_jsonable(getattr(obj, f.name)) for f in fields(obj)}
+    raise TypeError(
+        f"Object of type {type(obj).__name__!r} is not JSON-serialisable"
+    )
+
+
+def _f(value: Any) -> float:
+    """Convert a numeric scalar to a plain Python float."""
+    return float(value)
+
+
+def _array_summary(arr: np.ndarray) -> dict:
+    """Reduce a numeric array to (min, max, mean, p95) summary stats.
+
+    The exporter inlines short 1D arrays in full; long arrays
+    (per-Gauss-point fields) are summarised here so the JSON stays small.
+    """
+    a = np.asarray(arr, dtype=np.float64).ravel()
+    if a.size == 0:
+        return {"min": None, "max": None, "mean": None, "p95": None, "n": 0}
+    return {
+        "min": _f(np.min(a)),
+        "max": _f(np.max(a)),
+        "mean": _f(np.mean(a)),
+        "p95": _f(np.percentile(a, 95)),
+        "n": int(a.size),
+    }
+
+
+def _array_or_summary(arr: Any) -> Any:
+    """Inline short 1D arrays; summarise larger / multi-D arrays."""
+    if arr is None:
+        return None
+    a = np.asarray(arr)
+    if a.ndim == 1 and a.size <= _ARRAY_INLINE_LIMIT:
+        return [_f(x) for x in a]
+    return _array_summary(a)
+
+
+# ----------------------------------------------------------------------
+# Config + results -> dict
+# ----------------------------------------------------------------------
+
+def _config_to_dict(cfg: "AnalysisConfig") -> dict:
+    """Serialise an :class:`AnalysisConfig` to a plain JSON-able dict.
+
+    The material is reduced to its name (full property tables are not
+    needed in a results export — callers who need them already have the
+    material library).
+    """
+    out: dict = {}
+    for f in fields(cfg):
+        value = getattr(cfg, f.name)
+        if f.name == "material":
+            out[f.name] = value.name if value is not None else None
+        elif isinstance(value, np.ndarray):
+            out[f.name] = value.tolist()
+        elif isinstance(value, (list, tuple)):
+            out[f.name] = [
+                _f(v) if isinstance(v, (np.integer, np.floating)) else v
+                for v in value
+            ]
+        elif isinstance(value, (np.integer,)):
+            out[f.name] = int(value)
+        elif isinstance(value, (np.floating,)):
+            out[f.name] = _f(value)
+        else:
+            out[f.name] = value
+    return out
+
+
+def _per_ply_rows(results: "AnalysisResults") -> list[dict]:
+    """Build the per-ply summary table.
+
+    One row per ply with:
+        index, angle_deg, max_FI, min_RF, critical_mode, critical_criterion
+
+    If no failure_report is attached (e.g. ``analytical_only=True``) only
+    ``index`` and ``angle_deg`` are populated — the FI / mode columns are
+    written as ``None`` (JSON ``null``) so the schema is stable.
+    """
+    cfg = results.config
+    angles = list(cfg.angles or [])
+    n_plies = len(angles)
+
+    rows: list[dict] = []
+    rep = results.failure_report
+
+    # Pre-collect per-criterion FI arrays so we can find the worst across
+    # all criteria for each ply.
+    per_ply_fi: dict[str, np.ndarray] = {}
+    if rep is not None and getattr(rep, "ply_failure_indices", None):
+        for crit_name, arr in rep.ply_failure_indices.items():
+            per_ply_fi[crit_name] = np.asarray(arr, dtype=np.float64).ravel()
+
+    for k in range(n_plies):
+        row: dict = {
+            "index": int(k),
+            "angle_deg": _f(angles[k]),
+            "max_FI": None,
+            "min_RF": None,
+            "critical_mode": None,
+            "critical_criterion": None,
+        }
+        if per_ply_fi:
+            # Worst (largest) FI across criteria for this ply.
+            crit_best = None
+            fi_best = -np.inf
+            for crit_name, fi_arr in per_ply_fi.items():
+                if k < fi_arr.size and fi_arr[k] > fi_best:
+                    fi_best = float(fi_arr[k])
+                    crit_best = crit_name
+            if crit_best is not None and np.isfinite(fi_best):
+                row["max_FI"] = fi_best
+                # Reserve factor = 1 / FI for linear criteria; fall back
+                # to None when FI is zero (infinite RF) to keep the CSV
+                # round-trippable through csv.DictReader.
+                row["min_RF"] = (1.0 / fi_best) if fi_best > 0 else None
+                row["critical_criterion"] = crit_best
+                # Mode: pull from the FPF/LPF dict if available; the
+                # LaminateFailureReport stores per-criterion FPF/LPF
+                # which is keyed by criterion, not by ply, so we only
+                # populate the mode when the ply happens to be the FPF
+                # ply for that criterion.
+                fpf = (getattr(rep, "fpf", {}) or {}).get(crit_best, {})
+                if fpf.get("ply") == k:
+                    row["critical_mode"] = fpf.get("mode") or None
+                else:
+                    lpf = (getattr(rep, "lpf", {}) or {}).get(crit_best, {})
+                    if lpf.get("ply") == k:
+                        row["critical_mode"] = lpf.get("mode") or None
+        rows.append(row)
+    return rows
+
+
+def _first_ply_failure(results: "AnalysisResults") -> dict | None:
+    """First-ply failure summary across all criteria (lowest load factor)."""
+    rep = results.failure_report
+    if rep is None or not getattr(rep, "fpf", None):
+        return None
+    crit = rep.critical_criterion or next(iter(rep.fpf))
+    data = rep.fpf.get(crit, {})
+    return {
+        "criterion": crit,
+        "ply_index": int(data.get("ply", rep.critical_ply or 0)),
+        "mode": data.get("mode") or rep.critical_mode or None,
+        "load_factor": (
+            _f(data.get("load_factor"))
+            if data.get("load_factor") is not None
+            else None
+        ),
+    }
+
+
+def _knockdown_factors(results: "AnalysisResults") -> dict:
+    """Bundle the analytical + FE knockdown / retention factors."""
+    out: dict = {
+        "analytical": _f(results.analytical_knockdown),
+    }
+    # FE-derived strength retention factors are keyed by criterion in
+    # results.retention_factors; we surface a single ``fe`` scalar as the
+    # minimum (most conservative) retention across criteria, plus the
+    # per-criterion breakdown for callers who want detail.
+    retention = results.retention_factors or {}
+    if retention:
+        rf_values = [float(v) for v in retention.values() if v is not None]
+        if rf_values:
+            out["fe"] = min(rf_values)
+        out["fe_per_criterion"] = {k: float(v) for k, v in retention.items()}
+    if results.modulus_retention is not None:
+        out["modulus_retention"] = _f(results.modulus_retention)
+    return out
+
+
+def _load_factor(results: "AnalysisResults") -> float:
+    """Top-level "load factor" surfaced in the export.
+
+    For a wrinkled laminate the most useful single number is the FPF
+    load factor from the failure report.  When no FE/failure report is
+    available (analytical_only runs) we fall back to the analytical
+    knockdown so the field is always populated.
+    """
+    rep = results.failure_report
+    if rep is not None and getattr(rep, "fpf", None):
+        crit = rep.critical_criterion or next(iter(rep.fpf))
+        lf = rep.fpf.get(crit, {}).get("load_factor")
+        if lf is not None and np.isfinite(lf):
+            return _f(lf)
+    return _f(results.analytical_knockdown)
+
+
+def _stress_field_summary(results: "AnalysisResults") -> dict | None:
+    """Reduce the (n_elem, n_gauss, 6) stress tensor to summary stats."""
+    fr = results.field_results
+    if fr is None or fr.stress_global is None:
+        return None
+    stress = np.asarray(fr.stress_global, dtype=np.float64)
+    if stress.size == 0:
+        return None
+    component_names = (
+        "stress_11", "stress_22", "stress_33",
+        "stress_23", "stress_13", "stress_12",
+    )
+    out: dict = {}
+    # Voigt index along last axis.
+    flat = stress.reshape(-1, stress.shape[-1])
+    for i, name in enumerate(component_names):
+        out[name] = _array_summary(flat[:, i])
+    return out
+
+
+def results_to_dict(results: "AnalysisResults") -> dict:
+    """Build the JSON-shaped dict for :func:`export_results_json`.
+
+    Exposed so callers (CLI, Streamlit, tests) can introspect the same
+    payload that would be written to disk.
+    """
+    cfg = results.config
+
+    payload: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "config": _config_to_dict(cfg),
+        "load_factor": _load_factor(results),
+        "analytical": {
+            "morphology_factor": _f(results.morphology_factor),
+            "max_angle_rad": _f(results.max_angle_rad),
+            "max_angle_deg": _f(np.degrees(results.max_angle_rad)),
+            "effective_angle_rad": _f(results.effective_angle_rad),
+            "effective_angle_deg": _f(np.degrees(results.effective_angle_rad)),
+            "damage_index": _f(results.damage_index),
+            "analytical_knockdown": _f(results.analytical_knockdown),
+            "analytical_strength_MPa": _f(results.analytical_strength_MPa),
+            "gamma_Y_eff": _f(results.gamma_Y_eff),
+        },
+        "first_ply_failure": _first_ply_failure(results),
+        "per_ply": _per_ply_rows(results),
+        "knockdown_factors": _knockdown_factors(results),
+    }
+
+    # Optional mesh / FE summaries — only included when present so
+    # analytical-only runs produce a compact file.
+    if results.mesh is not None:
+        payload["mesh"] = {
+            "n_nodes": int(results.mesh.n_nodes),
+            "n_elements": int(results.mesh.n_elements),
+            "n_dof": int(results.mesh.n_dof),
+        }
+
+    if results.field_results is not None:
+        max_disp, max_disp_node = results.field_results.max_displacement()
+        payload["fe"] = {
+            "max_displacement_mm": _f(max_disp),
+            "max_displacement_node": int(max_disp_node),
+            "stress_field_summary": _stress_field_summary(results),
+        }
+
+    if results.tension_mechanisms:
+        payload["tension_mechanisms"] = {
+            k: (_f(v) if isinstance(v, (int, float, np.floating)) else v)
+            for k, v in results.tension_mechanisms.items()
+        }
+
+    return payload
+
+
+# ----------------------------------------------------------------------
+# Public file writers
+# ----------------------------------------------------------------------
+
+def export_results_json(
+    results: "AnalysisResults",
+    path: Union[str, Path],
+) -> None:
+    """Write an :class:`AnalysisResults` as a schema-versioned JSON file.
+
+    The output is deterministic (``sort_keys=True``) and uses plain
+    Python ``int`` / ``float`` everywhere so it round-trips cleanly
+    through :func:`json.load`.
+
+    Parameters
+    ----------
+    results : AnalysisResults
+        Output of :meth:`WrinkleAnalysis.run`.
+    path : str or Path
+        Output file path; parent directories are created if needed.
+
+    Notes
+    -----
+    Numpy arrays longer than ``_ARRAY_INLINE_LIMIT`` (or multi-
+    dimensional) are reduced to ``{min, max, mean, p95, n}`` summary
+    stats so a stress field at every Gauss point does not bloat the
+    file.
+
+    See Also
+    --------
+    export_results_csv : Pandas-friendly per-ply tabular export.
+    """
+    payload = results_to_dict(results)
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(
+            payload, sort_keys=True, indent=2, default=_to_jsonable
+        ),
+        encoding="utf-8",
+    )
+
+
+# CSV column order — kept stable so downstream consumers can pin to it.
+_CSV_COLUMNS = (
+    "ply_index",
+    "angle_deg",
+    "max_FI",
+    "min_RF",
+    "critical_mode",
+    "critical_criterion",
+)
+
+
+def export_results_csv(
+    results: "AnalysisResults",
+    path: Union[str, Path],
+) -> None:
+    """Write the per-ply summary table as a Pandas-friendly CSV.
+
+    Columns
+    -------
+    ``ply_index, angle_deg, max_FI, min_RF, critical_mode, critical_criterion``
+
+    The row count equals ``len(results.config.angles)``.  When no
+    failure report is attached (e.g. ``analytical_only=True``) the FI /
+    mode columns are written as empty strings, but the table shape is
+    preserved.
+
+    Parameters
+    ----------
+    results : AnalysisResults
+        Output of :meth:`WrinkleAnalysis.run`.
+    path : str or Path
+        Output file path; parent directories are created if needed.
+
+    See Also
+    --------
+    export_results_json : Structured JSON export with all numeric scalars.
+    """
+    rows = _per_ply_rows(results)
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_CSV_COLUMNS)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({
+                "ply_index": r["index"],
+                "angle_deg": r["angle_deg"],
+                "max_FI": (
+                    f"{r['max_FI']:.10g}" if r["max_FI"] is not None else ""
+                ),
+                "min_RF": (
+                    f"{r['min_RF']:.10g}" if r["min_RF"] is not None else ""
+                ),
+                "critical_mode": r["critical_mode"] or "",
+                "critical_criterion": r["critical_criterion"] or "",
+            })

--- a/tests/test_io/test_export_results.py
+++ b/tests/test_io/test_export_results.py
@@ -1,0 +1,318 @@
+"""Tests for :mod:`wrinklefe.io.results` (CSV / JSON export of results).
+
+Covers the v1.0 structured-export pair added for issue #2:
+
+- :func:`export_results_json` writes a deterministic, schema-versioned
+  JSON file containing the analytical predictions, per-ply table, FPF
+  summary, and knockdown factors.
+- :func:`export_results_csv` writes the per-ply table as a Pandas-
+  friendly CSV.
+
+The tests round-trip both formats through the stdlib (``json.load``,
+``csv.DictReader``) and assert the documented fields are present and
+parse as plain Python types.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import warnings
+
+import numpy as np
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.core.material import MaterialLibrary
+from wrinklefe.io.results import (
+    SCHEMA_VERSION,
+    export_results_csv,
+    export_results_json,
+    results_to_dict,
+)
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def fe_result():
+    """Run a tiny end-to-end FE analysis once for the module.
+
+    Uses a 16-ply layup and a mesh small enough to keep the test fast
+    (~a few seconds) while still producing a real
+    ``LaminateFailureReport`` and FE field, so the per-ply / FE branches
+    of the exporter are exercised.
+    """
+    mat = MaterialLibrary().get("IM7_8552")
+    cfg = AnalysisConfig(
+        amplitude=0.25,
+        wavelength=16.0,
+        width=12.0,
+        morphology="stack",
+        loading="compression",
+        material=mat,
+        angles=[0, 45, -45, 90, 0, 45, -45, 0,
+                0, -45, 45, 0, 90, -45, 45, 0],
+        ply_thickness=0.183,
+        nx=4, ny=3, nz_per_ply=1,
+        domain_length=20.0,
+        domain_width=8.0,
+        applied_strain=-0.005,
+        analytical_only=False,
+        verbose=False,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return WrinkleAnalysis(cfg).run()
+
+
+@pytest.fixture(scope="module")
+def analytical_result():
+    """A pure analytical run (no mesh, no FE) for the schema-stability
+    tests that must work even when ``failure_report is None``."""
+    cfg = AnalysisConfig(
+        amplitude=0.3,
+        wavelength=15.0,
+        width=10.0,
+        morphology="stack",
+        loading="compression",
+        angles=[0, 45, -45, 90, 90, -45, 45, 0],
+        analytical_only=True,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return WrinkleAnalysis(cfg).run(analytical_only=True)
+
+
+# ----------------------------------------------------------------------
+# JSON tests
+# ----------------------------------------------------------------------
+
+class TestExportResultsJSON:
+    """Round-trip + schema tests for export_results_json."""
+
+    def test_writes_valid_json(self, fe_result, tmp_path):
+        """The file is parseable by json.load."""
+        out = tmp_path / "results.json"
+        export_results_json(fe_result, out)
+        data = json.loads(out.read_text())
+        assert isinstance(data, dict)
+
+    def test_has_documented_top_level_fields(self, fe_result, tmp_path):
+        """Every field documented in the issue schema is present."""
+        out = tmp_path / "results.json"
+        export_results_json(fe_result, out)
+        data = json.loads(out.read_text())
+        for key in (
+            "schema_version",
+            "config",
+            "load_factor",
+            "first_ply_failure",
+            "per_ply",
+            "knockdown_factors",
+        ):
+            assert key in data, f"missing documented field: {key}"
+
+    def test_schema_version_is_set(self, fe_result, tmp_path):
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        assert json.loads(out.read_text())["schema_version"] == SCHEMA_VERSION
+
+    def test_per_ply_row_shape(self, fe_result, tmp_path):
+        """One row per ply, with the documented columns."""
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        data = json.loads(out.read_text())
+        per_ply = data["per_ply"]
+        assert isinstance(per_ply, list)
+        assert len(per_ply) == len(fe_result.config.angles)
+        for row in per_ply:
+            for col in ("index", "angle_deg", "max_FI", "min_RF",
+                        "critical_mode", "critical_criterion"):
+                assert col in row
+
+    def test_per_ply_indices_are_dense_and_sorted(self, fe_result, tmp_path):
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        per_ply = json.loads(out.read_text())["per_ply"]
+        assert [row["index"] for row in per_ply] == list(range(len(per_ply)))
+
+    def test_first_ply_failure_payload(self, fe_result, tmp_path):
+        """FPF block matches the documented shape when FE is present."""
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        fpf = json.loads(out.read_text())["first_ply_failure"]
+        assert fpf is not None
+        for key in ("ply_index", "criterion", "mode", "load_factor"):
+            assert key in fpf
+        assert isinstance(fpf["ply_index"], int)
+        assert isinstance(fpf["criterion"], str)
+
+    def test_knockdown_factors_block(self, fe_result, tmp_path):
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        kd = json.loads(out.read_text())["knockdown_factors"]
+        assert "analytical" in kd
+        assert 0.0 < kd["analytical"] <= 1.0
+        # FE branch is populated whenever there are retention factors.
+        if fe_result.retention_factors:
+            assert "fe" in kd
+
+    def test_load_factor_is_finite_float(self, fe_result, tmp_path):
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        lf = json.loads(out.read_text())["load_factor"]
+        assert isinstance(lf, float)
+        assert np.isfinite(lf)
+
+    def test_no_numpy_scalars_in_json(self, fe_result, tmp_path):
+        """Round-trip cleanly through json.load: all leaves are plain
+        Python types (int/float/str/bool/None/list/dict)."""
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        data = json.loads(out.read_text())
+
+        allowed = (bool, int, float, str, type(None))
+
+        def _walk(node):
+            if isinstance(node, dict):
+                for v in node.values():
+                    _walk(v)
+            elif isinstance(node, list):
+                for v in node:
+                    _walk(v)
+            else:
+                assert isinstance(node, allowed), (
+                    f"non-JSON-native leaf: {type(node).__name__}: {node!r}"
+                )
+
+        _walk(data)
+
+    def test_output_is_deterministic(self, fe_result, tmp_path):
+        """Same input -> byte-identical output (sort_keys=True)."""
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        export_results_json(fe_result, a)
+        export_results_json(fe_result, b)
+        assert a.read_bytes() == b.read_bytes()
+
+    def test_stress_field_summarised_not_inlined(self, fe_result, tmp_path):
+        """Per-Gauss-point stress arrays are reduced to summary stats so
+        the JSON stays small."""
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        data = json.loads(out.read_text())
+        fe_block = data.get("fe")
+        assert fe_block is not None
+        ss = fe_block["stress_field_summary"]
+        for comp in ("stress_11", "stress_22", "stress_33",
+                     "stress_23", "stress_13", "stress_12"):
+            assert comp in ss
+            for stat in ("min", "max", "mean", "p95", "n"):
+                assert stat in ss[comp]
+
+    def test_analytical_only_run_has_stable_schema(
+        self, analytical_result, tmp_path
+    ):
+        """A pure analytical run still produces all top-level fields,
+        with FE/mesh sections omitted and FPF as null."""
+        out = tmp_path / "r.json"
+        export_results_json(analytical_result, out)
+        data = json.loads(out.read_text())
+        assert data["schema_version"] == SCHEMA_VERSION
+        assert data["first_ply_failure"] is None
+        assert "fe" not in data
+        assert "mesh" not in data
+        # per_ply rows are still there, FI columns are null
+        assert len(data["per_ply"]) == len(analytical_result.config.angles)
+        assert data["per_ply"][0]["max_FI"] is None
+
+    def test_creates_parent_dirs(self, fe_result, tmp_path):
+        out = tmp_path / "sub" / "deep" / "results.json"
+        export_results_json(fe_result, out)
+        assert out.exists()
+
+    def test_results_to_dict_matches_file(self, fe_result, tmp_path):
+        """results_to_dict() is the same payload as the file content."""
+        out = tmp_path / "r.json"
+        export_results_json(fe_result, out)
+        from_file = json.loads(out.read_text())
+        in_memory = json.loads(json.dumps(
+            results_to_dict(fe_result),
+            sort_keys=True,
+            default=lambda o: float(o) if hasattr(o, "__float__") else str(o),
+        ))
+        assert from_file == in_memory
+
+
+# ----------------------------------------------------------------------
+# CSV tests
+# ----------------------------------------------------------------------
+
+class TestExportResultsCSV:
+    """Round-trip + schema tests for export_results_csv."""
+
+    def test_writes_file(self, fe_result, tmp_path):
+        out = tmp_path / "per_ply.csv"
+        export_results_csv(fe_result, out)
+        assert out.exists()
+
+    def test_row_count_matches_ply_count(self, fe_result, tmp_path):
+        out = tmp_path / "per_ply.csv"
+        export_results_csv(fe_result, out)
+        with open(out, newline="") as fh:
+            rows = list(csv.DictReader(fh))
+        assert len(rows) == len(fe_result.config.angles)
+
+    def test_columns_match_schema(self, fe_result, tmp_path):
+        out = tmp_path / "per_ply.csv"
+        export_results_csv(fe_result, out)
+        with open(out, newline="") as fh:
+            reader = csv.DictReader(fh)
+            assert reader.fieldnames == [
+                "ply_index",
+                "angle_deg",
+                "max_FI",
+                "min_RF",
+                "critical_mode",
+                "critical_criterion",
+            ]
+
+    def test_dictreader_parses_cleanly(self, fe_result, tmp_path):
+        """csv.DictReader returns one dict per ply with the right keys."""
+        out = tmp_path / "per_ply.csv"
+        export_results_csv(fe_result, out)
+        with open(out, newline="") as fh:
+            rows = list(csv.DictReader(fh))
+        for i, row in enumerate(rows):
+            assert int(row["ply_index"]) == i
+            # Angle column is always populated.
+            assert row["angle_deg"] != ""
+            float(row["angle_deg"])
+
+    def test_angle_values_match_config(self, fe_result, tmp_path):
+        out = tmp_path / "per_ply.csv"
+        export_results_csv(fe_result, out)
+        with open(out, newline="") as fh:
+            rows = list(csv.DictReader(fh))
+        for i, ang in enumerate(fe_result.config.angles):
+            assert float(rows[i]["angle_deg"]) == pytest.approx(ang)
+
+    def test_csv_for_analytical_only_run(self, analytical_result, tmp_path):
+        """CSV is still well-formed when no failure_report is attached."""
+        out = tmp_path / "per_ply.csv"
+        export_results_csv(analytical_result, out)
+        with open(out, newline="") as fh:
+            rows = list(csv.DictReader(fh))
+        assert len(rows) == len(analytical_result.config.angles)
+        # FI / mode columns are blank (the schema is stable).
+        for row in rows:
+            assert row["max_FI"] == ""
+            assert row["critical_mode"] == ""
+
+    def test_creates_parent_dirs(self, fe_result, tmp_path):
+        out = tmp_path / "sub" / "deep" / "per_ply.csv"
+        export_results_csv(fe_result, out)
+        assert out.exists()


### PR DESCRIPTION
## Summary
New `wrinklefe.io.results` module exposes structured CSV / JSON export for `AnalysisResults`. The legacy `wrinklefe.io.export` is preserved untouched, so existing CLI and tests continue to work.

### Public API
```python
from wrinklefe.io.results import (
    export_results_json,   # deterministic, schema-versioned JSON (v1.0)
    export_results_csv,    # per-ply table (Pandas-friendly)
    results_to_dict,       # in-memory payload
    SCHEMA_VERSION,        # "1.0"
)
```

### JSON schema (v1.0)
- `schema_version` (str)
- `config` (full `AnalysisConfig` as dict; material as name only)
- `load_factor` (FPF load factor when available, else analytical knockdown)
- `analytical` block: `morphology_factor`, `max_angle_rad/deg`, `effective_angle_rad/deg`, `damage_index`, `analytical_knockdown`, `analytical_strength_MPa`, `gamma_Y_eff`
- `first_ply_failure`: `ply_index`, `criterion`, `mode`, `load_factor`
- `per_ply`: list of rows with `index`, `angle_deg`, `max_FI`, `min_RF`, `critical_mode`, `critical_criterion`
- `knockdown_factors`: `analytical`, `fe`, `fe_per_criterion`, `modulus_retention`
- `mesh` (optional): `n_nodes`, `n_elements`, `n_dof`
- `fe` (optional): `max_displacement_mm`, `max_displacement_node`, `stress_field_summary` (per-Voigt-component `{min,max,mean,p95,n}`)
- `tension_mechanisms` (optional)

### CSV
Per-ply table, columns: `ply_index, angle_deg, max_FI, min_RF, critical_mode, critical_criterion`.

### Streamlit
Added a "Download per-ply results as CSV" button on the Export tab.

### Determinism
- `json.dumps(..., sort_keys=True, indent=2, default=_to_jsonable)`
- All numeric leaves are plain Python `int`/`float`/`str`/`bool`/`None` (verified by `test_no_numpy_scalars_in_json` deep-walk)
- Long / multi-dim arrays summarised to `{min, max, mean, p95, n}` instead of inlined

Fixes #2

## Test plan
- **21 new tests** in `tests/test_io/test_export_results.py` (round-trip, byte-determinism, no numpy scalars, analytical-only edge case)
- `pytest tests/test_io/` &mdash; 67 passed (no regressions)
- `pytest tests/test_streamlit_viz.py` &mdash; 21 passed
- Full unit suite (excl. integration) &mdash; 1027 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_