### PR TITLE
Replace LaTeX math notation with Unicode characters in plot title

### DIFF
--- a/app.py
+++ b/app.py
@@ -1160,7 +1160,7 @@ with tab_configure:
     ax_z.plot(x, z, color=MORPHOLOGY_COLORS["stack"], linewidth=1.5)
     ax_z.axhline(0.0, color="grey", linewidth=0.5)
     ax_z.set_ylabel("z(x) [mm]")
-    ax_z.set_title(r"$z(x) = A \cdot \exp(-x^2 / w^2) \cdot \cos(2\pi x / \lambda)$")
+    ax_z.set_title("z(x) = A · exp(−x²/w²) · cos(2π x/λ)")
     ax_z.grid(alpha=0.3)
 
     ax_theta.plot(x, theta_deg, color=MORPHOLOGY_COLORS["concave"], linewidth=1.2)


### PR DESCRIPTION
## Summary
Updated the z(x) plot title to use Unicode mathematical symbols instead of LaTeX notation for improved readability and compatibility.

## Changes
- Replaced LaTeX math mode syntax with Unicode equivalents in the z(x) morphology plot title:
  - `$z(x) = A \cdot \exp(-x^2 / w^2) \cdot \cos(2\pi x / \lambda)$` → `z(x) = A · exp(−x²/w²) · cos(2π x/λ)`
  - `\cdot` → `·` (middle dot)
  - `\exp` → `exp` (plain text)
  - `^2` → `²` (superscript 2)
  - `-` → `−` (minus sign)
  - `\cos` → `cos` (plain text)
  - `\pi` → `π` (Greek letter pi)

## Details
This change improves the plot title display by using Unicode mathematical symbols that render consistently across different environments without requiring LaTeX rendering support. The mathematical meaning remains identical while enhancing visual clarity.

https://claude.ai/code/session_01UoxkzbB9ZHo8pCdgwiZGu1