### PR TITLE
packaging: remove dead `export` extra (meshio was never imported)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ from wrinklefe.failure.evaluator import FailureEvaluator
 | `sweep/parametric_sweep.py` | Parametric sweep over amplitude/wavelength/morphology; CSV output |
 | `analysis.py` | Top-level orchestrator: `WrinkleAnalysis`, `AnalysisConfig`, `compare_morphologies`, `parametric_sweep` |
 | `cli.py` | Entry point referenced by `[project.scripts]` (the `wrinklefe` command) |
-| `io/export.py` | meshio-backed mesh/field export, gated by the `export` extra |
+| `io/export.py` | Native JSON, Abaqus `.inp`, and legacy VTK export (no extra dependencies) |
 
 ## Confinement Model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
 # so plain `pip install wrinklefe` produces a headless-safe environment. See
 # requirements.txt for the rationale.
 [project.optional-dependencies]
-export = ["meshio>=5.3"]
 # Streamlit web app deps — keep versions in sync with requirements.txt.
 streamlit = [
     "streamlit>=1.57",
@@ -47,7 +46,7 @@ dev = [
     "ruff>=0.1",
     "mypy>=1.5",
 ]
-all = ["wrinklefe[export,streamlit,dev]"]
+all = ["wrinklefe[streamlit,dev]"]
 
 [project.scripts]
 wrinklefe = "wrinklefe.cli:main"


### PR DESCRIPTION
Fixes #253.

## What
- Remove the `export = ["meshio>=5.3"]` optional-dependency group from `pyproject.toml` — `src/wrinklefe/io/export.py` writes Abaqus `.inp` and legacy VTK files natively and nothing in the package imports meshio (`grep -rn meshio src/` returns nothing).
- Update the `all` extra to `wrinklefe[streamlit,dev]`.
- Fix the stale `ARCHITECTURE.md` module-table row that described `io/export.py` as "meshio-backed … gated by the `export` extra".

## Verification
- `pyproject.toml` parses cleanly (`tomllib`); remaining extras: `streamlit`, `dev`, `all`.
- `export.py` loads standalone with only numpy installed and exposes `export_abaqus_inp` / `export_vtk` — confirming export works with no extras.
- `requirements.txt` never listed meshio, and README never documented the `export` extra, so no other docs need updating.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_