### PR TITLE
docs site (#255); validation harness + decay_floor fix (#254); multi-wrinkle FE Stage 1 (#252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,29 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install with docs extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      # -W turns warnings (broken cross-references, bad docstring
+      # syntax, stale autodoc targets) into build failures.
+      - name: Build docs
+        run: sphinx-build -W docs docs/_build
+
   examples:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,6 @@ joss/*.fls
 .superpowers/
 docs/superpowers/
 joss/
+docs/_build/
 validation/*.png
 validation/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# ReadTheDocs build configuration.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Runnable scripts for the common workflows — parametric sweeps,
 morphology comparison, CZM delamination, export round-trips, custom
 materials — live in [`examples/`](examples/); each states its expected
 runtime and output, and CI executes them all so they stay current.
+The full API reference and user guide are built from [`docs/`](docs/)
+with Sphinx (`pip install -e ".[docs]" && sphinx-build -W docs
+docs/_build`) and published at
+<https://wrinklefe.readthedocs.io>.
 
 `amplitude` (`A`) is the **half-amplitude** [mm]: the peak displacement
 of the wrinkled mid-surface from the flat (unwrinkled) reference plane,

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -20,6 +20,26 @@ A paper qualifies as a knockdown validation point when it reports, for a
 Each case is run through `WrinkleAnalysis`; predicted vs measured knockdown
 gives the per-point error, aggregated into the README table.
 
+## Reproducible harness
+
+The machine-readable ledger lives at `tests/test_validation/ledger.json`
+(per-case analysis recipe, measured knockdown, and a pinned analytical
+baseline computed by the current code). One command recomputes every
+case and fails on drift from the pinned baselines:
+
+```bash
+python scripts/validate.py            # compare; exit 1 on drift
+python scripts/validate.py --update   # re-pin after a deliberate model change
+```
+
+`tests/test_validation/test_ledger.py` runs the same comparisons in CI.
+The pinned values are regression baselines, not claims of experimental
+agreement — the measured-vs-predicted error per dataset is printed
+alongside. This is the harness whose absence forced the revert of the
+graded-decay fix (issue #254, commit `00584b4`); datasets whose raw
+case data are not yet in the repository (Elhajjar 2025, Mukhopadhyay
+2015, Li 2026) should be added to the ledger as their points land.
+
 ## Included datasets
 
 See the table in [README.md](README.md). Current sources:
@@ -145,10 +165,15 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   parameter (out of scope; excluded on future inclusion).
 - **Related**: the `graded` compression through-thickness decay has a
   separate real bug (`decay_floor` inert in compression, decay scale
-  hard-wired to amplitude A). A "mirror the tension path" fix was
-  prototyped and **reverted** (commit `00584b4`) pending a reproducible
-  harness for *all* existing datasets; it corrects the angle response but
-  does not address the amplitude gap above.
+  hard-wired to amplitude A), tracked by issue #254. A "mirror the
+  tension path" fix was prototyped and **reverted** (commit `00584b4`)
+  pending a reproducible harness for *all* existing datasets; it
+  corrects the angle response but does not address the amplitude gap
+  above. The harness now exists (see *Reproducible harness* above, with
+  this dataset's cases pinned in `tests/test_validation/ledger.json`,
+  and a strict-xfail test in `tests/test_validation/test_ledger.py`
+  documenting the compression `decay_floor` inertness), unblocking the
+  re-land.
 
 ## Identified — pending evaluation
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -163,17 +163,20 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   needs geometrically nonlinear progressive-damage FE (issue #161). S-A-2
   additionally exposes a missing through-thickness wrinkle-position
   parameter (out of scope; excluded on future inclusion).
-- **Related**: the `graded` compression through-thickness decay has a
-  separate real bug (`decay_floor` inert in compression, decay scale
-  hard-wired to amplitude A), tracked by issue #254. A "mirror the
-  tension path" fix was prototyped and **reverted** (commit `00584b4`)
-  pending a reproducible harness for *all* existing datasets; it
-  corrects the angle response but does not address the amplitude gap
-  above. The harness now exists (see *Reproducible harness* above, with
-  this dataset's cases pinned in `tests/test_validation/ledger.json`,
-  and a strict-xfail test in `tests/test_validation/test_ledger.py`
-  documenting the compression `decay_floor` inertness), unblocking the
-  re-land.
+- **Related (resolved)**: the `graded` compression through-thickness
+  decay had a separate real bug, tracked and closed by issue #254:
+  `decay_floor` was inert in compression (honored in tension), and the
+  decay scale was originally hard-wired to the amplitude A. An early
+  "mirror the tension path" fix was **reverted** (commit `00584b4`)
+  pending a reproducible harness. Both halves are now fixed: the decay
+  scale became the explicit `through_thickness_decay_scale` parameter
+  (auto default `max(λ/2, A)`), and `decay_floor` is applied with the
+  same floor semantics on both loading paths
+  (`Φ = floor + (1 − floor)·gaussian`), with defaults preserving prior
+  results bit-for-bit — confirmed by zero drift across this dataset's
+  pinned baselines in `tests/test_validation/ledger.json`. Neither
+  change addresses the amplitude-at-constant-angle gap above, which
+  remains issue #161.
 
 ## Identified — pending evaluation
 

--- a/docs/api/analysis.rst
+++ b/docs/api/analysis.rst
@@ -1,0 +1,7 @@
+wrinklefe.analysis
+==================
+
+.. automodule:: wrinklefe.analysis
+   :members: AnalysisConfig, WrinkleAnalysis, AnalysisResults, WrinkleSpec
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -1,0 +1,10 @@
+wrinklefe.cli
+=============
+
+The ``wrinklefe`` command installed by the package
+(``[project.scripts]``). Subcommands: ``analyze``, ``compare``,
+``sweep``, ``converge``, ``materials``; run any of them with
+``--help`` for the full option reference.
+
+.. automodule:: wrinklefe.cli
+   :members: main

--- a/docs/api/convergence.rst
+++ b/docs/api/convergence.rst
@@ -1,0 +1,6 @@
+wrinklefe.convergence
+=====================
+
+.. automodule:: wrinklefe.convergence
+   :members:
+   :show-inheritance:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -1,0 +1,38 @@
+wrinklefe.core
+==============
+
+Materials
+---------
+
+.. automodule:: wrinklefe.core.material
+   :members: OrthotropicMaterial, MaterialLibrary
+   :show-inheritance:
+
+Laminate and layup
+------------------
+
+.. automodule:: wrinklefe.core.laminate
+   :members: Laminate, LoadState
+   :show-inheritance:
+
+.. automodule:: wrinklefe.core.layup
+   :members:
+   :show-inheritance:
+
+Wrinkle geometry and morphology
+-------------------------------
+
+.. automodule:: wrinklefe.core.wrinkle
+   :members:
+   :show-inheritance:
+
+.. automodule:: wrinklefe.core.morphology
+   :members: WrinklePlacement, WrinkleConfiguration
+   :show-inheritance:
+
+Mesh
+----
+
+.. automodule:: wrinklefe.core.mesh
+   :members: WrinkleMesh, MeshData
+   :show-inheritance:

--- a/docs/api/failure.rst
+++ b/docs/api/failure.rst
@@ -1,0 +1,20 @@
+wrinklefe.failure
+=================
+
+Evaluator
+---------
+
+.. automodule:: wrinklefe.failure.evaluator
+   :members: FailureEvaluator, LaminateFailureReport
+   :show-inheritance:
+
+Criteria
+--------
+
+.. automodule:: wrinklefe.failure.base
+   :members: FailureCriterion, FailureResult
+   :show-inheritance:
+
+.. automodule:: wrinklefe.failure.larc05
+   :members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,16 @@
+API reference
+=============
+
+The public surface of the package: the analysis orchestrator and its
+configuration, the convergence helper, the core geometry/material
+model, the failure criteria, export functions, and the CLI.
+
+.. toctree::
+   :maxdepth: 1
+
+   analysis
+   convergence
+   core
+   failure
+   io
+   cli

--- a/docs/api/io.rst
+++ b/docs/api/io.rst
@@ -1,0 +1,6 @@
+wrinklefe.io
+============
+
+.. automodule:: wrinklefe.io.export
+   :members:
+   :show-inheritance:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,4 @@
+```{include} ../ARCHITECTURE.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,48 @@
+"""Sphinx configuration for the WrinkleFE documentation site."""
+
+import os
+import sys
+
+# Make the package importable without installation (autodoc).
+sys.path.insert(0, os.path.abspath("../src"))
+
+project = "WrinkleFE"
+author = "Elhajjar Research Group"
+copyright = "2026, Elhajjar Research Group"  # noqa: A001
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "myst_parser",
+]
+
+# The 3-D viz module imports pyvista at module scope; mock it so the
+# docs build does not require VTK.
+autodoc_mock_imports = ["pyvista"]
+
+autosummary_generate = True
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+# Render docstring "Attributes" sections as :ivar: fields so they do not
+# collide with the attribute entries autodoc emits for the same names.
+napoleon_use_ivar = True
+
+myst_enable_extensions = ["dollarmath", "colon_fence"]
+myst_heading_anchors = 3
+
+# The root markdown docs link to each other by repository-relative
+# paths (e.g. ``[VALIDATION.md](VALIDATION.md)``); those targets resolve
+# on GitHub but not inside the Sphinx tree, so the missing-xref warning
+# is suppressed rather than failing the -W build.
+suppress_warnings = ["myst.xref_missing"]
+
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "furo"
+html_title = "WrinkleFE"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,4 @@
+```{include} ../CONTRIBUTING.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/czm_plan.md
+++ b/docs/czm_plan.md
@@ -1,0 +1,4 @@
+```{include} ../CZM_PLAN.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/deployment_streamlit.md
+++ b/docs/deployment_streamlit.md
@@ -1,0 +1,4 @@
+```{include} ../DEPLOYMENT_STREAMLIT.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,47 @@
+# Getting started
+
+## Install
+
+```bash
+pip install wrinklefe            # core: analytical + FE pipeline
+pip install "wrinklefe[streamlit]"  # + the Streamlit web app
+```
+
+From a clone, `pip install -e ".[all]"` installs everything including
+the dev tooling.
+
+## A five-minute analysis
+
+```python
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+
+config = AnalysisConfig(
+    amplitude=0.366, wavelength=16.0, width=12.0,
+    morphology="stack", loading="compression",
+)
+result = WrinkleAnalysis(config).run()
+print(result.summary())
+```
+
+`amplitude` is the **half-amplitude** in mm (peak displacement of the
+wrinkled mid-surface from the flat reference); `wavelength` is the
+crest-to-crest period; `width` is the longitudinal envelope decay
+length. All lengths are millimetres. The full parameter reference is
+the wrinkle-geometry table in the [overview](overview.md) and the
+{class}`~wrinklefe.analysis.AnalysisConfig` API page.
+
+The same pipeline is available from the command line:
+
+```bash
+wrinklefe analyze --amplitude 0.366 --wavelength 16 --morphology stack
+wrinklefe converge --tolerance 0.01   # mesh-convergence study
+wrinklefe materials                   # list the material library
+```
+
+## Runnable examples
+
+The repository's `examples/` directory contains scripts for the common
+workflows — parametric sweeps, morphology comparison, CZM delamination,
+export round-trips, custom materials, mesh convergence — each with its
+expected runtime and output in the header. CI executes them all on
+every push.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# WrinkleFE
+
+Finite element analysis of wrinkled composite laminates with advanced
+failure theories — analytical Budiansky–Fleck knockdown, 3-D FE with
+LaRC05/Hashin/Puck ply failure, and cohesive-zone delamination.
+
+```{toctree}
+:maxdepth: 2
+:caption: Documentation
+
+getting_started
+overview
+api/index
+validation
+architecture
+czm_plan
+deployment_streamlit
+contributing
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,4 @@
+```{include} ../README.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,4 @@
+```{include} ../VALIDATION.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,20 @@ dev = [
     "ruff>=0.1",
     "mypy>=1.5",
 ]
-all = ["wrinklefe[streamlit,dev]"]
+docs = [
+    "sphinx>=8.0",
+    "myst-parser>=4.0",
+    "furo>=2024.8",
+]
+all = ["wrinklefe[streamlit,dev,docs]"]
 
 [project.scripts]
 wrinklefe = "wrinklefe.cli:main"
+
+[project.urls]
+Documentation = "https://wrinklefe.readthedocs.io"
+Repository = "https://github.com/elhajjar1/wrinkleFE"
+Issues = "https://github.com/elhajjar1/wrinkleFE/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Recompute every validation-ledger case and compare against baselines.
+
+One command from a clean checkout:
+
+    python scripts/validate.py            # recompute + compare, exit 1 on drift
+    python scripts/validate.py --update   # re-pin baselines after a deliberate change
+
+The ledger (tests/test_validation/ledger.json) carries, per case, the
+full analysis recipe, the measured experimental knockdown, and a pinned
+``expected_analytical_kd`` computed by the current code. This script is
+the reproducible harness named in issue #254 as the precondition for
+re-landing the graded compression decay fix (reverted in 00584b4): run
+it before and after a model change and every row that moved is visible,
+with measured-vs-predicted error statistics per dataset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+LEDGER = REPO / "tests" / "test_validation" / "ledger.json"
+
+sys.path.insert(0, str(REPO / "src"))
+
+
+def case_config(dataset: dict, case: dict):
+    """Build the AnalysisConfig for one ledger case (the reference recipe)."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.layup import parse_layup
+    from wrinklefe.core.material import MaterialLibrary
+
+    return AnalysisConfig(
+        amplitude=case["amplitude_p2p_mm"] / 2.0,
+        wavelength=case["wavelength_mm"],
+        width=case["wavelength_mm"],
+        morphology=dataset["morphology"],
+        loading=dataset["loading"],
+        material=MaterialLibrary().get(dataset["material"]),
+        angles=parse_layup(dataset["layup"]),
+        ply_thickness=dataset["ply_thickness_mm"],
+    )
+
+
+def run_case(dataset: dict, case: dict) -> float:
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    cfg = case_config(dataset, case)
+    return float(
+        WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update", action="store_true",
+        help="re-pin expected_analytical_kd to the current code's output",
+    )
+    args = parser.parse_args(argv)
+
+    ledger = json.loads(LEDGER.read_text())
+    tol = float(ledger["rel_tolerance"])
+    failures = 0
+
+    for dataset in ledger["datasets"]:
+        print(f"\n=== {dataset['name']}  ({dataset['reference']})")
+        print(
+            f"{'case':<8} {'KD meas':>8} {'KD pred':>9} {'pinned':>9} "
+            f"{'drift%':>8} {'meas err%':>10}"
+        )
+        abs_errors = []
+        for case in dataset["cases"]:
+            predicted = run_case(dataset, case)
+            pinned = float(case["expected_analytical_kd"])
+            drift = abs(predicted - pinned) / max(abs(pinned), 1e-30)
+            meas_err = (
+                100.0 * (predicted - case["measured_kd"]) / case["measured_kd"]
+            )
+            abs_errors.append(abs(predicted - case["measured_kd"]))
+            flag = ""
+            if drift > tol:
+                flag = "  <-- DRIFT vs pinned baseline"
+                failures += 1
+            print(
+                f"{case['case']:<8} {case['measured_kd']:>8.3f} "
+                f"{predicted:>9.4f} {pinned:>9.4f} {100 * drift:>8.3f} "
+                f"{meas_err:>10.1f}{flag}"
+            )
+            if args.update:
+                case["expected_analytical_kd"] = round(predicted, 6)
+        mae = sum(abs_errors) / len(abs_errors)
+        print(f"MAE vs measured KD: {mae:.4f}  ({len(abs_errors)} cases)")
+
+    if args.update:
+        LEDGER.write_text(json.dumps(ledger, indent=2) + "\n")
+        print(f"\nBaselines re-pinned in {LEDGER.relative_to(REPO)}")
+        return 0
+    if failures:
+        print(
+            f"\n{failures} case(s) drifted beyond rel_tolerance={tol}. "
+            "If the change is intentional, re-pin with --update and "
+            "explain the move in the commit message."
+        )
+        return 1
+    print("\nAll cases match the pinned baselines.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -216,6 +216,7 @@ def _profile_proportional_kd(
     through_thickness_decay: bool = True,
     z_position_fraction: float = 0.5,
     decay_scale: Optional[float] = None,
+    decay_floor: float = 0.0,
     kink_band_quadratic_coeff: float = 0.0,
 ) -> float:
     """Budiansky-Fleck knockdown averaged over the wrinkle profile.
@@ -305,6 +306,16 @@ def _profile_proportional_kd(
         Through-thickness Gaussian standard deviation [mm].  When None
         (default) the auto formula ``max(wavelength / 2, amplitude)`` is
         used.  Must be strictly positive when provided.
+    decay_floor : float
+        Minimum fraction of the wrinkle angle retained at any ply
+        (issue #254): the through-thickness term becomes
+        ``decay_floor + (1 - decay_floor) * raw`` with ``raw`` the
+        Gaussian above — the same floor semantics the tension graded
+        path applies, so a sign-flipped load sees the same envelope.
+        ``0.0`` (default) reproduces the legacy pure-Gaussian decay
+        bit-for-bit; ``1.0`` disables the decay (every ply sees the
+        full angle).  Caller is responsible for the [0, 1] range
+        (``AnalysisConfig`` validates it).
     kink_band_quadratic_coeff : float
         Argon-Fleck quadratic coefficient ``c_AF`` (dimensionless).
         Default 0.0 (legacy linear BF).  Must be >= 0.
@@ -350,7 +361,8 @@ def _profile_proportional_kd(
     for p in range(n_plies):
         z_p = (p + 0.5) * ply_thickness
         if through_thickness_decay:
-            phi_p = np.exp(-((z_p - z_center) ** 2) / sigma_sq2)
+            raw_p = np.exp(-((z_p - z_center) ** 2) / sigma_sq2)
+            phi_p = decay_floor + (1.0 - decay_floor) * raw_p
         else:
             phi_p = 1.0
         theta_xz = theta_x * phi_p  # local angle at (x, z_p)
@@ -2331,6 +2343,7 @@ class WrinkleAnalysis:
                 through_thickness_decay=True,
                 z_position_fraction=z_pos,
                 decay_scale=decay_scale_eff,
+                decay_floor=cfg.decay_floor,
                 kink_band_quadratic_coeff=c_AF,
             )
             kd_compression = f_0 * kd_profile + (1.0 - f_0)

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -373,6 +373,40 @@ def _profile_proportional_kd(
     return kd_sum / n_plies
 
 
+def _check_multi_wrinkle_fe_support(cfg: "AnalysisConfig") -> None:
+    """Reject multi-wrinkle FE configs the pipeline cannot represent yet.
+
+    Issue #252 Stage 1 supports N wrinkles whose longitudinal supports
+    (center offset from the phase, ± 3*width Gaussian extent) do not
+    overlap — the Li (2025) specimen layout. Overlapping wrinkles and
+    the CZM pathway remain analytical-only and are rejected with a
+    message that states exactly what is unsupported.
+    """
+    if cfg.enable_czm:
+        raise NotImplementedError(
+            "Multi-wrinkle FE with cohesive zones (enable_czm=True) is "
+            "not yet supported: cohesive interface placement assumes a "
+            "single wrinkle crest. Run with enable_czm=False or pass "
+            "analytical_only=True."
+        )
+    center = cfg.domain_length / 2.0
+    spans = []
+    for i, spec in enumerate(cfg.wrinkles):
+        c = center + spec.phase_offset * spec.wavelength / (2.0 * math.pi)
+        spans.append((c - 3.0 * spec.width, c + 3.0 * spec.width, i))
+    spans.sort()
+    for (lo1, hi1, i), (lo2, hi2, j) in zip(spans, spans[1:]):
+        if lo2 < hi1:
+            raise NotImplementedError(
+                f"Wrinkles {i} and {j} overlap longitudinally (supports "
+                f"[{lo1:.2f}, {hi1:.2f}] and [{lo2:.2f}, {hi2:.2f}] mm, "
+                "using the 3*width Gaussian extent). The FE solve "
+                "currently supports non-overlapping wrinkles only "
+                "(issue #252 Stage 1) — separate them via phase_offset "
+                "or pass analytical_only=True."
+            )
+
+
 def _max_consecutive_zero_plies(angles: List[float], tol: float = 5.0) -> int:
     """Find maximum number of consecutive 0-degree plies in a layup.
 
@@ -818,7 +852,22 @@ class AnalysisConfig:
 
     def __post_init__(self) -> None:
         if self.domain_length <= 0:
-            self.domain_length = 3.0 * self.wavelength
+            if self.wrinkles:
+                # Multi-wrinkle: size the domain from the union of the
+                # wrinkle extents (per-spec center offset from its phase
+                # plus the 3*width Gaussian support), not from the
+                # scalar wavelength field. The 3*wavelength floor keeps
+                # a single centred spec consistent with the scalar path.
+                half_span = max(
+                    abs(s.phase_offset) * s.wavelength / (2.0 * math.pi)
+                    + 3.0 * s.width
+                    for s in self.wrinkles
+                )
+                self.domain_length = max(
+                    2.0 * half_span, 3.0 * self.wavelength
+                )
+            else:
+                self.domain_length = 3.0 * self.wavelength
         if self.material is None:
             self.material = MaterialLibrary().get("IM7_8552")
         if self.angles is None:
@@ -1481,15 +1530,12 @@ class WrinkleAnalysis:
         if analytical_only is None:
             analytical_only = cfg.analytical_only
 
-        # Multi-wrinkle FE solve is not yet supported — the mesh
-        # generator currently assumes one or two wrinkle interfaces.
-        # Reject early so callers get a clear signal rather than a
-        # mid-pipeline failure.
+        # Multi-wrinkle FE solve supports non-overlapping wrinkles along
+        # the length (issue #252 Stage 1). Reject the still-unsupported
+        # shapes early, with a precise message, rather than failing
+        # mid-pipeline.
         if cfg.wrinkles is not None and not analytical_only:
-            raise NotImplementedError(
-                "Multi-wrinkle FE solve not yet implemented; "
-                "pass analytical_only=True."
-            )
+            _check_multi_wrinkle_fe_support(cfg)
 
         results = AnalysisResults(config=cfg)
 
@@ -1555,53 +1601,39 @@ class WrinkleAnalysis:
                 amplitude_profile_axis=cfg.amplitude_profile_axis,
             )
             results.wrinkle_config = wrinkle_config
-
-            _report("Computing analytical predictions", 0.05)
-
-            # 3. Analytical predictions (multi-wrinkle path)
-            self._compute_analytical(results, wrinkle_config)
-
-            # FE solve is unsupported for the multi-wrinkle path
-            # (guarded above); always return analytical-only here.
-            _report("Analytical predictions complete", 1.0)
-            logger.info(
-                "Analysis complete (multi-wrinkle analytical): "
-                "knockdown=%s", results.analytical_knockdown,
-            )
-            return results
-
-        profile = GaussianSinusoidal(
-            amplitude=cfg.amplitude,
-            wavelength=cfg.wavelength,
-            width=cfg.width,
-            center=wrinkle_center,
-        )
-        if cfg.phase is not None and (
-            cfg.morphology.lower().strip() not in SINGLE_WRINKLE_MODES
-        ):
-            # Explicit phase overrides the named-morphology phase so
-            # arbitrary dual-wrinkle phase offsets can be analysed/swept.
-            wrinkle_config = WrinkleConfiguration.dual_wrinkle(
-                profile,
-                interface1=cfg.interface_1,
-                interface2=cfg.interface_2,
-                phase=float(cfg.phase),
-                amplitude_profile=cfg.amplitude_profile,
-                amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
-                amplitude_profile_axis=cfg.amplitude_profile_axis,
-            )
-            wrinkle_config.decay_floor = max(0.0, min(1.0, cfg.decay_floor))
         else:
-            wrinkle_config = WrinkleConfiguration.from_morphology_name(
-                cfg.morphology, profile,
-                interface1=cfg.interface_1,
-                interface2=cfg.interface_2,
-                decay_floor=cfg.decay_floor,
-                amplitude_profile=cfg.amplitude_profile,
-                amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
-                amplitude_profile_axis=cfg.amplitude_profile_axis,
+            profile = GaussianSinusoidal(
+                amplitude=cfg.amplitude,
+                wavelength=cfg.wavelength,
+                width=cfg.width,
+                center=wrinkle_center,
             )
-        results.wrinkle_config = wrinkle_config
+            if cfg.phase is not None and (
+                cfg.morphology.lower().strip() not in SINGLE_WRINKLE_MODES
+            ):
+                # Explicit phase overrides the named-morphology phase so
+                # arbitrary dual-wrinkle phase offsets can be analysed/swept.
+                wrinkle_config = WrinkleConfiguration.dual_wrinkle(
+                    profile,
+                    interface1=cfg.interface_1,
+                    interface2=cfg.interface_2,
+                    phase=float(cfg.phase),
+                    amplitude_profile=cfg.amplitude_profile,
+                    amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
+                    amplitude_profile_axis=cfg.amplitude_profile_axis,
+                )
+                wrinkle_config.decay_floor = max(0.0, min(1.0, cfg.decay_floor))
+            else:
+                wrinkle_config = WrinkleConfiguration.from_morphology_name(
+                    cfg.morphology, profile,
+                    interface1=cfg.interface_1,
+                    interface2=cfg.interface_2,
+                    decay_floor=cfg.decay_floor,
+                    amplitude_profile=cfg.amplitude_profile,
+                    amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
+                    amplitude_profile_axis=cfg.amplitude_profile_axis,
+                )
+            results.wrinkle_config = wrinkle_config
 
         _report("Computing analytical predictions", 0.05)
 

--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -1,6 +1,7 @@
 """Orthotropic material properties and material library for composite FE analysis.
 
 This module provides:
+
 - OrthotropicMaterial: A dataclass encapsulating the full set of orthotropic
   elastic constants, strength allowables, hygrothermal coefficients, and
   kink-band parameters for a single composite ply material.

--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -754,11 +754,18 @@ class WrinkleMesh:
         ):
             return err  # Flat mesh — nothing wrinkle-specific to add.
 
-        w0 = self.wrinkle_config.wrinkles[0]
-        profile = w0.profile
-        inner = getattr(profile, "profile", profile)  # unwrap WrinkleSurface3D
-        amplitude = float(getattr(inner, "amplitude", 0.0))
-        wavelength = float(getattr(inner, "wavelength", 0.0))
+        # Use the most shear-severe wrinkle (largest A/lambda slope) so
+        # multi-wrinkle configurations get diagnostics for the wrinkle
+        # that actually drives the inversion.
+        amplitude = wavelength = 0.0
+        worst = -1.0
+        for w in self.wrinkle_config.wrinkles:
+            inner = getattr(w.profile, "profile", w.profile)
+            a = float(getattr(inner, "amplitude", 0.0))
+            lam = float(getattr(inner, "wavelength", 0.0))
+            if a > 0.0 and lam > 0.0 and a / lam > worst:
+                worst = a / lam
+                amplitude, wavelength = a, lam
         if amplitude <= 0.0 or wavelength <= 0.0:
             return err
 

--- a/src/wrinklefe/core/wrinkle.py
+++ b/src/wrinklefe/core/wrinkle.py
@@ -174,7 +174,7 @@ class WrinkleProfile(ABC):
         Sample density rationale (Nyquist vs wrinkle wavelength).  The
         finest oscillation in ``slope(x)`` has period ``wavelength``; its
         derivative content is band-limited to that scale.  Resolving every
-        |slope| lobe requires at least a few samples per quarter-wave.  The
+        ``|slope|`` lobe requires at least a few samples per quarter-wave.  The
         domain spans at most ~6 envelope widths or ~6 wavelengths, so
         ``n_grid = 4096`` yields hundreds of samples per wavelength even for
         the most oscillatory profiles in this module -- far above the

--- a/tests/test_integration/test_multi_wrinkle.py
+++ b/tests/test_integration/test_multi_wrinkle.py
@@ -164,16 +164,26 @@ class TestMultiWrinkleValidation:
         with pytest.raises(ValueError, match="ply_interface"):
             _build_cfg(ac318_material, ud14_angles, bad)
 
-    def test_fe_solve_raises_not_implemented(self, ac318_material, ud14_angles):
-        """Multi-wrinkle + FE solve must raise NotImplementedError."""
+    def test_fe_solve_rejects_overlapping_wrinkles(
+        self, ac318_material, ud14_angles
+    ):
+        """Overlapping wrinkles + FE solve raise a precise
+        NotImplementedError (issue #252 Stage 1 supports non-overlapping
+        wrinkles only; see tests/test_integration/test_multi_wrinkle_fe.py
+        for the supported path)."""
         wrinkles = [
-            WrinkleSpec(amplitude=1.5, wavelength=12.9, width=12.9, ply_interface=4),
+            WrinkleSpec(amplitude=1.5, wavelength=12.9, width=12.9,
+                        ply_interface=4),
+            WrinkleSpec(amplitude=1.5, wavelength=12.9, width=12.9,
+                        ply_interface=6, phase_offset=0.5),
         ]
         cfg = _build_cfg(
             ac318_material, ud14_angles, wrinkles, analytical_only=False
         )
         analysis = WrinkleAnalysis(cfg)
-        with pytest.raises(NotImplementedError, match="Multi-wrinkle FE solve"):
+        with pytest.raises(
+            NotImplementedError, match="overlap longitudinally"
+        ):
             analysis.run(analytical_only=False)
 
 

--- a/tests/test_integration/test_multi_wrinkle_fe.py
+++ b/tests/test_integration/test_multi_wrinkle_fe.py
@@ -1,0 +1,150 @@
+"""FE solve for multi-wrinkle configurations (issue #252, Stage 1).
+
+Stage 1 supports N wrinkles whose longitudinal supports do not overlap
+(the Li 2025 specimen layout): the composed displacement / fiber-angle
+fields come from ``WrinkleConfiguration.apply_to_nodes`` /
+``fiber_angles_at_nodes``, which already superpose N placements.
+Overlapping wrinkles and the CZM pathway remain rejected with precise
+messages.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis, WrinkleSpec
+
+_ANGLES_8 = [0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0]
+
+
+def _two_wrinkle_config(**overrides):
+    """Two identical wrinkles centred at x = L/2 ± 8 mm (disjoint supports).
+
+    Each spec: lambda = 8, width = 2 -> support = center ± 6 mm.
+    phase_offset = ±2*pi shifts the centre by ±lambda = ±8 mm.
+    """
+    spec = dict(amplitude=0.15, wavelength=8.0, width=2.0, ply_interface=3)
+    defaults = dict(
+        amplitude=0.15, wavelength=8.0, width=2.0,
+        morphology="graded", loading="compression",
+        angles=list(_ANGLES_8),
+        wrinkles=[
+            WrinkleSpec(**spec, phase_offset=-2.0 * np.pi),
+            WrinkleSpec(**spec, phase_offset=+2.0 * np.pi),
+        ],
+        nx=32, ny=2, nz_per_ply=1,
+    )
+    defaults.update(overrides)
+    return AnalysisConfig(**defaults)
+
+
+def _element_x_centroids(mesh) -> np.ndarray:
+    return mesh.nodes[mesh.elements].mean(axis=1)[:, 0]
+
+
+class TestMultiWrinkleFE:
+
+    def test_two_wrinkles_fe_runs_with_local_fi_peaks(self):
+        """FE solve runs for 2 non-overlapping wrinkles and produces a
+        local max-FI peak near each wrinkle centre."""
+        cfg = _two_wrinkle_config()
+        result = WrinkleAnalysis(cfg).run()
+
+        assert result.field_results is not None
+        assert result.failure_indices, "failure evaluation must run"
+
+        # Combined per-element max FI across criteria and Gauss points.
+        fi = np.max(
+            np.stack([
+                np.asarray(arr).max(axis=1)
+                for arr in result.failure_indices.values()
+            ]),
+            axis=0,
+        )
+        x_c = _element_x_centroids(result.mesh)
+        L = cfg.domain_length
+        centers = (L / 2.0 - 8.0, L / 2.0 + 8.0)
+
+        # The global FI maximum must sit inside one of the two wrinkle
+        # supports (the wrinkles, not the far field, govern).
+        x_peak = x_c[int(np.argmax(fi))]
+        assert any(abs(x_peak - c) < 6.0 for c in centers), (
+            f"global FI peak at x={x_peak:.1f} mm is outside both "
+            f"wrinkle supports {centers}"
+        )
+
+        # Each wrinkle produces a local elevation above the far field.
+        # (LaRC05 carries a uniform baseline FI under compression, so
+        # the peaks are elevations on that baseline, not zero-to-one.)
+        far = np.ones_like(x_c, dtype=bool)
+        for center in centers:
+            far &= np.abs(x_c - center) > 6.0
+        assert far.any()
+        peaks = []
+        for center in centers:
+            near = np.abs(x_c - center) < 4.0      # within lambda/2
+            assert near.any()
+            assert fi[near].max() > 1.1 * fi[far].max(), (
+                f"expected a local FI peak near x={center:.1f} mm"
+            )
+            peaks.append(fi[near].max())
+        # Identical wrinkles -> the two local peaks agree closely.
+        assert peaks[0] == pytest.approx(peaks[1], rel=0.05)
+
+    def test_domain_sized_from_union_of_extents(self):
+        cfg = _two_wrinkle_config()
+        # half-span = |dx| + 3*width = 8 + 6 = 14 -> L = 28 (> 3*lambda).
+        assert cfg.domain_length == pytest.approx(28.0)
+
+    def test_single_spec_matches_scalar_graded_path(self):
+        """A one-entry wrinkles list is tolerance-equal to the scalar
+        graded config it denotes (same placement, same mesh density,
+        same domain)."""
+        common = dict(
+            amplitude=0.15, wavelength=16.0, width=8.0,
+            morphology="graded", loading="compression",
+            angles=list(_ANGLES_8),
+            nx=16, ny=2, nz_per_ply=1,
+            domain_length=48.0,
+        )
+        scalar_cfg = AnalysisConfig(**common, interface_1=3)
+        multi_cfg = AnalysisConfig(
+            **common,
+            wrinkles=[
+                WrinkleSpec(
+                    amplitude=0.15, wavelength=16.0, width=8.0,
+                    ply_interface=3, phase_offset=0.0,
+                )
+            ],
+        )
+        r_scalar = WrinkleAnalysis(scalar_cfg).run()
+        r_multi = WrinkleAnalysis(multi_cfg).run()
+
+        assert r_multi.modulus_retention == pytest.approx(
+            r_scalar.modulus_retention, rel=1e-9
+        )
+        for crit, arr in r_scalar.failure_indices.items():
+            np.testing.assert_allclose(
+                r_multi.failure_indices[crit], arr, rtol=1e-9,
+                err_msg=f"{crit} FI field diverged between the scalar "
+                "graded path and the one-entry wrinkles path",
+            )
+
+    def test_overlapping_wrinkles_rejected_with_precise_message(self):
+        cfg = _two_wrinkle_config()
+        # Pull the second wrinkle onto the first: supports overlap.
+        cfg.wrinkles[1].phase_offset = 0.5 * np.pi  # dx = +2 mm
+        with pytest.raises(NotImplementedError, match="overlap longitudinally"):
+            WrinkleAnalysis(cfg).run()
+
+    def test_overlapping_wrinkles_still_run_analytically(self):
+        cfg = _two_wrinkle_config()
+        cfg.wrinkles[1].phase_offset = 0.5 * np.pi
+        r = WrinkleAnalysis(cfg).run(analytical_only=True)
+        assert 0.0 < r.analytical_knockdown <= 1.0
+
+    def test_multi_wrinkle_czm_rejected_with_precise_message(self):
+        cfg = _two_wrinkle_config(enable_czm=True)
+        with pytest.raises(NotImplementedError, match="cohesive"):
+            WrinkleAnalysis(cfg).run()

--- a/tests/test_validation/ledger.json
+++ b/tests/test_validation/ledger.json
@@ -1,0 +1,92 @@
+{
+  "_comment": [
+    "WrinkleFE validation ledger — machine-readable companion to VALIDATION.md.",
+    "Each case carries the full AnalysisConfig recipe (the 'harness reference",
+    "configuration'), the measured experimental knockdown, and a pinned",
+    "expected_analytical_kd computed by the current code. The pinned values are",
+    "REGRESSION BASELINES, not claims of experimental agreement: scripts/validate.py",
+    "recomputes them and fails if they move beyond rel_tolerance, which is the",
+    "reproducible-harness precondition named in issue #254 (and the revert of",
+    "00584b4) for re-landing the graded compression decay fix. Re-pin deliberately",
+    "with 'python scripts/validate.py --update' after an intentional model change.",
+    "NOTE: the 'KD analytical' column published in VALIDATION.md for Li (2025) was",
+    "produced by an uncommitted script whose configuration could not be reproduced",
+    "from a clean checkout — exactly the gap this ledger closes going forward.",
+    "Elhajjar (2025), Mukhopadhyay (2015) and Li (2026) case-level data are not in",
+    "the repository (see README 'Validation'); add their datasets here when the",
+    "raw points land (tracked by issue #22's follow-ups)."
+  ],
+  "rel_tolerance": 0.001,
+  "datasets": [
+    {
+      "name": "li_2025_multi_wrinkle_compression",
+      "reference": "Li, Li, Ge & Liang (2025), Polymer Composites 46(16):15176-15187, DOI 10.1002/pc.30121",
+      "status": "deferred — pending issue #161 (amplitude effect at constant peak angle); see VALIDATION.md",
+      "material": "AC318_S6C10",
+      "layup": "[0]_14",
+      "ply_thickness_mm": 0.44,
+      "loading": "compression",
+      "morphology": "graded",
+      "amplitude_convention": "config amplitude = peak-to-peak A / 2 (crest height)",
+      "width_convention": "config width = wavelength (Gaussian 1/e length of one period)",
+      "pristine_strength_MPa": 335.52,
+      "cases": [
+        {
+          "case": "S-M-1",
+          "amplitude_p2p_mm": 1.5,
+          "wavelength_mm": 26.0,
+          "peak_angle_deg": 10,
+          "measured_strength_MPa": 298.81,
+          "measured_kd": 0.891,
+          "expected_analytical_kd": 0.428859
+        },
+        {
+          "case": "S-M-2",
+          "amplitude_p2p_mm": 1.5,
+          "wavelength_mm": 12.9,
+          "peak_angle_deg": 20,
+          "measured_strength_MPa": 211.1,
+          "measured_kd": 0.629,
+          "expected_analytical_kd": 0.308699
+        },
+        {
+          "case": "S-M-3",
+          "amplitude_p2p_mm": 1.5,
+          "wavelength_mm": 8.1,
+          "peak_angle_deg": 30,
+          "measured_strength_MPa": 158.41,
+          "measured_kd": 0.472,
+          "expected_analytical_kd": 0.247616
+        },
+        {
+          "case": "S-M-4",
+          "amplitude_p2p_mm": 1.0,
+          "wavelength_mm": 8.6,
+          "peak_angle_deg": 20,
+          "measured_strength_MPa": 316.34,
+          "measured_kd": 0.943,
+          "expected_analytical_kd": 0.316646
+        },
+        {
+          "case": "S-M-5",
+          "amplitude_p2p_mm": 0.5,
+          "wavelength_mm": 4.3,
+          "peak_angle_deg": 20,
+          "measured_strength_MPa": 335.63,
+          "measured_kd": 1.0,
+          "expected_analytical_kd": 0.36273
+        },
+        {
+          "case": "S-A-2",
+          "amplitude_p2p_mm": 1.5,
+          "wavelength_mm": 12.9,
+          "peak_angle_deg": 20,
+          "measured_strength_MPa": 329.29,
+          "measured_kd": 0.981,
+          "expected_analytical_kd": 0.308699,
+          "note": "S-M-2 geometry at a near-surface interface; the model has no through-thickness wrinkle-position parameter, so the harness runs the mid-plane configuration (prediction identical to S-M-2 by construction)."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_validation/test_ledger.py
+++ b/tests/test_validation/test_ledger.py
@@ -54,51 +54,58 @@ def test_validate_script_passes():
 
 
 # --------------------------------------------------------------------------- #
-# Issue #254 defect documentation — strict xfail flips when the fix lands
+# Issue #254 — decay_floor symmetric under sign-flipped load
 # --------------------------------------------------------------------------- #
 
 
 def _graded_kd(loading: str, decay_floor: float) -> float:
-    # Quasi-isotropic IM7/8552: the tension path's decay_floor handling
-    # is exercised by multi-angle layups (a UD stack shows no effect on
-    # either path), which makes the compression-side inertness visible
-    # as an asymmetry rather than a shared no-op.
+    # Quasi-isotropic layup on a config whose through-thickness Gaussian
+    # actually decays inside the laminate: 24 plies (T = 4.39 mm) with an
+    # explicit 0.5 mm decay scale, so the surface plies see raw ~ 0 and
+    # the floor governs how much angle they retain.
     cfg = AnalysisConfig(
         amplitude=0.75, wavelength=12.9, width=12.9,
         morphology="graded", decay_floor=decay_floor, loading=loading,
-        angles=[0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0],
+        angles=[0.0, 45.0, -45.0, 90.0] * 3
+        + [90.0, -45.0, 45.0, 0.0] * 3,
+        through_thickness_decay_scale=0.5,
     )
     return float(
         WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="issue #254: decay_floor is inert on the graded compression "
-    "path (honored in tension). When the re-landed fix makes it "
-    "effective, this xfail flips and must be converted to a real test.",
-)
-def test_decay_floor_affects_compression_issue_254():
-    kd_floor0 = _graded_kd("compression", 0.0)
-    kd_floor1 = _graded_kd("compression", 0.9)
-    assert kd_floor0 != pytest.approx(kd_floor1), (
-        "decay_floor=0.0 and 0.9 produce identical compression knockdown"
+@pytest.mark.parametrize("loading", ["compression", "tension"])
+def test_decay_floor_effective_under_both_loadings_issue_254(loading):
+    """decay_floor produces the same envelope semantics under a
+    sign-flipped load: raising the floor retains more misalignment in
+    the outer plies and monotonically lowers the knockdown, in tension
+    AND compression. (Before the #254 fix, compression ignored the
+    floor entirely while tension honored it.)"""
+    kds = [_graded_kd(loading, f) for f in (0.0, 0.5, 1.0)]
+    assert kds[0] > kds[1] > kds[2], (
+        f"{loading}: KD must decrease monotonically as decay_floor "
+        f"retains more angle, got {kds}"
     )
+    # The floor must have a material effect, not a numerical whisper.
+    assert kds[0] - kds[2] > 0.01
 
 
-def test_decay_floor_compression_tension_asymmetry_is_current_behavior():
-    """Pin the asymmetry itself: tension honors decay_floor, compression
-    does not. Documents the user-visible inconsistency named in #254;
-    delete together with the xfail above when the fix lands."""
-    comp_delta = abs(
-        _graded_kd("compression", 0.0) - _graded_kd("compression", 0.9)
+def test_decay_floor_one_disables_compression_decay():
+    """floor=1.0 means every ply keeps the full angle — identical to a
+    decay scale so large the Gaussian never drops below ~1."""
+    kd_floor1 = _graded_kd("compression", 1.0)
+    cfg = AnalysisConfig(
+        amplitude=0.75, wavelength=12.9, width=12.9,
+        morphology="graded", decay_floor=0.0, loading="compression",
+        angles=[0.0, 45.0, -45.0, 90.0] * 3
+        + [90.0, -45.0, 45.0, 0.0] * 3,
+        through_thickness_decay_scale=1.0e6,
     )
-    tens_delta = abs(
-        _graded_kd("tension", 0.0) - _graded_kd("tension", 0.9)
+    kd_nodecay = float(
+        WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
     )
-    assert comp_delta == pytest.approx(0.0, abs=1e-12)
-    assert tens_delta > 1e-6
+    assert kd_floor1 == pytest.approx(kd_nodecay, rel=1e-9)
 
 
 def test_ledger_recipe_round_trips_config():

--- a/tests/test_validation/test_ledger.py
+++ b/tests/test_validation/test_ledger.py
@@ -1,0 +1,125 @@
+"""Validation-ledger regression harness (issue #254, deliverable 1).
+
+Recomputes every case in ``ledger.json`` and asserts the analytical
+knockdown matches the pinned baseline within the ledger's tolerance —
+the committed, reproducible harness whose absence forced the revert of
+the graded-decay fix (commit ``00584b4``). Also documents the two #254
+defects as strict xfails so that fixing them flips these tests loudly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+
+_HERE = Path(__file__).resolve().parent
+_LEDGER = json.loads((_HERE / "ledger.json").read_text())
+
+_spec = importlib.util.spec_from_file_location(
+    "validate", _HERE.parents[1] / "scripts" / "validate.py"
+)
+validate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(validate)
+
+
+def _all_cases():
+    for dataset in _LEDGER["datasets"]:
+        for case in dataset["cases"]:
+            yield pytest.param(
+                dataset, case, id=f"{dataset['name']}-{case['case']}"
+            )
+
+
+@pytest.mark.parametrize(("dataset", "case"), list(_all_cases()))
+def test_case_matches_pinned_baseline(dataset, case):
+    predicted = validate.run_case(dataset, case)
+    pinned = case["expected_analytical_kd"]
+    tol = _LEDGER["rel_tolerance"]
+    assert predicted == pytest.approx(pinned, rel=tol), (
+        f"{case['case']} analytical KD drifted from the pinned baseline "
+        f"({predicted} vs {pinned}). If intentional, re-pin via "
+        f"'python scripts/validate.py --update' and explain the move."
+    )
+
+
+def test_validate_script_passes():
+    """The one-command harness exits 0 from a clean checkout."""
+    assert validate.main([]) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Issue #254 defect documentation — strict xfail flips when the fix lands
+# --------------------------------------------------------------------------- #
+
+
+def _graded_kd(loading: str, decay_floor: float) -> float:
+    # Quasi-isotropic IM7/8552: the tension path's decay_floor handling
+    # is exercised by multi-angle layups (a UD stack shows no effect on
+    # either path), which makes the compression-side inertness visible
+    # as an asymmetry rather than a shared no-op.
+    cfg = AnalysisConfig(
+        amplitude=0.75, wavelength=12.9, width=12.9,
+        morphology="graded", decay_floor=decay_floor, loading=loading,
+        angles=[0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0],
+    )
+    return float(
+        WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="issue #254: decay_floor is inert on the graded compression "
+    "path (honored in tension). When the re-landed fix makes it "
+    "effective, this xfail flips and must be converted to a real test.",
+)
+def test_decay_floor_affects_compression_issue_254():
+    kd_floor0 = _graded_kd("compression", 0.0)
+    kd_floor1 = _graded_kd("compression", 0.9)
+    assert kd_floor0 != pytest.approx(kd_floor1), (
+        "decay_floor=0.0 and 0.9 produce identical compression knockdown"
+    )
+
+
+def test_decay_floor_compression_tension_asymmetry_is_current_behavior():
+    """Pin the asymmetry itself: tension honors decay_floor, compression
+    does not. Documents the user-visible inconsistency named in #254;
+    delete together with the xfail above when the fix lands."""
+    comp_delta = abs(
+        _graded_kd("compression", 0.0) - _graded_kd("compression", 0.9)
+    )
+    tens_delta = abs(
+        _graded_kd("tension", 0.0) - _graded_kd("tension", 0.9)
+    )
+    assert comp_delta == pytest.approx(0.0, abs=1e-12)
+    assert tens_delta > 1e-6
+
+
+def test_ledger_recipe_round_trips_config():
+    """The ledger carries everything needed to rebuild each config."""
+    dataset = _LEDGER["datasets"][0]
+    case = dataset["cases"][0]
+    cfg = validate.case_config(dataset, case)
+    assert cfg.amplitude == pytest.approx(case["amplitude_p2p_mm"] / 2.0)
+    assert cfg.wavelength == pytest.approx(case["wavelength_mm"])
+    assert len(cfg.angles) == 14 and set(cfg.angles) == {0.0}
+    assert cfg.material.name == dataset["material"]
+
+
+def test_replace_preserves_ledger_predictions():
+    """dataclasses.replace on a ledger config does not perturb the KD
+    (guards the sweep/convergence helpers that clone configs)."""
+    dataset = _LEDGER["datasets"][0]
+    case = dataset["cases"][0]
+    cfg = validate.case_config(dataset, case)
+    kd1 = WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
+    kd2 = WrinkleAnalysis(replace(cfg)).run(
+        analytical_only=True
+    ).analytical_knockdown
+    assert kd1 == pytest.approx(kd2, rel=1e-12)


### PR DESCRIPTION
Fixes #255. Fixes #254. Refs #252 (Stage 1 of 2).

Four additive commits:

## `cc22661` — Sphinx documentation site (#255)
New `docs/` tree (Sphinx + myst-parser + napoleon + autodoc). Root markdown docs included via myst `{include}` (single source of truth); API reference covers the full public surface; pyvista mocked. New `docs` CI job runs `sphinx-build -W` (green on this PR); `.readthedocs.yaml` (`fail_on_warning`); `docs` extra; `[project.urls]` + README link. Two source docstrings fixed for `-W`.

## `61c4db4` — committed validation harness (#254 deliverable 1)
- `tests/test_validation/ledger.json` — per-case recipe, measured KD, pinned analytical baseline (seeded with the six Li-2025 cases).
- `scripts/validate.py` — one command: recompute, compare with tolerance, MAE report, exit 1 on drift; `--update` re-pins deliberately.
- `tests/test_validation/test_ledger.py` — same comparisons in CI.
- Honesty note in ledger + VALIDATION.md: the published Li-2025 "KD analytical" column came from an uncommitted, unreproducible script — the exact gap this closes.

## `a275b7a` — graded compression `decay_floor` fix (#254 deliverable 2)
Compression ignored `decay_floor` while tension honored it; now `Φ = floor + (1 − floor)·gaussian(z)` matches the tension floor semantics. Defaults preserve current results bit-for-bit (zero ledger drift; 89 graded-path integration tests unchanged). The decay-length half of #254 was already resolved via `through_thickness_decay_scale`. Acceptance test: sign-flipped load, KD strictly decreasing with floor in both modes; `floor=1.0` ≡ no-decay.

## `e81538d` — multi-wrinkle FE solve, Stage 1 (#252)
`WrinkleConfiguration.apply_to_nodes` / `fiber_angles_at_nodes` already superpose N placements, so the blanket `NotImplementedError` was rejecting representable configurations. Now:
- Non-overlapping wrinkles (Li-2025 layout) run the full FE path; domain auto-sizes from the union of wrinkle extents (phase-offset centre ± 3·width, 3λ floor).
- Precise rejections remain for longitudinally overlapping wrinkles (Stage 2; message names the pair and supports) and multi-wrinkle CZM; both still run `analytical_only`.
- Tests: two-wrinkle FE solve with per-wrinkle local FI peaks (global peak inside a support; ≥1.1× far-field elevation on the uniform LaRC05 baseline; twin peaks agree within 5%); one-entry `wrinkles` list tolerance-equal (rtol 1e-9) to the scalar graded path across modulus retention and every FI field; domain sizing, overlap message, analytical fallback, CZM rejection pinned.

## Verification
- `sphinx-build -W` exits 0 locally + CI; `scripts/validate.py` zero drift; `tests/test_validation` 12 passed; 16 multi-wrinkle tests passed; 50-test analysis/sweep/progress regression batch passed; CI starter-scope ruff clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis