### PR TITLE
lint: clean the F (pyflakes) family, enforce E,W,I,F in CI (#87)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,13 +28,12 @@ jobs:
           pip install -e ".[dev]"
 
       # Enforced scope: E (pycodestyle errors), W (warnings), I (isort),
-      # plus the F syntax-level starter rules. The remaining families from
-      # pyproject.toml's full config still carry violations and are being
-      # expanded incrementally (issue #87): F ~87 (mostly F401/F841
-      # unused imports/variables), UP ~498 (pyupgrade), N ~1343
+      # F (pyflakes). The remaining families from pyproject.toml's full
+      # config still carry violations and are being expanded
+      # incrementally (issue #87): UP ~498 (pyupgrade), N ~1343
       # (scientific naming -- needs a per-file noqa policy first).
-      - name: Ruff (enforced scope - E,W,I + F starter rules)
-        run: ruff check --select E,W,I,F63,F7,F82 .
+      - name: Ruff (enforced scope - E,W,I,F)
+        run: ruff check --select E,W,I,F .
 
       # Starter scope: package `__init__` only. Broader src/wrinklefe has ~102
       # mypy errors today (mostly numpy `Any` returns + missing stubs); fixing

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import dataclass, fields, replace
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -55,7 +55,6 @@ from wrinklefe.core.morphology import (
 )
 from wrinklefe.core.wrinkle import (
     GaussianSinusoidal,
-    WrinkleProfile,
 )
 from wrinklefe.elements.cohesive8 import (
     Cohesive8Element,
@@ -64,7 +63,7 @@ from wrinklefe.elements.cohesive8 import (
 from wrinklefe.failure.delamination import build_delamination_report
 from wrinklefe.failure.evaluator import FailureEvaluator, LaminateFailureReport
 from wrinklefe.solver.assembler import GlobalAssembler
-from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
+from wrinklefe.solver.boundary import BoundaryHandler
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver
 from wrinklefe.solver.results import FieldResults
 from wrinklefe.solver.static import StaticSolver
@@ -1852,7 +1851,6 @@ class WrinkleAnalysis:
             # the two interfaces straddle the laminate midplane; for
             # single-wrinkle modes there is one wrinkle interface.
             ply_z = laminate.z_coords()  # length n_plies + 1
-            interface_z = 0.5 * (ply_z[1:n_plies] + ply_z[2:n_plies + 1])
             # Note: interface_z[i] is the midpoint between plies i+1 and
             # i+2; we want a z value associated with the boundary
             # between plies i and i+1, i.e. ply_z[i+1].  Use that
@@ -2539,7 +2537,6 @@ class WrinkleAnalysis:
             kd_matrix = 1.0
 
         # --- Mechanism 3: Out-of-plane delamination (curved-beam) ---
-        lam_thickness = len(angles) * cfg.ply_thickness
         amplitude = cfg.amplitude
         wavelength = cfg.wavelength
 

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -18,7 +18,6 @@ Usage
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import sys
 from typing import List, Optional, Sequence

--- a/src/wrinklefe/core/laminate.py
+++ b/src/wrinklefe/core/laminate.py
@@ -19,7 +19,7 @@ References
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import cached_property
 from typing import Literal
 

--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import functools
 import json
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 

--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -807,7 +807,6 @@ class WrinkleMesh:
         """
         nxp = self.nx + 1
         nyp = self.ny + 1
-        nzp = self.nz + 1
 
         # Build 1-D coordinate arrays
         x1d = np.linspace(0.0, self.Lx, nxp)
@@ -909,8 +908,6 @@ class WrinkleMesh:
         ply_angles : np.ndarray
             Shape ``(n_elements,)`` — nominal ply orientation (degrees).
         """
-        n_elem = self.nx * self.ny * self.nz
-
         # Element k-indices in the same ravel order used by _create_hex_connectivity
         ek = np.arange(self.nz)
         # Repeat for all (j, i) in each k-layer

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -31,8 +31,8 @@ References
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Literal, Optional, Union
+from dataclasses import dataclass
+from typing import Dict, Literal, Optional, Union
 
 import numpy as np
 

--- a/src/wrinklefe/core/wrinkle.py
+++ b/src/wrinklefe/core/wrinkle.py
@@ -192,7 +192,6 @@ class WrinkleProfile(ABC):
         xs = np.linspace(xlo, xhi, n_grid)
         vals = abs_slope_arr(xs)
         idx = int(np.argmax(vals))
-        best_x = float(xs[idx])
         best_val = float(vals[idx])
 
         # Local refinement bracketed to neighbours of the grid winner.
@@ -209,7 +208,6 @@ class WrinkleProfile(ABC):
                 refined_val = float(np.abs(self.slope(np.atleast_1d(result.x))[0]))
                 if refined_val > best_val:
                     best_val = refined_val
-                    best_x = float(result.x)
             except Exception:
                 # Fall back to grid winner on any optimizer hiccup.
                 pass
@@ -328,7 +326,6 @@ class RectangularSinusoidal(WrinkleProfile):
         arg = (self.width / 2.0 - adx) / tw
         sech2 = 1.0 / np.cosh(arg) ** 2
         tanh_val = np.tanh(arg)
-        sign = np.sign(dx)
         # env(x) = 0.5 * (tanh(arg) + 1) with arg = (w/2 - |dx|) / tw.
         # d(env)/dx = 0.5 * sech^2(arg) * d(arg)/dx, d(arg)/dx = -sign(dx)/tw,
         # so d(env)/dx = -0.5 * sech^2(arg) * sign(dx) / tw.

--- a/src/wrinklefe/failure/delamination.py
+++ b/src/wrinklefe/failure/delamination.py
@@ -31,7 +31,7 @@ actual CZM physics lives in
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Sequence
+from typing import Mapping
 
 import numpy as np
 

--- a/src/wrinklefe/failure/larc05.py
+++ b/src/wrinklefe/failure/larc05.py
@@ -117,11 +117,6 @@ class LaRC05Criterion(FailureCriterion):
         cos_a2 = np.cos(alpha_0_rad) ** 2
         tan_2a = np.tan(2.0 * alpha_0_rad)
 
-        # Transverse shear strength on fracture plane
-        S_T = material.Yc * np.cos(alpha_0_rad) * (
-            np.sin(alpha_0_rad) + np.cos(alpha_0_rad) / tan_2a
-        )
-
         # Friction coefficients (Pinho et al. 2005, Eq. 12-13)
         mu_T = -1.0 / tan_2a
         mu_L = -material.S12 * cos_2a / (material.Yc * cos_a2)

--- a/src/wrinklefe/failure/progressive.py
+++ b/src/wrinklefe/failure/progressive.py
@@ -35,7 +35,6 @@ References
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 
 import numpy as np
 

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -184,7 +184,7 @@ def export_abaqus_inp(
             elem_ids = mesh.elements_in_ply(ply_idx)
             if elem_ids.size == 0:
                 continue
-            f.write(f"**\n")
+            f.write("**\n")
             f.write(f"*ELEMENT, TYPE=C3D8, ELSET=PLY_{ply_idx}\n")
             for eid in elem_ids:
                 conn = mesh.elements[eid] + 1  # Convert to 1-based

--- a/src/wrinklefe/solver/boundary.py
+++ b/src/wrinklefe/solver/boundary.py
@@ -617,7 +617,6 @@ class BoundaryHandler:
         """
         bcs: list[BoundaryCondition] = []
         Lx, Ly, Lz = mesh.domain_size
-        h = Lz  # laminate thickness
 
         # ------ Rigid body suppression ------
         # Fix one corner node on x_min face to prevent rigid body motion.

--- a/src/wrinklefe/solver/results.py
+++ b/src/wrinklefe/solver/results.py
@@ -24,7 +24,6 @@ from scipy import sparse
 
 from wrinklefe.core.laminate import Laminate
 from wrinklefe.core.mesh import MeshData
-from wrinklefe.core.transforms import stress_transformation_3d
 
 
 @dataclass

--- a/src/wrinklefe/solver/static.py
+++ b/src/wrinklefe/solver/static.py
@@ -51,7 +51,7 @@ def _suppress_assembly_warnings():
         yield
 
 if TYPE_CHECKING:
-    from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
+    from wrinklefe.solver.boundary import BoundaryCondition
 
 
 class StaticSolver:
@@ -238,7 +238,6 @@ class StaticSolver:
         FieldResults
             Complete solution data.
         """
-        from wrinklefe.solver.boundary import BoundaryCondition
 
         bcs = self._load_state_to_bcs(load)
         return self.solve(bcs, solver=solver, verbose=verbose)

--- a/src/wrinklefe/sweep/parametric_sweep.py
+++ b/src/wrinklefe/sweep/parametric_sweep.py
@@ -148,13 +148,13 @@ def run_sweep(sweep_config, fine_mesh=False):
     grid = list(itertools.product(*param_arrays))
     total = len(grid)
 
-    print(f"\nParametric Sweep Configuration:")
+    print("\nParametric Sweep Configuration:")
     print(f"  Parameters: {', '.join(swept_params)}")
     for p in swept_params:
         vals = sweep_config[p]
         print(f"    {p}: {vals[0]:.4f} to {vals[-1]:.4f} ({len(vals)} points)")
     if is_phase_sweep:
-        print(f"  Mode: phase sweep (single morphology per point, arbitrary phase)")
+        print("  Mode: phase sweep (single morphology per point, arbitrary phase)")
     else:
         print(f"  Total configurations: {total} x {len(MORPHOLOGIES)} morphologies"
               f" = {total * len(MORPHOLOGIES)} runs")
@@ -261,10 +261,8 @@ def _plot_1d_sweep(sweep_results, output_dir):
     values = sweep_results['param_values'][param]
     results = sweep_results['results']
 
-    # Detect if this is a phase sweep (single 'custom' key) or standard (3 morphologies)
     first_result = results[values[0]]
     morphs = list(first_result.keys())
-    is_phase = morphs == ['custom']
 
     colors = {'stack': '#666666', 'convex': '#2196F3', 'concave': '#F44336', 'custom': '#9C27B0'}
     markers = {'stack': 's', 'convex': '^', 'concave': 'v', 'custom': 'o'}

--- a/src/wrinklefe/viz/plots_2d.py
+++ b/src/wrinklefe/viz/plots_2d.py
@@ -38,11 +38,9 @@ from matplotlib.figure import Figure
 from wrinklefe.viz.style import (
     ACCENT_GRAY,
     FIGSIZE_DOUBLE_COLUMN,
-    FIGSIZE_SINGLE_COLUMN,
     FIGSIZE_SINGLE_TALL,
     MORPHOLOGY_COLORS,
     MORPHOLOGY_LABELS,
-    MORPHOLOGY_LINESTYLES,
     colorbar_setup,
     ensure_axes,
     get_morphology_style,
@@ -164,7 +162,6 @@ def plot_dual_wrinkle_profiles(
     ax.plot(x, z_lower, color=MORPHOLOGY_COLORS["concave"], linewidth=1.5, label="Lower wrinkle")
 
     if show_gap:
-        gap = z_upper - z_lower
         ax.fill_between(
             x, z_lower, z_upper,
             alpha=0.15, color=MORPHOLOGY_COLORS["convex"], label="Interface gap",

--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -51,7 +51,6 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection  # type: ignore[import-u
 
 from wrinklefe.viz.style import (
     FIGSIZE_DOUBLE_COLUMN,
-    colorbar_setup,
     ensure_axes,
     set_axes_equal_aspect,
     set_publication_style,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
 """Shared pytest fixtures for WrinkleFE Phase 1 core module tests."""
 
-import numpy as np
 import pytest
 
-from wrinklefe.core.laminate import Laminate, Ply
+from wrinklefe.core.laminate import Laminate
 from wrinklefe.core.material import OrthotropicMaterial
-from wrinklefe.core.morphology import WrinkleConfiguration, WrinklePlacement
+from wrinklefe.core.morphology import WrinkleConfiguration
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 
 

--- a/tests/integration/test_dcb_experimental_validation.py
+++ b/tests/integration/test_dcb_experimental_validation.py
@@ -770,7 +770,6 @@ def test_dcb_experimental_validation_nasa_tm():
         delta_max=DELTA_MAX,
         sample_deltas=sample_deltas,
     )
-    deltas = res["deltas"]
     P_arr = res["P"]
     cd = res["converged_deltas"]
     cP = res["converged_P"]

--- a/tests/integration/test_enf_experimental_validation.py
+++ b/tests/integration/test_enf_experimental_validation.py
@@ -140,7 +140,6 @@ import matplotlib
 matplotlib.use("Agg")  # non-interactive backend for CI/test runs.
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
-import pytest  # noqa: E402
 
 from wrinklefe.core.cohesive_mesh import insert_cohesive_interface  # noqa: E402
 from wrinklefe.core.laminate import Laminate, Ply  # noqa: E402

--- a/tests/integration/test_enf_monotonic.py
+++ b/tests/integration/test_enf_monotonic.py
@@ -403,7 +403,6 @@ def _build_bcs(
     - Centerline load: prescribed ``u_z = -delta`` on the top face at
       x = 0 (i.e. the mesh-native ``CENTER_X``).
     """
-    tol = 1e-6
     left_support, right_support, center_load = _support_and_load_nodes(
         mesh,
     )

--- a/tests/integration/test_mmb_mixity_synthesis.py
+++ b/tests/integration/test_mmb_mixity_synthesis.py
@@ -91,7 +91,6 @@ import matplotlib
 matplotlib.use("Agg")  # non-interactive backend.
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
-import pytest  # noqa: E402
 from scipy.optimize import minimize_scalar  # noqa: E402
 
 # ----------------------------------------------------------------------

--- a/tests/test_analysis_czm.py
+++ b/tests/test_analysis_czm.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import dataclasses
 
 import numpy as np
-import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,6 @@ the configs/kwargs the CLI hands them.
 from __future__ import annotations
 
 import functools
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,8 +29,6 @@ def _stub_analysis_run():
     :meth:`WrinkleAnalysis.run`).
     """
     captured: dict = {}
-
-    real_init = None  # filled in below
 
     def fake_run(self, analytical_only=None):
         captured["analytical_only"] = analytical_only

--- a/tests/test_cli_czm.py
+++ b/tests/test_cli_czm.py
@@ -19,9 +19,6 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
-from pathlib import Path
-
-import pytest
 
 _WRINKLEFE_CLI = shutil.which("wrinklefe")
 

--- a/tests/test_failure/test_larc05.py
+++ b/tests/test_failure/test_larc05.py
@@ -18,7 +18,6 @@ the same data as ``MaterialLibrary().get("IM7_8552")``).
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from wrinklefe.core.material import OrthotropicMaterial
 from wrinklefe.failure.base import FailureResult
@@ -201,7 +200,6 @@ class TestLaRC05MatrixCompression:
     ):
         """The fracture-plane search must select the angle |alpha| = alpha_0
         (~53 deg for CFRP) for pure transverse compression."""
-        stress = np.array([0.0, -material.Yc, 0.0, 0.0, 0.0, 0.0])
         Yt_is, S12_is = criterion._in_situ_strengths(material)
         mu_L, mu_T = LaRC05Criterion._friction_coefficients(material)
 
@@ -210,7 +208,6 @@ class TestLaRC05MatrixCompression:
         S_T = material.Yc * np.cos(alpha_0_rad) * (
             np.sin(alpha_0_rad) + np.cos(alpha_0_rad) / tan_2a
         )
-        S_L = S12_is
 
         thetas = np.linspace(-np.pi / 2, np.pi / 2, criterion.n_theta)
         ct, st = np.cos(thetas), np.sin(thetas)

--- a/tests/test_failure/test_progressive.py
+++ b/tests/test_failure/test_progressive.py
@@ -1,6 +1,5 @@
 """Tests for progressive damage models: PlyDiscount and ContinuumDamage."""
 
-import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 

--- a/tests/test_integration/test_analysis.py
+++ b/tests/test_integration/test_analysis.py
@@ -6,13 +6,11 @@ material, laminate, wrinkle, mesh, solver, failure, and statistics modules.
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import pytest
 
-from wrinklefe.analysis import AnalysisConfig, AnalysisResults, WrinkleAnalysis
-from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.core.material import MaterialLibrary
 
 # ======================================================================
 # Fixtures

--- a/tests/test_integration/test_elhajjar_validation.py
+++ b/tests/test_integration/test_elhajjar_validation.py
@@ -10,9 +10,6 @@ References
 
 from __future__ import annotations
 
-import warnings
-
-import numpy as np
 import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis

--- a/tests/test_integration/test_tension_validation.py
+++ b/tests/test_integration/test_tension_validation.py
@@ -12,9 +12,6 @@ References
 
 from __future__ import annotations
 
-import warnings
-
-import numpy as np
 import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import warnings
-from pathlib import Path
 
 import numpy as np
 import pytest

--- a/tests/test_laminate.py
+++ b/tests/test_laminate.py
@@ -6,7 +6,6 @@ import pytest
 
 from wrinklefe.core.laminate import Laminate, LoadState, Ply
 from wrinklefe.core.material import OrthotropicMaterial
-from wrinklefe.core.transforms import reduced_stiffness_matrix, transform_reduced_stiffness
 
 
 class TestPly:
@@ -174,7 +173,6 @@ class TestABDValidation:
         Ply 3 (0-deg):  z_bot=0.125,  z_top=0.25    -> contributes Q11
         """
         mat = simple_material
-        t = 0.125
         nu21 = mat.nu12 * mat.E2 / mat.E1
         denom = 1.0 - mat.nu12 * nu21
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,6 +1,5 @@
 """Tests for wrinklefe.core.material module."""
 
-import json
 
 import numpy as np
 import numpy.testing as npt
@@ -274,7 +273,7 @@ class TestMaterialSerialization:
     def test_json_roundtrip(self, tmp_path):
         lib = MaterialLibrary()
         json_path = tmp_path / "materials.json"
-        json_str = lib.to_json(path=json_path)
+        lib.to_json(path=json_path)
 
         # Verify file was written
         assert json_path.exists()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -295,8 +295,7 @@ class TestWrinkledMesh:
         silently dropped nodes whose perturbed z deviated from the global
         minimum z, leaving only the trough nodes.
         """
-        nx, ny, nz_per_ply = 4, 3, 1
-        nz = small_laminate.n_plies * nz_per_ply
+        nx, ny = 4, 3
         face_nodes = wrinkled_mesh.nodes_on_face("z_min")
         assert len(face_nodes) == (nx + 1) * (ny + 1)
         # The k=0 plane is the first (nx+1)*(ny+1) nodes in canonical order.

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -9,7 +9,6 @@ from wrinklefe.core.morphology import (
     WrinkleConfiguration,
     WrinklePlacement,
 )
-from wrinklefe.core.wrinkle import GaussianSinusoidal
 
 
 class TestPhaseFromOffset:

--- a/tests/test_morphology_vectorised_parity.py
+++ b/tests/test_morphology_vectorised_parity.py
@@ -126,7 +126,6 @@ def _structured_mesh(nx=12, ny=6, nz=24):
     """Build a tensor-product mesh with shape (nx, ny, nz) flattened."""
     xs = np.linspace(-20.0, 20.0, nx)
     ys = np.linspace(0.0, 10.0, ny)
-    n_nodes_per_ply = nx * ny
     nodes = []
     ply_ids = []
     for p in range(nz):

--- a/tests/test_solver/test_static.py
+++ b/tests/test_solver/test_static.py
@@ -13,9 +13,9 @@ import numpy as np
 import pytest
 from scipy import sparse
 
-from wrinklefe.core.laminate import Laminate, LoadState, Ply
+from wrinklefe.core.laminate import Laminate, LoadState
 from wrinklefe.core.material import OrthotropicMaterial
-from wrinklefe.core.mesh import MeshData, WrinkleMesh
+from wrinklefe.core.mesh import WrinkleMesh
 from wrinklefe.solver.assembler import GlobalAssembler
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
 from wrinklefe.solver.results import FieldResults


### PR DESCRIPTION
Refs #87 — second incremental widening of CI's enforced Ruff scope (follows #287's E/W/I pass).

## What
- **F401:** 42 unused imports removed across `src/` and `tests/` (verified none were `__init__` re-exports); leftover import blocks re-sorted.
- **F541:** 3 placeholder-less f-strings de-f-stringed.
- **F841:** 19 unused locals reviewed **case by case**, not blanket-autofixed:
  - 18 were dead pure computations — deleted.
  - `tests/test_material.py`'s `json_str = lib.to_json(path=...)` has a side effect (writes the file the test asserts on) — the call is kept, only the binding dropped.
  - Two knock-on dead assignments surfaced and were removed (the grid-stage `best_x` in `WrinkleProfile.max_angle` once its refinement-stage twin went; a tuple element in `test_mesh`). One removal initially hit the wrong of two identical `t = 0.125` lines in `test_laminate` — ruff's F821 caught the resulting undefined name immediately and the used instance was restored.
- **CI:** lint job now enforces `E,W,I,F` (full pyflakes). Remaining: UP ~498, N ~1343 (documented in `lint.yml`).

## Verification
- `ruff check --select E,W,I,F .` clean repo-wide.
- 485 tests pass across every touched area (laminate, mesh, material, CLI, LaRC05, vectorised parity, validation ledger, solver, CZM, wrinkle, export, integration, sweep, viz).
- `scripts/validate.py`: zero drift on all pinned baselines.
- `sphinx-build -W` clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_