### PR TITLE
morphology: compose-then-differentiate fiber angles; multi-wrinkle FE Stage 2 (#252)

### DIFF
--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -376,11 +376,12 @@ def _profile_proportional_kd(
 def _check_multi_wrinkle_fe_support(cfg: "AnalysisConfig") -> None:
     """Reject multi-wrinkle FE configs the pipeline cannot represent yet.
 
-    Issue #252 Stage 1 supports N wrinkles whose longitudinal supports
-    (center offset from the phase, ± 3*width Gaussian extent) do not
-    overlap — the Li (2025) specimen layout. Overlapping wrinkles and
-    the CZM pathway remain analytical-only and are rejected with a
-    message that states exactly what is unsupported.
+    Issue #252: arbitrary N-wrinkle layouts — including longitudinally
+    overlapping and interacting wrinkles — run through the FE path; the
+    displacement and fiber-angle fields both derive from the composed
+    wrinkle field ("compose then differentiate"). Only the CZM pathway
+    remains analytical-only, because cohesive interface placement
+    assumes a single wrinkle crest.
     """
     if cfg.enable_czm:
         raise NotImplementedError(
@@ -389,22 +390,6 @@ def _check_multi_wrinkle_fe_support(cfg: "AnalysisConfig") -> None:
             "single wrinkle crest. Run with enable_czm=False or pass "
             "analytical_only=True."
         )
-    center = cfg.domain_length / 2.0
-    spans = []
-    for i, spec in enumerate(cfg.wrinkles):
-        c = center + spec.phase_offset * spec.wavelength / (2.0 * math.pi)
-        spans.append((c - 3.0 * spec.width, c + 3.0 * spec.width, i))
-    spans.sort()
-    for (lo1, hi1, i), (lo2, hi2, j) in zip(spans, spans[1:]):
-        if lo2 < hi1:
-            raise NotImplementedError(
-                f"Wrinkles {i} and {j} overlap longitudinally (supports "
-                f"[{lo1:.2f}, {hi1:.2f}] and [{lo2:.2f}, {hi2:.2f}] mm, "
-                "using the 3*width Gaussian extent). The FE solve "
-                "currently supports non-overlapping wrinkles only "
-                "(issue #252 Stage 1) — separate them via phase_offset "
-                "or pass analytical_only=True."
-            )
 
 
 def _max_consecutive_zero_plies(angles: List[float], tol: float = 5.0) -> int:
@@ -1530,9 +1515,9 @@ class WrinkleAnalysis:
         if analytical_only is None:
             analytical_only = cfg.analytical_only
 
-        # Multi-wrinkle FE solve supports non-overlapping wrinkles along
-        # the length (issue #252 Stage 1). Reject the still-unsupported
-        # shapes early, with a precise message, rather than failing
+        # Multi-wrinkle FE solve (issue #252): overlapping and
+        # non-overlapping layouts both run; only the CZM pathway is
+        # rejected (early, with a precise message) rather than failing
         # mid-pipeline.
         if cfg.wrinkles is not None and not analytical_only:
             _check_multi_wrinkle_fe_support(cfg)

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -878,14 +878,21 @@ class WrinkleConfiguration:
     ) -> np.ndarray:
         """Compute local fiber misalignment angle at each node.
 
-        For nodes within the wrinkle zone, the angle is computed as
-        arctan(dz/dx) from the wrinkle profile slope. Each node receives
-        the angle contribution from the wrinkle affecting its ply
-        interface. Nodes outside any wrinkle zone receive angle = 0.
+        The angle is the slope of the **composed** displacement field —
+        the same field :meth:`apply_to_nodes` applies to the mesh
+        (issue #252, "compose then differentiate"): per-wrinkle signed
+        slopes, scaled by the same through-thickness decay and amplitude
+        modulation as the displacement, are summed and the angle is
+        ``arctan(|dz_total/dx|)``. Nodes outside every wrinkle zone
+        receive angle = 0.
 
-        When multiple wrinkles affect the same ply (via through-thickness
-        decay), the angles are combined as the root-sum-square, reflecting
-        independent misalignment contributions.
+        Because displacement and angle derive from one field, two
+        coincident half-amplitude wrinkles are exactly equivalent to a
+        single full-amplitude wrinkle, and phase-opposed wrinkles cancel
+        consistently in both fields. (The pre-#252 convention combined
+        per-wrinkle *angles* root-sum-square and scaled the angle — not
+        the slope — by the decay, which broke that identity and let the
+        angle field disagree with the geometry the mesh actually sees.)
 
         Parameters
         ----------
@@ -911,16 +918,21 @@ class WrinkleConfiguration:
 
         Notes
         -----
-        The fiber angle at a point is determined by the local slope of
-        the wrinkle profile (Jin et al., 2026, Eq. 3):
+        The fiber angle at a point is the slope of the deformed surface
+        the node actually sits on (Jin et al., 2026, Eq. 3):
 
         .. math::
 
-            \\theta(x) = \\arctan\\left|\\frac{dz}{dx}\\right|
+            \\theta(x) = \\arctan\\left|\\frac{dz_{total}}{dx}\\right|,
+            \\qquad
+            \\frac{dz_{total}}{dx}
+            = \\sum_w \\frac{dz_w}{dx}\\,\\Phi_w(p)\\,s_w(x, y)
 
-        For multi-wrinkle configurations, the effective local angle uses
-        root-sum-square combination to avoid double-counting while capturing
-        the aggregate misalignment.
+        with :math:`\\Phi_w` the through-thickness decay and :math:`s_w`
+        the in-plane amplitude modulation — the identical factors used
+        by the displacement composition in :meth:`apply_to_nodes`
+        (their slow in-plane variation is treated as locally constant,
+        as before).
         """
         n_nodes = len(nodes)
         if n_plies is None:
@@ -929,7 +941,7 @@ class WrinkleConfiguration:
             # array must pass the explicit n_plies (the same value given
             # to apply_to_nodes) so both decay fields stay synced (#146).
             n_plies = int(ply_ids.max()) + 1 if len(ply_ids) > 0 else 1
-        angle_sq = np.zeros(n_nodes, dtype=np.float64)
+        slope_total = np.zeros(n_nodes, dtype=np.float64)
 
         x = nodes[:, 0]
         y = nodes[:, 1] if nodes.shape[1] >= 2 else np.zeros(n_nodes)
@@ -948,10 +960,9 @@ class WrinkleConfiguration:
             amp_scale = self._amplitude_scale_vec(wrinkle, x, y)
             decay = self._through_thickness_decay(ply_ids, k, n_plies) * amp_scale
 
-            angle = np.arctan(np.abs(slope)) * decay
-            angle_sq += angle * angle
+            slope_total += slope * decay
 
-        return np.sqrt(angle_sq)
+        return np.arctan(np.abs(slope_total))
 
     # ------------------------------------------------------------------
     # Convenience constructors

--- a/tests/test_integration/test_multi_wrinkle.py
+++ b/tests/test_integration/test_multi_wrinkle.py
@@ -164,13 +164,13 @@ class TestMultiWrinkleValidation:
         with pytest.raises(ValueError, match="ply_interface"):
             _build_cfg(ac318_material, ud14_angles, bad)
 
-    def test_fe_solve_rejects_overlapping_wrinkles(
+    def test_fe_solve_rejects_multi_wrinkle_czm(
         self, ac318_material, ud14_angles
     ):
-        """Overlapping wrinkles + FE solve raise a precise
-        NotImplementedError (issue #252 Stage 1 supports non-overlapping
-        wrinkles only; see tests/test_integration/test_multi_wrinkle_fe.py
-        for the supported path)."""
+        """Multi-wrinkle + CZM raises a precise NotImplementedError
+        (cohesive interface placement assumes a single crest); the FE
+        path itself supports arbitrary N-wrinkle layouts since #252 —
+        see tests/test_integration/test_multi_wrinkle_fe.py."""
         wrinkles = [
             WrinkleSpec(amplitude=1.5, wavelength=12.9, width=12.9,
                         ply_interface=4),
@@ -178,12 +178,11 @@ class TestMultiWrinkleValidation:
                         ply_interface=6, phase_offset=0.5),
         ]
         cfg = _build_cfg(
-            ac318_material, ud14_angles, wrinkles, analytical_only=False
+            ac318_material, ud14_angles, wrinkles, analytical_only=False,
+            enable_czm=True,
         )
         analysis = WrinkleAnalysis(cfg)
-        with pytest.raises(
-            NotImplementedError, match="overlap longitudinally"
-        ):
+        with pytest.raises(NotImplementedError, match="cohesive"):
             analysis.run(analytical_only=False)
 
 

--- a/tests/test_integration/test_multi_wrinkle_fe.py
+++ b/tests/test_integration/test_multi_wrinkle_fe.py
@@ -1,11 +1,11 @@
-"""FE solve for multi-wrinkle configurations (issue #252, Stage 1).
+"""FE solve for multi-wrinkle configurations (issue #252).
 
-Stage 1 supports N wrinkles whose longitudinal supports do not overlap
-(the Li 2025 specimen layout): the composed displacement / fiber-angle
-fields come from ``WrinkleConfiguration.apply_to_nodes`` /
-``fiber_angles_at_nodes``, which already superpose N placements.
-Overlapping wrinkles and the CZM pathway remain rejected with precise
-messages.
+Stage 1: N wrinkles with disjoint longitudinal supports (the Li 2025
+specimen layout). Stage 2: overlapping/interacting wrinkles — both the
+displacement and the fiber-angle field derive from the composed wrinkle
+field ("compose then differentiate"), so two coincident half-amplitude
+wrinkles reproduce the single full-amplitude result exactly. Only the
+CZM pathway remains rejected, with a precise message.
 """
 
 from __future__ import annotations
@@ -131,12 +131,61 @@ class TestMultiWrinkleFE:
                 "graded path and the one-entry wrinkles path",
             )
 
-    def test_overlapping_wrinkles_rejected_with_precise_message(self):
+    def test_coincident_half_wrinkles_equal_full_amplitude(self):
+        """Issue #252 Stage 2 regression: two coincident half-amplitude
+        wrinkles reproduce the single full-amplitude result — exact
+        under compose-then-differentiate, where displacement and fiber
+        angle both derive from the composed field."""
+        common = dict(
+            wavelength=16.0, width=8.0,
+            morphology="graded", loading="compression",
+            angles=list(_ANGLES_8),
+            nx=16, ny=2, nz_per_ply=1,
+            domain_length=48.0,
+        )
+        spec = dict(wavelength=16.0, width=8.0, ply_interface=3,
+                    phase_offset=0.0)
+        full = AnalysisConfig(
+            **common, amplitude=0.15,
+            wrinkles=[WrinkleSpec(amplitude=0.15, **spec)],
+        )
+        halves = AnalysisConfig(
+            **common, amplitude=0.15,
+            wrinkles=[
+                WrinkleSpec(amplitude=0.075, **spec),
+                WrinkleSpec(amplitude=0.075, **spec),
+            ],
+        )
+        r_full = WrinkleAnalysis(full).run()
+        r_halves = WrinkleAnalysis(halves).run()
+
+        np.testing.assert_allclose(
+            r_halves.mesh.nodes, r_full.mesh.nodes, rtol=0, atol=1e-12,
+            err_msg="coincident halves must deform the mesh identically",
+        )
+        np.testing.assert_allclose(
+            r_halves.mesh.fiber_angles, r_full.mesh.fiber_angles,
+            rtol=0, atol=1e-12,
+            err_msg="coincident halves must produce the same angle field",
+        )
+        assert r_halves.modulus_retention == pytest.approx(
+            r_full.modulus_retention, rel=1e-9
+        )
+        for crit, arr in r_full.failure_indices.items():
+            np.testing.assert_allclose(
+                r_halves.failure_indices[crit], arr, rtol=1e-9,
+                err_msg=f"{crit} FI field diverged between coincident "
+                "halves and the full-amplitude wrinkle",
+            )
+
+    def test_overlapping_wrinkles_run_through_fe(self):
+        """Stage 2: longitudinally overlapping wrinkles solve end-to-end."""
         cfg = _two_wrinkle_config()
-        # Pull the second wrinkle onto the first: supports overlap.
-        cfg.wrinkles[1].phase_offset = 0.5 * np.pi  # dx = +2 mm
-        with pytest.raises(NotImplementedError, match="overlap longitudinally"):
-            WrinkleAnalysis(cfg).run()
+        cfg.wrinkles[1].phase_offset = 0.5 * np.pi  # dx = +2 mm: overlap
+        r = WrinkleAnalysis(cfg).run()
+        assert r.field_results is not None
+        assert r.failure_indices
+        assert 0.0 < r.modulus_retention <= 1.0
 
     def test_overlapping_wrinkles_still_run_analytically(self):
         cfg = _two_wrinkle_config()

--- a/tests/test_morphology_amplitude_profile.py
+++ b/tests/test_morphology_amplitude_profile.py
@@ -297,7 +297,12 @@ class TestGeometryAngleParity:
         nonzero = np.abs(dz_base[mask]) > 1e-12
         ratio_dz = dz_mod[mask][nonzero] / dz_base[mask][nonzero]
         nonzero_ang = np.abs(ang_base[mask]) > 1e-12
-        ratio_ang = ang_mod[mask][nonzero_ang] / ang_base[mask][nonzero_ang]
+        # Composed-field angles (#252): the amplitude scale multiplies
+        # the slope, so the ratio is recovered in tan space.
+        ratio_ang = (
+            np.tan(ang_mod[mask][nonzero_ang])
+            / np.tan(ang_base[mask][nonzero_ang])
+        )
         # Both ratios must equal the Gaussian scale at the same x.
         # Use the displacement-side ratio as ground truth and compare.
         npt.assert_allclose(ratio_dz.mean(), ratio_ang.mean(), rtol=1e-12)

--- a/tests/test_morphology_apply_nodes.py
+++ b/tests/test_morphology_apply_nodes.py
@@ -261,8 +261,10 @@ class TestGradedDecayParity:
     """Regression for the asymmetric clamp-order drift flagged in
     #32 / #40: with a *fully spanning* ply_ids array, the decay implicit
     in ``apply_to_nodes`` (dz / profile(x)) must equal the decay implicit
-    in ``fiber_angles_at_nodes`` (angle / arctan|slope|) across a sweep of
-    ``decay_floor`` and ply index."""
+    in ``fiber_angles_at_nodes`` across a sweep of ``decay_floor`` and
+    ply index. Since #252 the angle is the slope of the composed field
+    (``arctan(decay * |slope|)``), so the angle-side decay is recovered
+    in slope space: ``tan(angle) / |slope|``."""
 
     @pytest.mark.parametrize("decay_floor", [0.0, 0.25, 0.5, 1.0])
     @pytest.mark.parametrize("n_plies", [4, 7, 8])
@@ -278,7 +280,7 @@ class TestGradedDecayParity:
         )
         x = 2.0  # non-zero slope and non-zero displacement here
         prof_val = prof.displacement(np.array([x]))[0]
-        ang_base = np.arctan(np.abs(prof.slope(np.array([x]))[0]))
+        slope_base = np.abs(prof.slope(np.array([x]))[0])
 
         # ply_ids spans the full laminate so fiber_angles_at_nodes infers
         # the same n_plies that apply_to_nodes is given (see issue #146).
@@ -287,9 +289,9 @@ class TestGradedDecayParity:
         ang = cfg.fiber_angles_at_nodes(nodes, ply)
 
         decay_from_disp = dz / prof_val
-        decay_from_angle = ang / ang_base
+        decay_from_slope = np.tan(ang) / slope_base
         npt.assert_allclose(
-            decay_from_disp, decay_from_angle, rtol=1e-12, atol=1e-14
+            decay_from_disp, decay_from_slope, rtol=1e-12, atol=1e-14
         )
 
 
@@ -375,12 +377,13 @@ class TestFiberAnglesSlopeMagnitude:
 # fiber_angles_at_nodes -- dual-wrinkle RSS combination
 # ----------------------------------------------------------------------
 
-class TestFiberAnglesDualWrinkleRSS:
-    """Two identical co-located wrinkles (phase=0) combine as
-    root-sum-square -> sqrt(2) x the single-wrinkle angle. With phase=pi
-    the displacement fields partly cancel."""
+class TestFiberAnglesDualWrinkleComposed:
+    """Angles derive from the composed displacement field (#252):
+    two identical co-located wrinkles (phase=0) double the slope, so
+    the dual angle is ``arctan(2 * tan(single))``. With phase=pi the
+    displacement fields partly cancel."""
 
-    def test_phase0_rss_is_sqrt2_times_single(self, gaussian_wrinkle):
+    def test_phase0_doubles_the_slope(self, gaussian_wrinkle):
         single = _single_config(gaussian_wrinkle, ply_interface=2)
         dual = WrinkleConfiguration.dual_wrinkle(
             gaussian_wrinkle, interface1=2, interface2=2, phase=0.0
@@ -388,7 +391,9 @@ class TestFiberAnglesDualWrinkleRSS:
         nodes, ply = _strip(np.array([2.0]), n_plies=6)
         a_single = single.fiber_angles_at_nodes(nodes, ply)[ply == 2][0]
         a_dual = dual.fiber_angles_at_nodes(nodes, ply)[ply == 2][0]
-        npt.assert_allclose(a_dual, np.sqrt(2.0) * a_single, rtol=1e-12)
+        npt.assert_allclose(
+            a_dual, np.arctan(2.0 * np.tan(a_single)), rtol=1e-12
+        )
 
     def test_phase_pi_partially_cancels_displacement(self, gaussian_wrinkle):
         """Anti-stack (phase=pi) shifts the 2nd wrinkle by lambda/2, so the
@@ -524,7 +529,8 @@ def test_partial_ply_ids_decay_stays_synced():
     ang = cfg.fiber_angles_at_nodes(nodes, ply, n_plies=8)
 
     decay_from_disp = dz / prof_val
-    decay_from_angle = ang / ang_base
+    # Slope-space decay recovery (composed-field angles since #252).
+    decay_from_angle = np.tan(ang) / np.tan(ang_base)
     # Once #146 is fixed these two decay fields will match.
     npt.assert_allclose(
         decay_from_disp, decay_from_angle, rtol=1e-12, atol=1e-14
@@ -620,7 +626,10 @@ class TestIssue17_18DefaultDecayBC:
         ang = cfg.fiber_angles_at_nodes(nodes, ply, n_plies=n_plies)
 
         decay_from_disp = dz / prof_val
-        decay_from_angle = ang / ang_base
+        # Since #252 the angle is the slope of the composed field
+        # (arctan(decay * |slope|)), so the angle-side decay is
+        # recovered in slope space.
+        decay_from_angle = np.tan(ang) / np.tan(ang_base)
         npt.assert_allclose(
             decay_from_disp,
             decay_from_angle,

--- a/tests/test_morphology_graded_decay_shared_path.py
+++ b/tests/test_morphology_graded_decay_shared_path.py
@@ -112,10 +112,10 @@ def test_through_thickness_decay_helper_drives_both_methods(monkeypatch):
     profile = cfg.wrinkles[0].profile
     x = nodes[:, 0]
     raw_dz = profile.displacement(x)
-    raw_angle = np.arctan(np.abs(profile.slope(x)))
 
     expected_dz = raw_dz * sentinel_value
-    expected_angle = np.sqrt((raw_angle * sentinel_value) ** 2)
+    # Composed-field angles (#252): decay scales the slope, not the angle.
+    expected_angle = np.arctan(np.abs(profile.slope(x)) * sentinel_value)
 
     deformed = cfg.apply_to_nodes(nodes, ply_ids, N_PLIES)
     angles = cfg.fiber_angles_at_nodes(nodes, ply_ids, n_plies=N_PLIES)
@@ -160,11 +160,11 @@ def test_apply_to_nodes_and_fiber_angles_share_graded_decay():
     nodes_steep = np.zeros((N_PLIES, 3), dtype=np.float64)
     nodes_steep[:, 0] = x_steep
     angles = cfg.fiber_angles_at_nodes(nodes_steep, ply_ids, n_plies=N_PLIES)
-    raw_angle = np.arctan(np.abs(profile.slope(nodes_steep[:, 0])))
-    assert raw_angle[0] > 1e-9, "slope at quarter-wavelength should be non-zero"
-    # The angle field RSS-combines a single wrinkle's contribution => same as
-    # raw_angle * decay (positive). Recover decay by dividing.
-    decay_from_angle = angles / raw_angle
+    raw_slope = np.abs(profile.slope(nodes_steep[:, 0]))
+    assert raw_slope[0] > 1e-9, "slope at quarter-wavelength should be non-zero"
+    # Composed-field angles (#252): angle = arctan(decay * |slope|), so
+    # the decay is recovered in slope space.
+    decay_from_angle = np.tan(angles) / raw_slope
 
     # --- The two recovered decay vectors must agree exactly. --------------
     npt.assert_allclose(
@@ -217,8 +217,8 @@ def test_decay_parity_across_modes(decay_mode):
     nodes_steep = np.zeros((N_PLIES, 3), dtype=np.float64)
     nodes_steep[:, 0] = WAVELENGTH / 4.0
     angles = cfg.fiber_angles_at_nodes(nodes_steep, ply_ids, n_plies=N_PLIES)
-    raw_angle = np.arctan(np.abs(profile.slope(nodes_steep[:, 0])))
-    decay_from_angle = angles / raw_angle
+    raw_slope = np.abs(profile.slope(nodes_steep[:, 0]))
+    decay_from_angle = np.tan(angles) / raw_slope
 
     npt.assert_allclose(
         decay_from_disp,

--- a/tests/test_morphology_vectorised_parity.py
+++ b/tests/test_morphology_vectorised_parity.py
@@ -83,7 +83,10 @@ def _legacy_fiber_angles_at_nodes(
     n_plies: int,
 ) -> np.ndarray:
     n_nodes = len(nodes)
-    angle_sq = np.zeros(n_nodes, dtype=np.float64)
+    # Per-node scalar loop mirroring the composed-field semantics of
+    # fiber_angles_at_nodes (issue #252, "compose then differentiate"):
+    # sum the decayed signed slopes, then take arctan of the magnitude.
+    slope_total = np.zeros(n_nodes, dtype=np.float64)
 
     for wrinkle in cfg.wrinkles:
         profile = wrinkle.profile
@@ -111,11 +114,9 @@ def _legacy_fiber_angles_at_nodes(
             else:
                 decay = cfg._ply_decay(p, k, n_plies)
 
-            decay = decay * amp_scale
-            angle = np.arctan(np.abs(slope)) * decay
-            angle_sq[node_idx] += angle ** 2
+            slope_total[node_idx] += slope * decay * amp_scale
 
-    return np.sqrt(angle_sq)
+    return np.arctan(np.abs(slope_total))
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #252 (Stage 2 — completes the issue).

Implements the maintainer-approved **"compose then differentiate"** option from the [design discussion](https://github.com/elhajjar1/wrinkleFE/issues/252#issuecomment-4664841611).

## What
`fiber_angles_at_nodes` now derives the misalignment angle from the slope of the **composed** displacement field — the same field `apply_to_nodes` applies to the mesh: per-wrinkle signed slopes, scaled by the identical through-thickness decay and amplitude modulation, are summed and the angle is `arctan(|Σ slope·Φ·s|)`. Previously per-wrinkle *angles* were combined root-sum-square with the decay scaling the angle rather than the slope, so the angle field could disagree with the actual deformed geometry (two coincident half-amplitude wrinkles gave ~0.707× the full-amplitude angle).

With displacement and angle deriving from one field, the Stage-1 longitudinal-overlap rejection is removed: **arbitrary N-wrinkle layouts now run through the FE path.** Only multi-wrinkle CZM remains rejected (cohesive placement assumes a single crest).

## Numerical consequences, quantified
- **Analytical predictions untouched** — the BF path doesn't use the node-angle field; `scripts/validate.py` reports **zero drift** on every pinned ledger baseline.
- **FE fields shift wherever through-thickness decay < 1** (`arctan(Φ·|s|)` vs `Φ·arctan|s|`) and wherever dual wrinkles overlap (additive slopes vs RSS angles). Tests pinning the old conventions are updated to the new invariants: decay recovery moves to slope space (`tan(angle)/|slope|`), the dual phase-0 identity becomes `arctan(2·tan(single))`, and the vectorised-parity scalar reference mirrors the composed form — each preserving its original regression intent (#17/#18, #32/#40, #146, #185).

## Acceptance test (from the issue)
Two coincident half-amplitude wrinkles reproduce the single full-amplitude result: mesh nodes and angle field equal to 1e-12; modulus retention and every per-criterion FI field to rtol 1e-9. Plus: overlapping wrinkles solve end-to-end, and the CZM rejection is re-pinned.

## Verification
620 tests pass locally across morphology, mesh, solver, failure, CZM, convergence, validation-ledger, and integration suites; `sphinx-build -W` and CI-scope ruff clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_