### PR TITLE
feat: surface enable_czm in Streamlit app and CLI

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,6 +138,19 @@ DEFAULT_NX = _CFG_DEFAULTS.nx
 DEFAULT_NY = _CFG_DEFAULTS.ny
 DEFAULT_NZ_PER_PLY = _CFG_DEFAULTS.nz_per_ply
 
+# CZM defaults. Mirrors AnalysisConfig's class defaults; the toughness /
+# strength inputs default to 0.0 in the UI when the material exposes no
+# default and are otherwise seeded from the chosen material below at
+# render time.
+DEFAULT_ENABLE_CZM = _CFG_DEFAULTS.enable_czm
+DEFAULT_CZM_INTERFACES = (
+    _CFG_DEFAULTS.czm_interfaces
+    if isinstance(_CFG_DEFAULTS.czm_interfaces, str)
+    else "near_crest"
+)
+DEFAULT_CZM_LOAD_INCREMENTS = _CFG_DEFAULTS.czm_n_load_increments
+DEFAULT_CZM_NEWTON_TOL = _CFG_DEFAULTS.czm_newton_tol
+
 # Single source of truth used by the "Reset to defaults" button: maps each
 # sidebar widget ``key=`` argument to the value it should hold after a reset.
 # Keep this aligned with the ``key=`` strings on the widgets below.
@@ -161,6 +174,11 @@ DEFAULTS: dict[str, object] = {
     "sb_nx": DEFAULT_NX,
     "sb_ny": DEFAULT_NY,
     "sb_nz_per_ply": DEFAULT_NZ_PER_PLY,
+    # CZM
+    "sb_enable_czm": DEFAULT_ENABLE_CZM,
+    "sb_czm_interfaces": DEFAULT_CZM_INTERFACES,
+    "sb_czm_load_increments": DEFAULT_CZM_LOAD_INCREMENTS,
+    "sb_czm_newton_tol": DEFAULT_CZM_NEWTON_TOL,
 }
 
 
@@ -814,6 +832,122 @@ with st.sidebar:
             "for the full FE solve, stress fields, and per-ply failure indices."
         )
 
+    # ------------------------------------------------------------------
+    # Cohesive zone modelling (delamination prediction). Collapsed by
+    # default so the existing UI flow is unchanged for users who don't
+    # want CZM. When the checkbox is ticked, the FE solve switches from
+    # the linear StaticSolver to Newton-Raphson and zero-thickness
+    # cohesive elements are inserted at the requested ply interfaces.
+    # ------------------------------------------------------------------
+    with st.expander(
+        "Cohesive Zone Modeling (delamination)", expanded=False,
+    ):
+        enable_czm = st.checkbox(
+            "Enable Cohesive Zone Modeling (delamination prediction)",
+            value=DEFAULT_ENABLE_CZM,
+            key="sb_enable_czm",
+            help=(
+                "Adds zero-thickness cohesive interface elements at ply "
+                "boundaries. When enabled, the FE solve switches from "
+                "linear (StaticSolver) to nonlinear Newton-Raphson. "
+                "Run time is ~5-20x longer; produces damage field "
+                "output and energy dissipation per interface."
+            ),
+        )
+
+        # Seed the toughness / strength inputs from the chosen material
+        # so users only have to override values they care about. When
+        # the material exposes no default for a quantity, fall back to
+        # 0.0 — AnalysisConfig will then refuse to run unless the user
+        # supplies a non-zero override (matching the API contract).
+        _mat_seed = OrthotropicMaterial.from_dict(material_dict)
+        _gic_seed = float(_mat_seed.GIc) if _mat_seed.GIc is not None else 0.30
+        _giic_seed = float(_mat_seed.GIIc) if _mat_seed.GIIc is not None else 0.80
+        _sigma_seed = float(_mat_seed.sigma_max)
+        _tau_seed = float(_mat_seed.tau_max)
+
+        if enable_czm:
+            czm_GIc = st.number_input(
+                "Mode-I toughness G_Ic [N/mm]",
+                min_value=0.0, value=_gic_seed, step=0.01,
+                format="%.4f", key="sb_czm_GIc",
+                help=(
+                    "Mode-I (opening) fracture toughness. Default seeded "
+                    "from the selected material's library value."
+                ),
+            )
+            czm_GIIc = st.number_input(
+                "Mode-II toughness G_IIc [N/mm]",
+                min_value=0.0, value=_giic_seed, step=0.01,
+                format="%.4f", key="sb_czm_GIIc",
+                help=(
+                    "Mode-II (shear) fracture toughness. Default seeded "
+                    "from the selected material's library value."
+                ),
+            )
+            czm_sigma_max = st.number_input(
+                "Mode-I peak strength σ_max [MPa]",
+                min_value=0.0, value=_sigma_seed, step=1.0,
+                format="%.1f", key="sb_czm_sigma_max",
+                help="Peak normal traction at which interface damage initiates.",
+            )
+            czm_tau_max = st.number_input(
+                "Mode-II peak strength τ_max [MPa]",
+                min_value=0.0, value=_tau_seed, step=1.0,
+                format="%.1f", key="sb_czm_tau_max",
+                help="Peak shear traction at which interface damage initiates.",
+            )
+            czm_interfaces_choice = st.selectbox(
+                "Interface placement",
+                ["near_crest", "all"],
+                index=["near_crest", "all"].index(DEFAULT_CZM_INTERFACES),
+                key="sb_czm_interfaces",
+                help=(
+                    "*near_crest* (default) inserts cohesive elements at "
+                    "the single ply interface closest to the wrinkle "
+                    "peak. *all* inserts cohesive elements at every "
+                    "interior ply interface (slower)."
+                ),
+            )
+            czm_load_increments = st.number_input(
+                "Newton load increments",
+                min_value=5, max_value=100,
+                value=int(DEFAULT_CZM_LOAD_INCREMENTS), step=1,
+                key="sb_czm_load_increments",
+                help=(
+                    "Number of incremental load steps used by the "
+                    "Newton-Raphson solver. More increments improve "
+                    "robustness for stiff damage problems at the cost "
+                    "of run time."
+                ),
+            )
+            czm_newton_tol = st.number_input(
+                "Newton residual tolerance",
+                min_value=1.0e-8, max_value=1.0e-2,
+                value=float(DEFAULT_CZM_NEWTON_TOL),
+                step=1.0e-5, format="%.1e",
+                key="sb_czm_newton_tol",
+                help=(
+                    "Relative residual tolerance for Newton convergence "
+                    "at each load increment."
+                ),
+            )
+            st.caption(
+                ":hourglass_flowing_sand: CZM run time is typically "
+                "5–20x the linear FE path. Use a small mesh "
+                "(nx ≤ 8) for first explorations."
+            )
+        else:
+            # Defaults still need to be defined so the run handler can
+            # reference them unconditionally.
+            czm_GIc = _gic_seed
+            czm_GIIc = _giic_seed
+            czm_sigma_max = _sigma_seed
+            czm_tau_max = _tau_seed
+            czm_interfaces_choice = DEFAULT_CZM_INTERFACES
+            czm_load_increments = DEFAULT_CZM_LOAD_INCREMENTS
+            czm_newton_tol = DEFAULT_CZM_NEWTON_TOL
+
     run_disabled = bool(mesh_diag is not None and mesh_diag.will_invert)
     run_clicked = st.button(
         "Run analysis",
@@ -873,6 +1007,24 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
     angles = list(cfg_dict.pop("angles_tuple"))
     material_dict = dict(cfg_dict.pop("material_tuple"))
     material = OrthotropicMaterial.from_dict(material_dict)
+
+    # CZM kwargs only enter ``AnalysisConfig`` when CZM is actually
+    # enabled — passing them while ``enable_czm=False`` would be a
+    # silent no-op but would also churn the cache for users who never
+    # touch the feature.
+    czm_kwargs: dict = {}
+    if cfg_dict.get("enable_czm", False):
+        czm_kwargs = dict(
+            enable_czm=True,
+            czm_interfaces=cfg_dict.get("czm_interfaces", "near_crest"),
+            czm_GIc=cfg_dict.get("czm_GIc"),
+            czm_GIIc=cfg_dict.get("czm_GIIc"),
+            czm_sigma_max=cfg_dict.get("czm_sigma_max"),
+            czm_tau_max=cfg_dict.get("czm_tau_max"),
+            czm_n_load_increments=int(cfg_dict.get("czm_n_load_increments", 20)),
+            czm_newton_tol=float(cfg_dict.get("czm_newton_tol", 1.0e-4)),
+        )
+
     cfg = AnalysisConfig(
         amplitude=cfg_dict["amplitude"],
         wavelength=cfg_dict["wavelength"],
@@ -893,6 +1045,7 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         ny=cfg_dict.get("ny", 6),
         nz_per_ply=cfg_dict.get("nz_per_ply", 1),
         analytical_only=cfg_dict["analytical_only"],
+        **czm_kwargs,
     )
     result = WrinkleAnalysis(cfg).run(
         analytical_only=cfg_dict["analytical_only"],
@@ -981,6 +1134,52 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             ),
         }
 
+    # CZM payload — only populated when AnalysisConfig.enable_czm=True
+    # actually drove the FE solve down the Newton-Raphson path. Kept in
+    # a sub-dict so the Results tab can quickly check ``results.get("czm")``
+    # without juggling None-checks on a flat top-level structure.
+    czm_payload: Optional[dict] = None
+    if cfg_dict.get("enable_czm", False) and result.czm_damage is not None:
+        damage_arr = np.asarray(result.czm_damage)
+        if damage_arr.size:
+            damage_per_elem = (
+                damage_arr.mean(axis=1) if damage_arr.ndim == 2 else damage_arr
+            )
+            n_above_half = int(np.sum(damage_per_elem > 0.5))
+            max_d = float(np.max(damage_arr))
+        else:
+            damage_per_elem = damage_arr
+            n_above_half = 0
+            max_d = 0.0
+        crack_per_iface = {
+            int(k): float(v)
+            for k, v in (result.czm_crack_length_per_interface or {}).items()
+        }
+        energy_per_iface = {
+            int(k): float(v)
+            for k, v in (result.czm_energy_per_interface or {}).items()
+        }
+        czm_payload = {
+            "enabled": True,
+            "converged": bool(result.czm_converged)
+            if result.czm_converged is not None else None,
+            "interfaces_used": list(result.czm_interfaces_used or []),
+            "max_damage": max_d,
+            "n_elements_above_half": n_above_half,
+            "energy_dissipated": float(result.czm_energy_dissipated or 0.0),
+            "crack_length_per_interface": crack_per_iface,
+            "energy_per_interface": energy_per_iface,
+            # Keep the full AnalysisResults object alongside the
+            # scalar metrics so the Results tab can call
+            # ``czm_overview_figure(result)`` without re-running the
+            # solve. The object is non-pickleable in places (e.g. it
+            # holds mesh handles) so the JSON export must strip it; we
+            # tag it with a leading underscore so ``_strip_arrays``
+            # (which only filters ``np.ndarray``) can be extended to
+            # drop underscore-prefixed keys too.
+            "_result": result,
+        }
+
     return {
         "summary": result.summary(),
         "loading": cfg_dict["loading"],
@@ -998,6 +1197,7 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             if result.tension_mechanisms else None
         ),
         "fe": fe,
+        "czm": czm_payload,
     }
 
 
@@ -1749,6 +1949,13 @@ with tab_results:
                 "panel and re-run to see modulus and strength retention."
             )
 
+        # ------------------------------------------------------------------
+        # Cohesive Zone Modeling Results — only rendered when CZM ran.
+        # ------------------------------------------------------------------
+        _czm = r.get("czm")
+        if _czm is not None:
+            _render_czm_results(_czm)
+
         st.subheader("Full text summary")
         st.text(r["summary"])
 
@@ -1762,13 +1969,17 @@ with tab_export:
             _wrinklefe_version = "0.0.0+unknown"
 
         def _strip_arrays(obj):
-            """Drop numpy arrays so the JSON export stays small. Arrays
-            are only useful for the in-app 3D viz."""
+            """Drop numpy arrays and internal AnalysisResults handles so
+            the JSON export stays small. Arrays are only useful for the
+            in-app 3D viz; underscore-prefixed keys hold non-JSON-safe
+            Python objects (e.g. the CZM `_result`) that the export must
+            not attempt to serialise."""
             if isinstance(obj, dict):
                 return {
                     k: _strip_arrays(v)
                     for k, v in obj.items()
                     if not isinstance(v, np.ndarray)
+                    and not (isinstance(k, str) and k.startswith("_"))
                 }
             if isinstance(obj, list):
                 return [_strip_arrays(v) for v in obj]

--- a/app.py
+++ b/app.py
@@ -138,10 +138,11 @@ DEFAULT_NX = _CFG_DEFAULTS.nx
 DEFAULT_NY = _CFG_DEFAULTS.ny
 DEFAULT_NZ_PER_PLY = _CFG_DEFAULTS.nz_per_ply
 
-# CZM defaults. Mirrors AnalysisConfig's class defaults; the toughness /
-# strength inputs default to 0.0 in the UI when the material exposes no
-# default and are otherwise seeded from the chosen material below at
-# render time.
+# CZM defaults. The on/off flag, interface placement, Newton tunables
+# mirror ``AnalysisConfig``. The toughness/strength fields default to
+# the IM7/8552 library values (the default material) so the *Reset to
+# defaults* button has a concrete starting point; the actual seed value
+# used at render time tracks whichever material the user has selected.
 DEFAULT_ENABLE_CZM = _CFG_DEFAULTS.enable_czm
 DEFAULT_CZM_INTERFACES = (
     _CFG_DEFAULTS.czm_interfaces
@@ -150,6 +151,17 @@ DEFAULT_CZM_INTERFACES = (
 )
 DEFAULT_CZM_LOAD_INCREMENTS = _CFG_DEFAULTS.czm_n_load_increments
 DEFAULT_CZM_NEWTON_TOL = _CFG_DEFAULTS.czm_newton_tol
+_default_mat_for_czm = LIB.get(DEFAULT_MATERIAL)
+DEFAULT_CZM_GIC = (
+    float(_default_mat_for_czm.GIc)
+    if _default_mat_for_czm.GIc is not None else 0.30
+)
+DEFAULT_CZM_GIIC = (
+    float(_default_mat_for_czm.GIIc)
+    if _default_mat_for_czm.GIIc is not None else 0.80
+)
+DEFAULT_CZM_SIGMA_MAX = float(_default_mat_for_czm.sigma_max)
+DEFAULT_CZM_TAU_MAX = float(_default_mat_for_czm.tau_max)
 
 # Single source of truth used by the "Reset to defaults" button: maps each
 # sidebar widget ``key=`` argument to the value it should hold after a reset.
@@ -179,6 +191,10 @@ DEFAULTS: dict[str, object] = {
     "sb_czm_interfaces": DEFAULT_CZM_INTERFACES,
     "sb_czm_load_increments": DEFAULT_CZM_LOAD_INCREMENTS,
     "sb_czm_newton_tol": DEFAULT_CZM_NEWTON_TOL,
+    "sb_czm_GIc": DEFAULT_CZM_GIC,
+    "sb_czm_GIIc": DEFAULT_CZM_GIIC,
+    "sb_czm_sigma_max": DEFAULT_CZM_SIGMA_MAX,
+    "sb_czm_tau_max": DEFAULT_CZM_TAU_MAX,
 }
 
 
@@ -1202,6 +1218,109 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# CZM rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_czm_results(czm: dict) -> None:
+    """Render the *Cohesive Zone Modeling Results* section on the Results tab.
+
+    Driven by the ``czm`` sub-dict that ``run_analysis_cached`` attaches
+    to the results payload. When the underlying solve was enabled but
+    produced no damage data (e.g. ``czm_damage`` is empty), the function
+    surfaces a clear warning instead of crashing on the missing figure.
+    """
+    with st.expander("Cohesive Zone Modeling Results", expanded=True):
+        result_obj = czm.get("_result")
+        # Sentinel: enable_czm=True but no damage array was populated.
+        # This usually means the solve failed before reaching the
+        # Newton-Raphson stage or no cohesive elements were inserted.
+        damage_missing = (
+            result_obj is None
+            or result_obj.czm_damage is None
+            or not result_obj.czm_damage.size
+        )
+        if damage_missing:
+            st.warning(
+                "CZM was enabled but no damage data was produced — "
+                "the solver may have failed before the Newton-Raphson "
+                "stage, or no cohesive elements were inserted at the "
+                "selected interfaces."
+            )
+            return
+
+        # Top-line metrics
+        m1, m2, m3, m4 = st.columns(4)
+        m1.metric(
+            "Max damage",
+            f"{czm['max_damage']:.3f}",
+            help=(
+                "Peak Gauss-point damage scalar across every cohesive "
+                "element. 0 = intact, 1 = fully separated."
+            ),
+        )
+        m2.metric(
+            "Energy dissipated",
+            f"{czm['energy_dissipated']:.3e} N·mm",
+            help="Total cohesive energy dissipated across all interfaces.",
+        )
+        m3.metric(
+            "Elements w/ damage > 0.5",
+            f"{czm['n_elements_above_half']}",
+            help=(
+                "Count of cohesive elements whose per-element mean "
+                "damage exceeds 0.5 — a proxy for the partially-failed "
+                "delamination footprint."
+            ),
+        )
+        crack_lengths = czm.get("crack_length_per_interface", {}) or {}
+        if crack_lengths:
+            _total_crack = sum(crack_lengths.values())
+            m4.metric(
+                "Total crack length",
+                f"{_total_crack:.3e} mm",
+                help=(
+                    "Summed crack length across all cohesive "
+                    "interfaces (element area / mesh width, with "
+                    "damage > 0.99)."
+                ),
+            )
+        else:
+            m4.metric("Total crack length", "—")
+
+        st.caption(
+            f"Converged: **{czm.get('converged')}**  ·  "
+            f"Interfaces: **{', '.join(str(i) for i in czm.get('interfaces_used', [])) or '(none)'}**"
+        )
+
+        # Per-interface crack-length table
+        if crack_lengths:
+            st.markdown("**Crack length per interface**")
+            rows = sorted(crack_lengths.items())
+            st.table(
+                {
+                    "Interface": [str(i) for i, _ in rows],
+                    "Crack length (mm)": [f"{v:.4e}" for _, v in rows],
+                    "Energy (N·mm)": [
+                        f"{czm.get('energy_per_interface', {}).get(i, 0.0):.4e}"
+                        for i, _ in rows
+                    ],
+                }
+            )
+
+        # 2x2 overview figure from wrinklefe.viz.plots_2d
+        try:
+            from wrinklefe.viz import czm_overview_figure as _czm_fig
+
+            fig = _czm_fig(result_obj)
+            st.pyplot(fig, clear_figure=True)
+        except Exception as exc:
+            st.warning(
+                f"Could not render the CZM overview figure: {exc}"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Main area
 # ---------------------------------------------------------------------------
 
@@ -1253,6 +1372,12 @@ if run_clicked or _demo_pending:
             st.error(f"Invalid custom material: {e}")
             st.stop()
 
+        # CZM requires the Newton-Raphson FE path; force analytical_only
+        # off when CZM is enabled regardless of the *Analytical only*
+        # checkbox so the user can't accidentally request an analytical
+        # CZM run (which would silently drop the cohesive solve).
+        _effective_analytical_only = bool(analytical_only) and not bool(enable_czm)
+
         cfg_items: dict = {
             "amplitude": amplitude,
             "wavelength": wavelength,
@@ -1267,15 +1392,26 @@ if run_clicked or _demo_pending:
             "angles_tuple": tuple(layup),
             "applied_strain": applied_strain_pct / 100.0,
             "material_tuple": tuple(sorted(material_dict.items())),
-            "analytical_only": bool(analytical_only),
+            "analytical_only": _effective_analytical_only,
         }
         # Mesh keys only matter for the FE path; omitting them in
         # analytical-only mode means the cache key doesn't churn when the
         # user tweaks nx/ny/nz.
-        if not analytical_only:
+        if not _effective_analytical_only:
             cfg_items["nx"] = int(nx)
             cfg_items["ny"] = int(ny)
             cfg_items["nz_per_ply"] = int(nz_per_ply)
+        # CZM keys — only added when CZM is enabled so the cache key
+        # for non-CZM runs is bit-identical to the pre-CZM behaviour.
+        if enable_czm:
+            cfg_items["enable_czm"] = True
+            cfg_items["czm_interfaces"] = czm_interfaces_choice
+            cfg_items["czm_GIc"] = float(czm_GIc)
+            cfg_items["czm_GIIc"] = float(czm_GIIc)
+            cfg_items["czm_sigma_max"] = float(czm_sigma_max)
+            cfg_items["czm_tau_max"] = float(czm_tau_max)
+            cfg_items["czm_n_load_increments"] = int(czm_load_increments)
+            cfg_items["czm_newton_tol"] = float(czm_newton_tol)
         cfg_payload = tuple(sorted(cfg_items.items()))
 
     with st.status("Running analysis…", expanded=True) as status:

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -201,6 +201,83 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # ------------------------------------------------------------------ #
+    # CZM (cohesive zone modelling) flags. Off by default; when
+    # --enable-czm is absent every other czm flag is silently ignored so
+    # the legacy ``analyze`` behaviour is bit-identical.
+    # ------------------------------------------------------------------ #
+    p_analyze.add_argument(
+        "--enable-czm", action="store_true", default=False,
+        dest="enable_czm",
+        help=(
+            "Enable cohesive zone modelling (delamination prediction). "
+            "Inserts zero-thickness cohesive interface elements at ply "
+            "boundaries and switches the FE solve from the linear "
+            "StaticSolver to Newton-Raphson. Run time is ~5-20x longer; "
+            "produces damage field output and energy dissipation per "
+            "interface."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-GIc", type=float, default=None, dest="czm_GIc",
+        help=(
+            "Mode-I fracture toughness G_Ic in N/mm. Defaults to the "
+            "material's GIc when omitted."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-GIIc", type=float, default=None, dest="czm_GIIc",
+        help=(
+            "Mode-II fracture toughness G_IIc in N/mm. Defaults to the "
+            "material's GIIc when omitted."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-sigma-max", type=float, default=None, dest="czm_sigma_max",
+        help=(
+            "Mode-I peak interface strength sigma_max in MPa. Defaults "
+            "to the material's sigma_max when omitted."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-tau-max", type=float, default=None, dest="czm_tau_max",
+        help=(
+            "Mode-II peak interface strength tau_max in MPa. Defaults "
+            "to the material's tau_max when omitted."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-interfaces", type=str, default="near_crest",
+        dest="czm_interfaces",
+        help=(
+            "Which ply interfaces receive cohesive elements. Accepts "
+            "'near_crest' (default), 'all', or a comma-separated list "
+            "of interface indices (e.g. '11,12')."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-load-increments", type=int, default=20,
+        dest="czm_load_increments",
+        help=(
+            "Number of Newton-Raphson load increments for the CZM "
+            "solve (default: 20)."
+        ),
+    )
+    p_analyze.add_argument(
+        "--czm-newton-tol", type=float, default=1.0e-4,
+        dest="czm_newton_tol",
+        help="Newton-Raphson residual tolerance (default: 1e-4).",
+    )
+    p_analyze.add_argument(
+        "--save-czm-figure", type=str, default=None,
+        dest="save_czm_figure",
+        help=(
+            "When --enable-czm is set, save the CZM overview figure "
+            "(2x2 dashboard) to this path. Matplotlib infers the "
+            "format from the file extension (.png, .pdf, .svg)."
+        ),
+    )
+
+    # ------------------------------------------------------------------ #
     # compare
     # ------------------------------------------------------------------ #
     p_compare = subparsers.add_parser(
@@ -356,6 +433,40 @@ def _build_parser() -> argparse.ArgumentParser:
 # Subcommand handlers
 # ====================================================================== #
 
+def _parse_czm_interfaces(value: Optional[str]):
+    """Parse --czm-interfaces into the form ``AnalysisConfig`` expects.
+
+    Accepts the two sentinel strings ``"near_crest"`` / ``"all"`` (passed
+    through verbatim) and a comma-separated list of non-negative
+    integers (returned as a ``list[int]``). Anything else is a fatal
+    CLI error so the user gets a clear message rather than a deep
+    validation traceback.
+    """
+    if value is None:
+        return "near_crest"
+    s = value.strip()
+    if s in ("near_crest", "all"):
+        return s
+    # Otherwise treat as comma-separated list of ints.
+    parts = [p.strip() for p in s.split(",") if p.strip()]
+    if not parts:
+        print(
+            "error: --czm-interfaces must be 'near_crest', 'all', or "
+            "a comma-separated list of interface indices",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        return [int(p) for p in parts]
+    except ValueError:
+        print(
+            f"error: --czm-interfaces could not parse {value!r} as a "
+            "list of integers",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def _parse_angles(angles_str: Optional[str]) -> Optional[List[float]]:
     """Parse a layup string into a list of ply angles (degrees).
 
@@ -390,11 +501,15 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     # Resolve analytical-only vs. full FE intent.
     #
     # Precedence (highest first):
-    #   1. --analytical-only -> skip FE
-    #   2. --fe              -> full FE solve
-    #   3. --no-fe           -> analytical-only
-    #   4. default           -> full FE solve
-    if args.analytical_only:
+    #   1. --enable-czm      -> force full FE solve (CZM requires NR)
+    #   2. --analytical-only -> skip FE
+    #   3. --fe              -> full FE solve
+    #   4. --no-fe           -> analytical-only
+    #   5. default           -> full FE solve
+    enable_czm = bool(getattr(args, "enable_czm", False))
+    if enable_czm:
+        analytical_only = False
+    elif args.analytical_only:
         analytical_only = True
     elif args.fe is True:
         analytical_only = False
@@ -402,6 +517,22 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         analytical_only = True
     else:
         analytical_only = False
+
+    # CZM kwargs. When --enable-czm is absent these defaults exactly
+    # match ``AnalysisConfig``'s class defaults so the resulting config
+    # is bit-identical to the pre-CZM behaviour.
+    czm_kwargs: dict = {}
+    if enable_czm:
+        czm_kwargs = dict(
+            enable_czm=True,
+            czm_interfaces=_parse_czm_interfaces(args.czm_interfaces),
+            czm_GIc=args.czm_GIc,
+            czm_GIIc=args.czm_GIIc,
+            czm_sigma_max=args.czm_sigma_max,
+            czm_tau_max=args.czm_tau_max,
+            czm_n_load_increments=args.czm_load_increments,
+            czm_newton_tol=args.czm_newton_tol,
+        )
 
     config = AnalysisConfig(
         amplitude=args.amplitude,
@@ -422,6 +553,7 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         solver=args.solver,
         analytical_only=analytical_only,
         verbose=args.verbose,
+        **czm_kwargs,
     )
 
     analysis = WrinkleAnalysis(config)
@@ -433,11 +565,70 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
 
     print(result.summary())
 
+    # Extra CZM section: AnalysisResults.summary() already prints the
+    # core CZM metrics (max/mean damage, energy, convergence) but it
+    # does not break out crack length or # interfaces above the 0.5
+    # threshold. Emit those here so the CLI surface matches the
+    # Streamlit "Cohesive Zone Modeling Results" block.
+    if enable_czm and result.czm_damage is not None and result.czm_damage.size:
+        _print_czm_extras(result)
+
+    # Optional CZM figure export.
+    if enable_czm and args.save_czm_figure is not None:
+        if result.czm_damage is None or not result.czm_damage.size:
+            print(
+                "warning: --save-czm-figure ignored, no CZM damage data "
+                "was produced (the solve may have failed to insert "
+                "cohesive elements).",
+                file=sys.stderr,
+            )
+        else:
+            try:
+                from wrinklefe.viz import czm_overview_figure
+                fig = czm_overview_figure(result)
+                fig.savefig(args.save_czm_figure)
+                print(f"\nCZM overview figure saved to: {args.save_czm_figure}")
+                # Close to free memory and keep matplotlib's "too many open
+                # figures" warning quiet when the CLI is scripted.
+                import matplotlib.pyplot as _plt
+                _plt.close(fig)
+            except Exception as exc:  # pragma: no cover - exercised via tests
+                print(
+                    f"warning: failed to save CZM figure: {exc}",
+                    file=sys.stderr,
+                )
+
     # Export to JSON if requested
     if args.output_json is not None:
         from wrinklefe.io.export import export_results_json
         export_results_json(result, args.output_json)
         print(f"\nResults exported to: {args.output_json}")
+
+
+def _print_czm_extras(result) -> None:
+    """Print CZM crack length / damaged-interface counts after the summary.
+
+    ``AnalysisResults.summary()`` already covers max/mean damage, energy,
+    convergence, and the interface list. This helper appends the two
+    extras the Streamlit UI also exposes so the CLI and web surfaces
+    show the same set of CZM metrics.
+    """
+    damage = result.czm_damage
+    # Per-element damage = mean across Gauss points. An interface "fails"
+    # if any of its elements exceed the 0.5 threshold.
+    damage_per_elem = np.asarray(damage).mean(axis=1) if damage.ndim == 2 else np.asarray(damage)
+    n_above_half = int(np.sum(damage_per_elem > 0.5))
+
+    crack_per_iface = result.czm_crack_length_per_interface or {}
+
+    print()
+    print("  Cohesive Zone Modeling extras:")
+    print(f"    Elements with damage > 0.5: {n_above_half}")
+    if crack_per_iface:
+        for iface, length in sorted(crack_per_iface.items()):
+            print(f"    Crack length, interface {iface}: {length:.4e} mm")
+    else:
+        print("    Crack length per interface: (none)")
 
 
 def _cmd_compare(args: argparse.Namespace) -> None:

--- a/tests/test_app_czm.py
+++ b/tests/test_app_czm.py
@@ -1,0 +1,224 @@
+"""Smoke tests for the Streamlit app's Cohesive Zone Modeling controls.
+
+The Streamlit ``app.py`` exposes a collapsed *Cohesive Zone Modeling*
+expander in the sidebar that, when checked, reveals toughness /
+strength / interface / Newton inputs and switches the FE solve to
+the Newton-Raphson path. These tests use ``streamlit.testing.v1.AppTest``
+to drive the page without a real browser and verify:
+
+1. The CZM checkbox lives in the sidebar with ``key='sb_enable_czm'``
+   and starts unchecked, so the existing UI is unchanged for users
+   who don't want CZM.
+2. Setting ``session_state['sb_enable_czm'] = True`` reveals the full
+   set of CZM widgets (toughness, strength, interface placement, load
+   increments, Newton tolerance).
+3. The CZM defaults are exposed via the module-level ``DEFAULTS`` dict
+   so the *Reset to defaults* button restores them.
+4. The CZM result renderer (``_render_czm_results``) gracefully
+   handles the sentinel case where ``enable_czm=True`` but no damage
+   data was populated.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# ``app.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+pytest.importorskip(
+    "streamlit.testing.v1", reason="Streamlit testing API not available."
+)
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    """Import ``app.py`` for module-level constants and helpers."""
+    import app as app_module  # noqa: WPS433 - test-time import.
+    return app_module
+
+
+# ----------------------------------------------------------------------
+# 1. Imports cleanly + DEFAULTS round-trip
+# ----------------------------------------------------------------------
+
+
+def test_defaults_include_czm_entries(app_module):
+    """``DEFAULTS`` must hold every CZM widget key so reset works."""
+    d = app_module.DEFAULTS
+    assert "sb_enable_czm" in d
+    assert d["sb_enable_czm"] is False
+    assert d["sb_czm_interfaces"] in ("near_crest", "all")
+    assert isinstance(d["sb_czm_load_increments"], int)
+    assert isinstance(d["sb_czm_newton_tol"], float)
+
+
+def test_czm_defaults_match_analysis_config(app_module):
+    """The CZM defaults must mirror ``AnalysisConfig()`` so the UI cannot
+    silently drift from the analysis contract."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig()
+    assert app_module.DEFAULT_ENABLE_CZM == cfg.enable_czm
+    assert app_module.DEFAULT_CZM_LOAD_INCREMENTS == cfg.czm_n_load_increments
+    assert app_module.DEFAULT_CZM_NEWTON_TOL == cfg.czm_newton_tol
+
+
+# ----------------------------------------------------------------------
+# 2. AppTest-driven UI smoke tests
+# ----------------------------------------------------------------------
+
+
+def _app_path() -> str:
+    return str(_REPO_ROOT / "app.py")
+
+
+def test_app_runs_with_czm_disabled():
+    """Default page load: no exceptions, CZM checkbox is False."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    # CZM checkbox is present and unchecked by default.
+    cbs = {cb.key: cb for cb in at.checkbox if cb.key is not None}
+    assert "sb_enable_czm" in cbs, (
+        f"CZM checkbox missing from app; saw keys: {sorted(cbs)}"
+    )
+    assert cbs["sb_enable_czm"].value is False
+
+    # With CZM off, none of the dependent czm_* widgets should render.
+    czm_inputs = [ni for ni in at.number_input if "czm" in (ni.key or "")]
+    assert czm_inputs == [], (
+        f"CZM inputs leaked into the default UI: {[ni.key for ni in czm_inputs]}"
+    )
+
+
+def test_enabling_czm_reveals_full_widget_set():
+    """Toggling ``sb_enable_czm`` reveals every CZM input widget."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["sb_enable_czm"] = True
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    expected_inputs = {
+        "sb_czm_GIc",
+        "sb_czm_GIIc",
+        "sb_czm_sigma_max",
+        "sb_czm_tau_max",
+        "sb_czm_load_increments",
+        "sb_czm_newton_tol",
+    }
+    actual_inputs = {ni.key for ni in at.number_input if ni.key is not None}
+    missing = expected_inputs - actual_inputs
+    assert not missing, (
+        f"CZM number_input widgets missing after enable: {missing}; "
+        f"saw {sorted(actual_inputs)}"
+    )
+
+    # ``sb_czm_interfaces`` is a selectbox.
+    selectboxes = {sb.key for sb in at.selectbox if sb.key is not None}
+    assert "sb_czm_interfaces" in selectboxes
+
+
+def test_czm_widgets_seed_from_material_defaults():
+    """The toughness / strength fields default to the chosen material's
+    library values (IM7/8552: GIc=0.28, GIIc=0.79, sigma_max=80, tau_max=90)."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["sb_enable_czm"] = True
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    by_key = {
+        ni.key: ni.value for ni in at.number_input if ni.key is not None
+    }
+    assert by_key["sb_czm_GIc"] == pytest.approx(0.28, rel=1e-3)
+    assert by_key["sb_czm_GIIc"] == pytest.approx(0.79, rel=1e-3)
+    assert by_key["sb_czm_sigma_max"] == pytest.approx(80.0, rel=1e-3)
+    assert by_key["sb_czm_tau_max"] == pytest.approx(90.0, rel=1e-3)
+
+
+# ----------------------------------------------------------------------
+# 3. Result-rendering sentinel: enable_czm=True but no damage data
+# ----------------------------------------------------------------------
+
+
+def test_render_czm_results_handles_missing_damage(app_module):
+    """``_render_czm_results`` must not crash when the solve produced
+    no damage data — it should surface a warning instead."""
+    from streamlit.testing.v1 import AppTest
+
+    # Drive ``_render_czm_results`` indirectly by stuffing a CZM payload
+    # whose ``_result`` carries an empty damage array into the session
+    # state and running the page. AppTest exposes the rendered warnings
+    # via the ``at.warning`` collection.
+    from wrinklefe.analysis import AnalysisConfig, AnalysisResults
+
+    empty_result = AnalysisResults(
+        config=AnalysisConfig(),
+        morphology_factor=1.0,
+        max_angle_rad=0.0,
+        effective_angle_rad=0.0,
+        damage_index=0.0,
+        analytical_knockdown=1.0,
+        analytical_strength_MPa=1000.0,
+        gamma_Y_eff=0.05,
+        czm_damage=np.empty((0, 0)),
+    )
+    fake_results = {
+        "summary": "stub summary",
+        "loading": "tension",
+        "applied_strain_abs": 0.01,
+        "max_angle_deg": 0.0,
+        "effective_angle_deg": 0.0,
+        "morphology_factor": 1.0,
+        "gamma_Y_eff": 0.05,
+        "analytical_knockdown": 1.0,
+        "analytical_strength_MPa": 1000.0,
+        "damage_index": 0.0,
+        "tension_mechanisms": None,
+        "fe": None,
+        "czm": {
+            "enabled": True,
+            "converged": True,
+            "interfaces_used": [3],
+            "max_damage": 0.0,
+            "n_elements_above_half": 0,
+            "energy_dissipated": 0.0,
+            "crack_length_per_interface": {},
+            "energy_per_interface": {},
+            "_result": empty_result,
+        },
+    }
+    # The session-state cfg_payload is consumed by the Export tab; an
+    # empty tuple is safe because the export logic re-parses material /
+    # angles defensively.
+    fake_payload = (
+        ("amplitude", 0.3),
+        ("angles_tuple", (0, 45, -45, 90)),
+        ("material_tuple", tuple()),
+        ("wavelength", 16.0),
+    )
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["results"] = fake_results
+    at.session_state["cfg_payload"] = fake_payload
+    at.run()
+    # The CZM section must render *something* warning-like, not crash.
+    assert not at.exception, [str(e.value) for e in at.exception]
+    warning_texts = [w.value for w in at.warning]
+    assert any("CZM" in t and "no damage" in t.lower() for t in warning_texts), (
+        f"missing CZM-no-damage warning; saw warnings: {warning_texts!r}"
+    )

--- a/tests/test_cli_czm.py
+++ b/tests/test_cli_czm.py
@@ -1,0 +1,157 @@
+"""End-to-end tests for the ``wrinklefe analyze`` CZM CLI flags.
+
+These tests invoke the installed ``wrinklefe`` console-script entry
+point via :mod:`subprocess` so that:
+
+1. argparse argument parsing, flag mapping into :class:`AnalysisConfig`,
+   the analyze handler's printout, and the optional CZM-figure export
+   are all exercised together as the user sees them.
+2. Regression coverage protects the **absence** of a CZM section in the
+   baseline (no ``--enable-czm``) output — the contract is that adding
+   the new flags must not perturb existing CLI behaviour.
+
+A tiny ``[0/90]_4s`` mesh (``--nx 4 --ny 2 --czm-load-increments 5``) is
+used everywhere CZM runs so each test completes in single-digit seconds.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_WRINKLEFE_CLI = shutil.which("wrinklefe")
+
+
+def _run_cli(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess:
+    """Invoke ``wrinklefe <args>`` and return the completed process.
+
+    Prefers the installed console script (``wrinklefe``); falls back to
+    ``python -m wrinklefe.cli`` so the suite still passes in a venv that
+    has the package importable but not pip-installed with entry points
+    registered.
+    """
+    if _WRINKLEFE_CLI is not None:
+        cmd = [_WRINKLEFE_CLI, *args]
+    else:
+        cmd = [sys.executable, "-m", "wrinklefe.cli", *args]
+    return subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout,
+    )
+
+
+# ----------------------------------------------------------------------
+# Baseline: --enable-czm absent must reproduce the existing analyze output
+# ----------------------------------------------------------------------
+
+
+def test_cli_without_czm_unchanged():
+    """No ``--enable-czm`` flag: exit code 0 and *no* CZM section in stdout.
+
+    Guards the anti-goal: 'do not change the existing UI flow for users
+    who leave CZM off; default behaviour must be bit-identical.'
+    """
+    proc = _run_cli(
+        "analyze",
+        "--analytical-only",
+        "--amplitude", "0.3",
+        "--wavelength", "16",
+    )
+    assert proc.returncode == 0, (
+        f"baseline CLI run failed: stderr={proc.stderr!r}"
+    )
+    assert "WrinkleFE Analysis Results" in proc.stdout
+    # CZM-only headings/keys must not appear when the user did not opt
+    # in. ``czm_overview_figure`` is also part of the CZM extras path.
+    assert "Cohesive Zone Modeling" not in proc.stdout
+    assert "Max damage" not in proc.stdout
+    assert "CZM overview figure saved" not in proc.stdout
+
+
+# ----------------------------------------------------------------------
+# Happy path: --enable-czm with a tiny mesh runs end-to-end
+# ----------------------------------------------------------------------
+
+
+def test_cli_with_czm_runs():
+    """``--enable-czm`` with a tiny mesh produces a CZM section in stdout."""
+    proc = _run_cli(
+        "analyze",
+        "--enable-czm",
+        "--amplitude", "0.3",
+        "--wavelength", "16",
+        "--nx", "4",
+        "--ny", "2",
+        "--strain", "0.01",
+        "--layup", "[0/90]_4s",
+        "--czm-load-increments", "5",
+    )
+    assert proc.returncode == 0, (
+        f"CZM CLI run failed: stderr={proc.stderr!r}, stdout={proc.stdout!r}"
+    )
+    # ``AnalysisResults.summary()`` already prints the core CZM block;
+    # the ``analyze`` handler also appends the *extras* line.
+    assert "Cohesive Zone Modeling" in proc.stdout
+    assert "Max damage" in proc.stdout
+    assert "Elements with damage > 0.5" in proc.stdout
+
+
+def test_cli_czm_save_figure(tmp_path):
+    """``--save-czm-figure`` writes a non-empty image file to disk."""
+    out_png = tmp_path / "czm_overview.png"
+    proc = _run_cli(
+        "analyze",
+        "--enable-czm",
+        "--amplitude", "0.3",
+        "--wavelength", "16",
+        "--nx", "4",
+        "--ny", "2",
+        "--strain", "0.01",
+        "--layup", "[0/90]_4s",
+        "--czm-load-increments", "5",
+        "--save-czm-figure", str(out_png),
+    )
+    assert proc.returncode == 0, (
+        f"--save-czm-figure run failed: stderr={proc.stderr!r}"
+    )
+    assert out_png.exists(), "CZM overview figure was not created"
+    assert out_png.stat().st_size > 1000, (
+        f"CZM overview figure suspiciously small: "
+        f"{out_png.stat().st_size} bytes"
+    )
+    assert "CZM overview figure saved" in proc.stdout
+
+
+# ----------------------------------------------------------------------
+# Defensive: the new interface-list parser must reject garbage cleanly
+# ----------------------------------------------------------------------
+
+
+def test_cli_czm_interfaces_rejects_garbage():
+    """``--czm-interfaces foo`` is not a sentinel or int list -> exit 2."""
+    proc = _run_cli(
+        "analyze",
+        "--enable-czm",
+        "--amplitude", "0.3",
+        "--wavelength", "16",
+        "--nx", "4",
+        "--ny", "2",
+        "--strain", "0.01",
+        "--layup", "[0/90]_4s",
+        "--czm-load-increments", "5",
+        "--czm-interfaces", "foo",
+    )
+    assert proc.returncode != 0, (
+        "garbage --czm-interfaces should exit non-zero, got "
+        f"stdout={proc.stdout!r}"
+    )
+    # Either the CLI's own parser error or AnalysisConfig._validate
+    # rejects it; both are acceptable, both are clearly flagged.
+    assert (
+        "czm-interfaces" in proc.stderr.lower()
+        or "interfaces" in proc.stderr.lower()
+    )


### PR DESCRIPTION
## Summary

Surfaces the CZM feature (merged in #248) in the public Streamlit app and CLI. Off by default; backward compatible.

## Streamlit (`app.py`)

Adds a collapsible "Cohesive Zone Modeling" section to the sidebar (starts collapsed so the default UI is unchanged):

- `[ ] Enable Cohesive Zone Modeling` toggle
- When checked: number inputs for `GIc`, `GIIc`, `σ_max`, `τ_max` (pre-populated from material library defaults), `interface placement` selectbox (`near_crest` | `all`), Newton load increments + residual tolerance
- Results page: when CZM runs, shows top-line metrics (max damage, energy dissipated, # damaged interfaces, crack lengths) plus the `czm_overview_figure(result)` plot

## CLI (`src/wrinklefe/cli.py`)

Adds CZM flags to the `analyze` subcommand:

- `--enable-czm` toggle (default off)
- `--czm-GIc FLOAT`, `--czm-GIIc FLOAT`, `--czm-sigma-max FLOAT`, `--czm-tau-max FLOAT` (None → material defaults)
- `--czm-interfaces TEXT` — accepts `near_crest`, `all`, or comma-separated int list
- `--czm-load-increments INT` (default 20), `--czm-newton-tol FLOAT` (default 1e-4)
- `--save-czm-figure PATH` — saves `czm_overview_figure` to disk after the analysis

CLI output gains a "Cohesive Zone Modeling" section when `--enable-czm` is set.

## Tests

- `tests/test_cli_czm.py` (4 tests): toggle wiring, parameter pass-through, interfaces parser, `--save-czm-figure`
- `tests/test_app_czm.py` (6 tests): default state, widget reveal, material-default seeding, missing-damage handling

Total: 1263 passed / 1 xfailed (was 1253 — +10 from this PR).

## Backward compatibility

- `--enable-czm` absent → existing CLI behavior bit-identical
- Sidebar checkbox off → existing Streamlit behavior bit-identical
- All other CLI flags and Streamlit widgets unchanged

## Test plan

- [ ] `pytest tests/test_cli_czm.py tests/test_app_czm.py -v` — 10/10 pass
- [ ] `pytest` — 1263 passed / 1 xfailed
- [ ] `wrinklefe analyze --help` shows the new CZM flags
- [ ] `wrinklefe analyze --enable-czm --strain 0.005 --nx 4 --ny 2` runs without crash and prints a CZM section
- [ ] `streamlit run app.py` opens with a collapsed "Cohesive Zone Modeling" section in the sidebar; expanding and toggling it reveals the parameter inputs

## Note

Closes the "Streamlit / CLI integration pending" item flagged as Known Limitation #5 in [`CZM_PLAN.md`](./CZM_PLAN.md).

https://claude.ai/code/session_01NEiTrrm4LcSBdKikQMqUDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEiTrrm4LcSBdKikQMqUDz)_