### PR TITLE
mesh: pre-run feasibility warning + actionable inversion errors (fix #244)

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ if _SRC.is_dir() and str(_SRC) not in sys.path:
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
+from wrinklefe.core.mesh import mesh_shear_diagnostics
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 from wrinklefe.io.export import (
     build_analysis_summary,
@@ -752,6 +753,43 @@ with st.sidebar:
                     "ply. Increase to capture interlaminar stress gradients."
                 ),
             )
+            # Pre-run feasibility check: the wrinkle's in-plane slope
+            # shears stacked hex8 elements in z; if the shear exceeds
+            # the z-layer height the FE mesh inverts and the solve
+            # aborts after 5–30 s of setup. Surface a warning here so
+            # the user can adjust before clicking Run analysis. See
+            # issue #244 and core/mesh.mesh_shear_diagnostics.
+            mesh_diag = (
+                mesh_shear_diagnostics(
+                    amplitude=float(amplitude),
+                    wavelength=float(wavelength),
+                    ply_thickness=float(ply_thickness),
+                    nx=int(nx),
+                    nz_per_ply=int(nz_per_ply),
+                    Lx=3.0 * float(wavelength),
+                )
+                if not analytical_only
+                else None
+            )
+            if mesh_diag is not None:
+                if mesh_diag.will_invert:
+                    st.error(
+                        f"⚠ FE mesh will invert at this nz_per_ply for the "
+                        f"current amplitude (nz·A/ply_t ≈ "
+                        f"{mesh_diag.decay_ratio:.1f}, must be < 5). "
+                        f"Reduce to **nz_per_ply ≤ "
+                        f"{mesh_diag.nz_per_ply_safe}** or set **amplitude ≤ "
+                        f"{mesh_diag.amplitude_safe:.3g} mm** before running."
+                    )
+                elif not mesh_diag.is_safe:
+                    st.warning(
+                        f"Through-thickness decay ratio is high "
+                        f"(nz·A/ply_t ≈ {mesh_diag.decay_ratio:.2f}; "
+                        f"target < 2.5). Solve usually still succeeds, but "
+                        f"nz_per_ply ≤ {mesh_diag.nz_per_ply_safe} or "
+                        f"amplitude ≤ {mesh_diag.amplitude_safe:.3g} mm "
+                        f"adds margin."
+                    )
             if analytical_only:
                 st.caption(
                     "Mesh inputs are inactive — the closed-form analytical "
@@ -770,12 +808,24 @@ with st.sidebar:
         nx = DEFAULT_NX
         ny = DEFAULT_NY
         nz_per_ply = DEFAULT_NZ_PER_PLY
+        mesh_diag = None
         st.caption(
             "Quick analytical estimate. Switch on **Expert mode** above "
             "for the full FE solve, stress fields, and per-ply failure indices."
         )
 
-    run_clicked = st.button("Run analysis", type="primary", width="stretch")
+    run_disabled = bool(mesh_diag is not None and mesh_diag.will_invert)
+    run_clicked = st.button(
+        "Run analysis",
+        type="primary",
+        width="stretch",
+        disabled=run_disabled,
+        help=(
+            "Fix the mesh-inversion warning above before running."
+            if run_disabled
+            else None
+        ),
+    )
 
     st.divider()
     reset_clicked = st.button(

--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -27,6 +27,7 @@ Elhajjar, R. (2025). Scientific Reports 15, 25977.
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -620,12 +621,88 @@ class WrinkleMesh:
             laminate=self.laminate,
         )
 
-        # Run basic quality checks
-        mesh_warnings = mesh_data.validate()
+        # Run basic quality checks.  When the wrinkle field would shear
+        # hex8 elements into themselves (det(J) <= 0 at the centroid),
+        # ``validate()`` raises ``MeshValidationError``.  The raw message
+        # tells the user *what* went wrong but not *which knob to turn* —
+        # so for the wrinkle-driven path we re-raise with the actual
+        # geometry parameters and a small remediation table.  Issue #244.
+        try:
+            mesh_warnings = mesh_data.validate()
+        except MeshValidationError as err:
+            raise self._augment_inversion_error(err) from err
         for w in mesh_warnings:
             logger.warning(w)
 
         return mesh_data
+
+    def _augment_inversion_error(
+        self, err: "MeshValidationError"
+    ) -> "MeshValidationError":
+        """Attach wrinkle parameters and tuning suggestions to an inversion error.
+
+        Heuristic: each hex8 element shears in z by roughly
+        ``(2π A / λ) * (Lx / nx)`` near the wrinkle peak, while its
+        through-thickness extent is ``ply_thickness / nz_per_ply``.
+        When the shear approaches or exceeds the layer height the
+        Jacobian at the centroid flips sign and ``validate()`` rejects
+        the mesh.  The suggestions below propose values that bring the
+        ratio under ~0.7 by adjusting one knob at a time.
+        """
+        if self.wrinkle_config is None or not getattr(
+            self.wrinkle_config, "wrinkles", ()
+        ):
+            return err  # Flat mesh — nothing wrinkle-specific to add.
+
+        w0 = self.wrinkle_config.wrinkles[0]
+        profile = w0.profile
+        inner = getattr(profile, "profile", profile)  # unwrap WrinkleSurface3D
+        amplitude = float(getattr(inner, "amplitude", 0.0))
+        wavelength = float(getattr(inner, "wavelength", 0.0))
+        if amplitude <= 0.0 or wavelength <= 0.0:
+            return err
+
+        ply_thickness = float(self.laminate.plies[0].thickness)
+        Lx = float(self.Lx)
+        nx = int(self.nx)
+        nz_per_ply = int(self.nz_per_ply)
+
+        slope = 2.0 * math.pi * amplitude / wavelength
+        in_plane_edge = Lx / max(nx, 1)
+        z_layer = ply_thickness / max(nz_per_ply, 1)
+        shear_ratio = slope * in_plane_edge / z_layer if z_layer > 0 else float("inf")
+
+        # Solve shear_ratio < 0.7 for each knob in turn, holding the others fixed.
+        target = 0.7
+        nz_safe = max(
+            1,
+            int(math.floor(target * ply_thickness * nx / (slope * Lx))),
+        )
+        amp_safe = target * ply_thickness * nx / (2.0 * math.pi * nz_per_ply * Lx) * wavelength
+        lam_safe = 2.0 * math.pi * amplitude * Lx * nz_per_ply / (target * ply_thickness * nx)
+        nx_safe = int(math.ceil(slope * Lx * nz_per_ply / (target * ply_thickness)))
+
+        suggestions = (
+            f"  • nz_per_ply ≤ {nz_safe} (currently {nz_per_ply})\n"
+            f"  • amplitude ≤ {amp_safe:.3g} mm (currently {amplitude:.3g} mm)\n"
+            f"  • wavelength ≥ {lam_safe:.3g} mm (currently {wavelength:.3g} mm)\n"
+            f"  • nx ≥ {nx_safe} (currently {nx})"
+        )
+
+        new_msg = (
+            f"{err}\n"
+            f"Applied wrinkle: A={amplitude:.3g} mm, λ={wavelength:.3g} mm; "
+            f"mesh: nx={nx}, nz_per_ply={nz_per_ply}, "
+            f"ply_thickness={ply_thickness:.3g} mm, Lx={Lx:.3g} mm. "
+            f"Shear ratio ≈ {shear_ratio:.2f} (target < 0.7). "
+            f"Adjust any one of:\n{suggestions}"
+        )
+        new_err = MeshValidationError(new_msg)
+        # Preserve diagnostic attributes set by validate().
+        for attr in ("inverted_element_indices", "detJ"):
+            if hasattr(err, attr):
+                setattr(new_err, attr, getattr(err, attr))
+        return new_err
 
     # =======================================================================
     # Grid and connectivity helpers

--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -56,6 +56,111 @@ class MeshValidationError(ValueError):
     """
 
 
+# Through-thickness wrinkle-decay ratio (``nz_per_ply * amplitude /
+# ply_thickness``) that the inversion heuristic flags as borderline /
+# certain-fail.  Calibrated empirically against ``MeshData.validate()``
+# over an (nx, nz_per_ply) sweep at A=0.37 mm / λ=16 mm / ply_t=0.183
+# mm: nz=1,2 always pass (ratio ≤ 4.0); nz=4 always inverts (ratio ≥
+# 8.1), regardless of nx ∈ [12, 60].  Used by both the Streamlit
+# sidebar pre-run warning and the post-failure error augmentation.
+MESH_DECAY_WARN_RATIO: float = 2.5
+MESH_DECAY_INVERT_RATIO: float = 5.0
+
+
+@dataclass(frozen=True)
+class MeshShearDiagnostics:
+    """Mesh-feasibility diagnostic for a hex8 mesh under a sinusoidal wrinkle.
+
+    See :func:`mesh_shear_diagnostics` for the heuristic.
+    """
+
+    decay_ratio: float
+    amplitude: float
+    wavelength: float
+    ply_thickness: float
+    nx: int
+    nz_per_ply: int
+    Lx: float
+    nz_per_ply_safe: int
+    amplitude_safe: float
+
+    @property
+    def is_safe(self) -> bool:
+        return self.decay_ratio < MESH_DECAY_WARN_RATIO
+
+    @property
+    def will_invert(self) -> bool:
+        """Likely to produce inverted elements (det(J) <= 0) on validate()."""
+        return self.decay_ratio >= MESH_DECAY_INVERT_RATIO
+
+    def message(self) -> str:
+        """Human-readable summary with one-knob-at-a-time remediation suggestions."""
+        suggestions = (
+            f"  • nz_per_ply ≤ {self.nz_per_ply_safe} (currently {self.nz_per_ply})\n"
+            f"  • amplitude ≤ {self.amplitude_safe:.3g} mm "
+            f"(currently {self.amplitude:.3g} mm)"
+        )
+        return (
+            f"Applied wrinkle: A={self.amplitude:.3g} mm, "
+            f"λ={self.wavelength:.3g} mm; mesh: nx={self.nx}, "
+            f"nz_per_ply={self.nz_per_ply}, "
+            f"ply_thickness={self.ply_thickness:.3g} mm, Lx={self.Lx:.3g} mm. "
+            f"Through-thickness decay ratio (nz·A/ply_t) ≈ "
+            f"{self.decay_ratio:.2f} (target < {MESH_DECAY_WARN_RATIO}). "
+            f"Adjust either:\n{suggestions}"
+        )
+
+
+def mesh_shear_diagnostics(
+    *,
+    amplitude: float,
+    wavelength: float,
+    ply_thickness: float,
+    nx: int,
+    nz_per_ply: int,
+    Lx: float,
+) -> MeshShearDiagnostics:
+    """Decay-ratio diagnostic plus safe single-knob targets.
+
+    The dominant inversion driver for sinusoidal wrinkles is the
+    through-thickness decay gradient relative to the per-layer extent.
+    Empirically the dimensionless group ``nz_per_ply * amplitude /
+    ply_thickness`` predicts the validate() inversion outcome with
+    100 % accuracy on the calibration sweep (see
+    :data:`MESH_DECAY_INVERT_RATIO`); ``nx``, ``wavelength``, and
+    ``Lx`` recorded for the diagnostic message but they don't change
+    the predicate.
+
+    The returned dataclass carries the largest single-knob values
+    (``nz_per_ply`` and ``amplitude``) that bring the ratio under
+    :data:`MESH_DECAY_WARN_RATIO`.
+    """
+    nx_i = max(int(nx), 1)
+    nz_i = max(int(nz_per_ply), 1)
+    if ply_thickness > 0 and amplitude > 0:
+        decay_ratio = nz_i * amplitude / ply_thickness
+        nz_safe = max(
+            1, int(math.floor(MESH_DECAY_WARN_RATIO * ply_thickness / amplitude))
+        )
+        amp_safe = MESH_DECAY_WARN_RATIO * ply_thickness / nz_i
+    else:
+        decay_ratio = 0.0
+        nz_safe = nz_i
+        amp_safe = amplitude
+
+    return MeshShearDiagnostics(
+        decay_ratio=float(decay_ratio),
+        amplitude=float(amplitude),
+        wavelength=float(wavelength),
+        ply_thickness=float(ply_thickness),
+        nx=nx_i,
+        nz_per_ply=nz_i,
+        Lx=float(Lx),
+        nz_per_ply_safe=int(nz_safe),
+        amplitude_safe=float(amp_safe),
+    )
+
+
 # ---------------------------------------------------------------------------
 # MeshData — immutable container for a generated mesh
 # ---------------------------------------------------------------------------
@@ -641,13 +746,8 @@ class WrinkleMesh:
     ) -> "MeshValidationError":
         """Attach wrinkle parameters and tuning suggestions to an inversion error.
 
-        Heuristic: each hex8 element shears in z by roughly
-        ``(2π A / λ) * (Lx / nx)`` near the wrinkle peak, while its
-        through-thickness extent is ``ply_thickness / nz_per_ply``.
-        When the shear approaches or exceeds the layer height the
-        Jacobian at the centroid flips sign and ``validate()`` rejects
-        the mesh.  The suggestions below propose values that bring the
-        ratio under ~0.7 by adjusting one knob at a time.
+        Delegates to :func:`mesh_shear_diagnostics` so the post-failure
+        message and any proactive pre-run UI warnings stay in sync.
         """
         if self.wrinkle_config is None or not getattr(
             self.wrinkle_config, "wrinkles", ()
@@ -662,43 +762,17 @@ class WrinkleMesh:
         if amplitude <= 0.0 or wavelength <= 0.0:
             return err
 
-        ply_thickness = float(self.laminate.plies[0].thickness)
-        Lx = float(self.Lx)
-        nx = int(self.nx)
-        nz_per_ply = int(self.nz_per_ply)
-
-        slope = 2.0 * math.pi * amplitude / wavelength
-        in_plane_edge = Lx / max(nx, 1)
-        z_layer = ply_thickness / max(nz_per_ply, 1)
-        shear_ratio = slope * in_plane_edge / z_layer if z_layer > 0 else float("inf")
-
-        # Solve shear_ratio < 0.7 for each knob in turn, holding the others fixed.
-        target = 0.7
-        nz_safe = max(
-            1,
-            int(math.floor(target * ply_thickness * nx / (slope * Lx))),
-        )
-        amp_safe = target * ply_thickness * nx / (2.0 * math.pi * nz_per_ply * Lx) * wavelength
-        lam_safe = 2.0 * math.pi * amplitude * Lx * nz_per_ply / (target * ply_thickness * nx)
-        nx_safe = int(math.ceil(slope * Lx * nz_per_ply / (target * ply_thickness)))
-
-        suggestions = (
-            f"  • nz_per_ply ≤ {nz_safe} (currently {nz_per_ply})\n"
-            f"  • amplitude ≤ {amp_safe:.3g} mm (currently {amplitude:.3g} mm)\n"
-            f"  • wavelength ≥ {lam_safe:.3g} mm (currently {wavelength:.3g} mm)\n"
-            f"  • nx ≥ {nx_safe} (currently {nx})"
+        diag = mesh_shear_diagnostics(
+            amplitude=amplitude,
+            wavelength=wavelength,
+            ply_thickness=float(self.laminate.plies[0].thickness),
+            nx=int(self.nx),
+            nz_per_ply=int(self.nz_per_ply),
+            Lx=float(self.Lx),
         )
 
-        new_msg = (
-            f"{err}\n"
-            f"Applied wrinkle: A={amplitude:.3g} mm, λ={wavelength:.3g} mm; "
-            f"mesh: nx={nx}, nz_per_ply={nz_per_ply}, "
-            f"ply_thickness={ply_thickness:.3g} mm, Lx={Lx:.3g} mm. "
-            f"Shear ratio ≈ {shear_ratio:.2f} (target < 0.7). "
-            f"Adjust any one of:\n{suggestions}"
-        )
+        new_msg = f"{err}\n{diag.message()}"
         new_err = MeshValidationError(new_msg)
-        # Preserve diagnostic attributes set by validate().
         for attr in ("inverted_element_indices", "detJ"):
             if hasattr(err, attr):
                 setattr(new_err, attr, getattr(err, attr))


### PR DESCRIPTION
## Summary

Two related improvements to the FE mesh feasibility UX (fixes #244):

1. **Pre-run warning + Run-button block in the Streamlit sidebar.** Adds a feasibility check in the *Advanced — mesh & solver* expander, directly under the `Mesh divisions per ply (z)` input. Borderline configurations get a yellow `st.warning`; configurations that will invert the FE mesh get a red `st.error` AND the **Run analysis** button is disabled, so the user can't sink 30–90 s into a doomed solve.

2. **Augmented `MeshValidationError`.** When a mesh does fail the centroid-Jacobian check, `WrinkleMesh.generate()` now re-raises with the actual wrinkle parameters and concrete single-knob remediation suggestions (max `nz_per_ply`, max amplitude). Preserves `inverted_element_indices` and `detJ` attributes on the new exception.

Both surfaces share one helper — `mesh_shear_diagnostics()` in `core/mesh.py` — so the sidebar warning and the post-failure error report identical numbers.

## Calibration

Swept `(nx, nz_per_ply) ∈ {12, 18, 30, 60} × {1, 2, 3, 4}` at `A=0.37 mm`, `λ=16 mm`, `ply_t=0.183 mm` against `MeshData.validate()`:

- `nz_per_ply · A / ply_t ≤ 4` → always passes
- `nz_per_ply · A / ply_t ≥ 8` → always inverts, regardless of `nx`

The previous in-plane shear ratio (`(2π·A/λ)·(Lx/nx)/(ply_t/nz_per_ply)`) did **not** predict the boundary — `nz_per_ply` is the dominant factor. The heuristic uses `nz_per_ply · A / ply_t` with thresholds `2.5` (warn) and `5.0` (block).

For the reported reproduction (A=0.37 mm, nz_per_ply=4): decay ratio = 8.09 → block, with the message *"nz_per_ply ≤ 1 or amplitude ≤ 0.114 mm before running."*

## Test plan

- [x] `pytest tests/ -k "mesh or analysis"` — 188 passed locally
- [x] Sanity-check that the user's failing case (A=0.37, λ=16, nx=18, nz_per_ply=4) triggers `will_invert=True` and produces an actionable message
- [x] Flat-mesh (`wrinkle_config is None`) and analytical-only paths are unaffected — diagnostic only fires when an FE solve will run
- [ ] Manually verify in the deployed Streamlit app: nz_per_ply slider triggers red error + button disabled; reducing amplitude to ≤0.11 mm or nz_per_ply to 1 clears the error

---
_Generated by [Claude Code](https://claude.ai/code/session_013pnrYp7fpXy47iEttzkqdo)_