### PR TITLE
test(material): pin built-in library roster + headline allowables (closes #88)

### DIFF
--- a/tests/test_material_library_completeness.py
+++ b/tests/test_material_library_completeness.py
@@ -1,0 +1,107 @@
+"""Regression tests pinning the built-in MaterialLibrary roster (refs #88).
+
+Issue #88 requested the addition of common aerospace prepregs (M21, T800/M21,
+IM10, S-2 glass, Kevlar) to the built-in material library. By the time this
+test was authored, all five had already been added (T800S_M21, IM10_8552,
+S2_GLASS_EPOXY, KEVLAR49_EPOXY — M21 is covered by T800S_M21). See
+``src/wrinklefe/core/material.py::MaterialLibrary._load_builtins`` for the
+data sources.
+
+The tests here pin:
+
+* the exact set of 9 built-in names (so a silent deletion regresses);
+* a handful of headline allowables for each #88 material (so a silent edit
+  that zeros out or wildly perturbs a property also regresses).
+
+Tolerances are loose (±5%) because the precise values are sourced from
+public datasheets and may be re-tuned within that band as references are
+refreshed; what we want to catch is *placeholder* / *zero* / *wrong-order-
+of-magnitude* regressions, not legitimate datasheet updates.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wrinklefe.core.material import MaterialLibrary
+
+
+# Frozen built-in roster as of issue #88 closure. Update only if the
+# library intentionally adds or removes a material.
+EXPECTED_BUILTIN_NAMES = frozenset({
+    "AC318_S6C10",
+    "AS4_3501_6",
+    "IM10_8552",
+    "IM7_8552",
+    "KEVLAR49_EPOXY",
+    "S2_GLASS_EPOXY",
+    "T300_914",
+    "T700_2510",
+    "T800S_M21",
+})
+
+
+# Headline allowables for the four #88 prepregs. Values mirror the
+# datasheet-cited numbers in MaterialLibrary._load_builtins; a 5% tolerance
+# permits legitimate datasheet refreshes while still catching zero /
+# wrong-order regressions.
+#
+# Schema: name -> dict(attr -> expected MPa value)
+ISSUE_88_HEADLINE_ALLOWABLES = {
+    "T800S_M21": {
+        "E1": 157_000.0, "E2": 8_500.0, "G12": 4_200.0,
+        "Xt": 2_950.0, "Xc": 1_680.0,
+        "Yt": 70.0, "Yc": 290.0, "S12": 98.0,
+    },
+    "IM10_8552": {
+        "E1": 185_000.0, "E2": 9_400.0, "G12": 5_500.0,
+        "Xt": 3_310.0, "Xc": 1_690.0,
+        "Yt": 63.0, "Yc": 240.0, "S12": 95.0,
+    },
+    "S2_GLASS_EPOXY": {
+        "E1": 52_000.0, "E2": 19_000.0, "G12": 6_700.0,
+        "Xt": 1_700.0, "Xc": 970.0,
+        "Yt": 49.0, "Yc": 158.0, "S12": 83.0,
+    },
+    "KEVLAR49_EPOXY": {
+        "E1": 76_000.0, "E2": 5_500.0, "G12": 2_300.0,
+        "Xt": 1_400.0, "Xc": 235.0,
+        "Yt": 12.0, "Yc": 53.0, "S12": 34.0,
+    },
+}
+
+
+REL_TOL = 0.05  # 5% — permits datasheet refresh, catches zero/order-of-mag drift
+
+
+def test_builtin_count_pinned():
+    """The library ships exactly 9 built-in materials (issue #88 roster)."""
+    lib = MaterialLibrary()
+    assert len(lib) == len(EXPECTED_BUILTIN_NAMES), (
+        f"Built-in count drifted: got {len(lib)} "
+        f"({sorted(lib.list_names())}), expected "
+        f"{len(EXPECTED_BUILTIN_NAMES)} ({sorted(EXPECTED_BUILTIN_NAMES)})."
+    )
+
+
+def test_builtin_names_pinned():
+    """Exact set of built-in names is frozen — guards against silent drops."""
+    lib = MaterialLibrary()
+    assert set(lib.list_names()) == EXPECTED_BUILTIN_NAMES
+
+
+@pytest.mark.parametrize("name", sorted(ISSUE_88_HEADLINE_ALLOWABLES))
+def test_issue_88_material_allowables(name):
+    """Headline elastic and strength allowables match cited datasheet values.
+
+    Loose 5% tolerance — flags zeroed-out placeholders or order-of-magnitude
+    typos without forbidding legitimate datasheet refreshes.
+    """
+    lib = MaterialLibrary()
+    mat = lib.get(name)
+    expected = ISSUE_88_HEADLINE_ALLOWABLES[name]
+    for attr, want in expected.items():
+        got = getattr(mat, attr)
+        assert got == pytest.approx(want, rel=REL_TOL), (
+            f"{name}.{attr}: got {got}, expected {want} (±{REL_TOL:.0%})"
+        )


### PR DESCRIPTION
## Summary
**Issue #88 is already resolved.** Per the #204 (PR #219) verification, `MaterialLibrary().list_names()` already returns 9 materials including all 5 from the #88 wishlist:

| Wishlist | Library name | E1 (MPa) | Xt (MPa) | Source cited inline |
|---|---|---|---|---|
| M21 / T800/M21 | `T800S_M21` | 157,000 | 2,950 | Hexcel HexPly M21 + Catalanotti 2013 |
| IM10 | `IM10_8552` | 185,000 | 3,310 | Hexcel IM10/8552 datasheet + Lopes 2007 |
| S-2 glass | `S2_GLASS_EPOXY` | 52,000 | 1,700 | MIL-HDBK-17 + Daniel & Ishai 2006 |
| Kevlar | `KEVLAR49_EPOXY` | 76,000 | 1,400 | Daniel & Ishai 2006 + Kaw 2005 |

All have non-zero, physically sensible elastic constants, strength allowables (Xt/Xc/Yt/Yc/S12/S23), hygrothermal coefficients, and pass the existing compliance-PD validation. README line 22 already documents all 9.

## What's in this PR
`tests/test_material_library_completeness.py` (tests-only, +107 lines) with three pinning tests:

- `test_builtin_count_pinned` &mdash; exact length == 9
- `test_builtin_names_pinned` &mdash; exact frozen set of names
- `test_issue_88_material_allowables` (parametrised over 4 materials) &mdash; pins 8 headline values (E1, E2, G12, Xt, Xc, Yt, Yc, S12) at &plusmn;5% tolerance

This complements existing `TestNewBuiltinMaterials` (positivity-only) by catching silent value drift, not just deletions.

Fixes #88 (recommend closing as already-resolved + regression-pinned)

## Test plan
- `pytest tests/ -k "material or library" -x` &mdash; **60 passed** (54 pre-existing + 6 new), 0 failed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtmLs7DVuFPKbD2fbaoVoN)_