### PR TITLE
lint: modernize annotations (UP), enforce E,W,I,F,UP in CI (#87)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,11 @@ jobs:
           pip install -e ".[dev]"
 
       # Enforced scope: E (pycodestyle errors), W (warnings), I (isort),
-      # F (pyflakes). The remaining families from pyproject.toml's full
-      # config still carry violations and are being expanded
-      # incrementally (issue #87): UP ~498 (pyupgrade), N ~1343
-      # (scientific naming -- needs a per-file noqa policy first).
-      - name: Ruff (enforced scope - E,W,I,F)
-        run: ruff check --select E,W,I,F .
+      # F (pyflakes), UP (pyupgrade). The one remaining family from
+      # pyproject.toml's full config is N (~1343, scientific naming --
+      # needs a per-file noqa policy before any renaming); see issue #87.
+      - name: Ruff (enforced scope - E,W,I,F,UP)
+        run: ruff check --select E,W,I,F,UP .
 
       # Starter scope: package `__init__` only. Broader src/wrinklefe has ~102
       # mypy errors today (mostly numpy `Any` returns + missing stubs); fixing

--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ import sys
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Optional
 
 import matplotlib
 
@@ -707,7 +706,7 @@ with st.sidebar:
         # back-compat behaviour where the wrinkle's own ``width`` is the
         # effective decay length.
         if not _profile_active:
-            amplitude_profile_decay_length: Optional[float] = None
+            amplitude_profile_decay_length: float | None = None
         else:
             amplitude_profile_decay_length = float(
                 amplitude_profile_decay_length_ui
@@ -1153,7 +1152,7 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
     # actually drove the FE solve down the Newton-Raphson path. Kept in
     # a sub-dict so the Results tab can quickly check ``results.get("czm")``
     # without juggling None-checks on a flat top-level structure.
-    czm_payload: Optional[dict] = None
+    czm_payload: dict | None = None
     if cfg_dict.get("enable_czm", False) and result.czm_damage is not None:
         damage_arr = np.asarray(result.czm_damage)
         if damage_arr.size:
@@ -2177,7 +2176,7 @@ with tab_export:
         _ply_fi = (fe or {}).get("ply_failure_indices") or {}
         for _k, _ang in enumerate(_angles_export):
             _row_fi = -float("inf")
-            _row_crit: Optional[str] = None
+            _row_crit: str | None = None
             for _crit_name, _arr in _ply_fi.items():
                 if _k < len(_arr) and _arr[_k] > _row_fi:
                     _row_fi = float(_arr[_k])

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -38,8 +38,8 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, fields, replace
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -99,7 +99,7 @@ _BETA_BLOCK = 0.010   # per-extra-ply block penalty on gamma_Y_eff
 _GAMMA_Y_FLOOR = _GAMMA_Y_UD / 2.0  # = 0.016 (UD half-strain floor)
 
 
-def _confined_fraction(angles: List[float], tol: float = 5.0) -> float:
+def _confined_fraction(angles: list[float], tol: float = 5.0) -> float:
     """Weighted confinement fraction for 0-degree plies.
 
     Each 0-degree ply is scored by how many of its neighbors are off-axis:
@@ -134,7 +134,7 @@ def _confined_fraction(angles: List[float], tol: float = 5.0) -> float:
     return score / n_0
 
 
-def _effective_gamma_Y(angles: List[float]) -> float:
+def _effective_gamma_Y(angles: list[float]) -> float:
     """Compute layup-dependent effective matrix yield strain.
 
     Three-parameter model::
@@ -214,7 +214,7 @@ def _profile_proportional_kd(
     morphology_factor: float = 1.0,
     through_thickness_decay: bool = True,
     z_position_fraction: float = 0.5,
-    decay_scale: Optional[float] = None,
+    decay_scale: float | None = None,
     decay_floor: float = 0.0,
     kink_band_quadratic_coeff: float = 0.0,
 ) -> float:
@@ -372,7 +372,7 @@ def _profile_proportional_kd(
     return kd_sum / n_plies
 
 
-def _check_multi_wrinkle_fe_support(cfg: "AnalysisConfig") -> None:
+def _check_multi_wrinkle_fe_support(cfg: AnalysisConfig) -> None:
     """Reject multi-wrinkle FE configs the pipeline cannot represent yet.
 
     Issue #252: arbitrary N-wrinkle layouts — including longitudinally
@@ -391,7 +391,7 @@ def _check_multi_wrinkle_fe_support(cfg: "AnalysisConfig") -> None:
         )
 
 
-def _max_consecutive_zero_plies(angles: List[float], tol: float = 5.0) -> int:
+def _max_consecutive_zero_plies(angles: list[float], tol: float = 5.0) -> int:
     """Find maximum number of consecutive 0-degree plies in a layup.
 
     Used by the tension OOP model to determine the effective curved-beam
@@ -722,7 +722,7 @@ class AnalysisConfig:
     # `morphology` (stack=0, convex=+pi/2, concave=-pi/2). A float
     # overrides the named-morphology phase so arbitrary phases can be
     # analysed/swept. Ignored for single-wrinkle modes (uniform/graded).
-    phase: Optional[float] = None
+    phase: float | None = None
     decay_floor: float = 0.0  # graded mode: min amplitude fraction at surfaces (0–1)
     # Single-wrinkle through-thickness position as a fraction of the laminate
     # thickness (0 = bottom surface, 0.5 = midplane, 1 = top surface). Only
@@ -734,15 +734,15 @@ class AnalysisConfig:
     # mirror WrinkleConfiguration so the legacy "constant" behaviour is
     # preserved when callers leave them unset.
     amplitude_profile: str = "constant"
-    amplitude_profile_decay_length: Optional[float] = None
+    amplitude_profile_decay_length: float | None = None
     amplitude_profile_axis: str = "x"
 
     # Loading
     loading: str = "compression"
 
     # Material & laminate
-    material: Optional[OrthotropicMaterial] = None
-    angles: Optional[List[float]] = None
+    material: OrthotropicMaterial | None = None
+    angles: list[float] | None = None
 
     # Ply thickness
     ply_thickness: float = 0.183  # mm (1 ply thickness for CYCOM X850/T800)
@@ -751,15 +751,15 @@ class AnalysisConfig:
     # ``__post_init__`` from ``len(angles)`` so small laminates work out
     # of the box (issues #154/#156). For the default 24-ply layup the
     # auto-derived pair is (11, 12), preserving backwards compatibility.
-    interface_1: Optional[int] = None
-    interface_2: Optional[int] = None
+    interface_1: int | None = None
+    interface_2: int | None = None
 
     # Multi-wrinkle override. When non-empty, this overrides the named
     # single/dual-wrinkle dispatch in WrinkleAnalysis.run, allowing
     # arbitrary N-wrinkle configurations (Li et al. 2025 Dataset F).
     # Each spec contributes one WrinklePlacement; FE solve is currently
     # out of scope for this path (set analytical_only=True).
-    wrinkles: Optional[List["WrinkleSpec"]] = None
+    wrinkles: list[WrinkleSpec] | None = None
 
     # Mesh
     nx: int = 12
@@ -787,7 +787,7 @@ class AnalysisConfig:
     # its (much smaller) amplitude.  Provide an explicit positive float
     # to pin the decay scale (e.g. to reproduce the pre-PR amplitude-
     # based behaviour for regression testing).  Must be > 0 when set.
-    through_thickness_decay_scale: Optional[float] = None
+    through_thickness_decay_scale: float | None = None
 
     # Argon-Fleck quadratic coefficient ``c_AF`` (dimensionless) for the
     # extended Budiansky-Fleck closed form ``KD = 1/(1 + r + c_AF*r^2)``
@@ -814,12 +814,12 @@ class AnalysisConfig:
     #     is closest to the wrinkle peak amplitude,
     #   * ``list[int]`` — explicit list of interface indices in
     #     ``[0, n_plies-1)`` (0 = bottom-most interior interface).
-    czm_interfaces: Union[List[int], str] = "near_crest"
+    czm_interfaces: list[int] | str = "near_crest"
     czm_law: str = "bilinear"
-    czm_GIc: Optional[float] = None      # N/mm; None -> material default
-    czm_GIIc: Optional[float] = None
-    czm_sigma_max: Optional[float] = None  # MPa; None -> material default
-    czm_tau_max: Optional[float] = None
+    czm_GIc: float | None = None      # N/mm; None -> material default
+    czm_GIIc: float | None = None
+    czm_sigma_max: float | None = None  # MPa; None -> material default
+    czm_tau_max: float | None = None
     czm_penalty: float = 1.0e6           # N/mm^3 initial interface stiffness
     czm_BK_eta: float = 1.45
     # Default bumped 20 -> 100 after the Phase 7 NASA TM DCB validation
@@ -1279,9 +1279,9 @@ class AnalysisResults:
     """
 
     config: AnalysisConfig
-    mesh: Optional[MeshData] = None
-    wrinkle_config: Optional[WrinkleConfiguration] = None
-    laminate: Optional[Laminate] = None
+    mesh: MeshData | None = None
+    wrinkle_config: WrinkleConfiguration | None = None
+    laminate: Laminate | None = None
 
     # Analytical predictions
     morphology_factor: float = 1.0
@@ -1290,70 +1290,70 @@ class AnalysisResults:
     mesh_max_angle_rad: float = 0.0  # max fiber angle from FE mesh (accounts for decay)
     damage_index: float = 0.0
     analytical_knockdown: float = 1.0
-    analytical_onset_knockdown: Optional[float] = None
+    analytical_onset_knockdown: float | None = None
     analytical_strength_MPa: float = 0.0
     gamma_Y_eff: float = 0.02  # layup-dependent effective yield strain
-    tension_mechanisms: Optional[dict] = None  # {kd_fiber, kd_matrix, kd_oop, mode, ...}
+    tension_mechanisms: dict | None = None  # {kd_fiber, kd_matrix, kd_oop, mode, ...}
 
     # FE results
-    field_results: Optional[FieldResults] = None
-    failure_report: Optional[LaminateFailureReport] = None
-    failure_indices: Optional[dict] = None
-    failure_modes: Optional[dict] = None  # {criterion: (n_elem, n_gauss) str array}
+    field_results: FieldResults | None = None
+    failure_report: LaminateFailureReport | None = None
+    failure_indices: dict | None = None
+    failure_modes: dict | None = None  # {criterion: (n_elem, n_gauss) str array}
 
     # Retention factor (wrinkled / pristine)
-    retention_factors: Optional[dict] = None  # {criterion_name: float}
-    baseline_fi: Optional[dict] = None  # {criterion_name: float} pristine max FI
+    retention_factors: dict | None = None  # {criterion_name: float}
+    baseline_fi: dict | None = None  # {criterion_name: float} pristine max FI
 
     # Modulus retention (E_wrinkled / E_pristine from FE)
     modulus_retention: float = 1.0
 
     # Tension mechanism decomposition (only for tension loading)
-    tension_mechanisms: Optional[dict] = None  # {kd_fiber, kd_matrix, kd_oop, ...}
+    tension_mechanisms: dict | None = None  # {kd_fiber, kd_matrix, kd_oop, ...}
 
     # ------------------------------------------------------------------
     # CZM results — only populated when AnalysisConfig.enable_czm = True.
     # ------------------------------------------------------------------
-    czm_damage: Optional[np.ndarray] = None
+    czm_damage: np.ndarray | None = None
     """Cohesive damage variable per (interface element, Gauss point).
     Shape ``(n_iface_elems, n_gauss)``."""
 
-    czm_separation: Optional[np.ndarray] = None
+    czm_separation: np.ndarray | None = None
     """Displacement jump in the local cohesive frame per (interface
     element, Gauss point, component).  Shape ``(n_iface_elems, n_gauss,
     3)`` with components ``(delta_n, delta_s, delta_t)``."""
 
-    czm_traction: Optional[np.ndarray] = None
+    czm_traction: np.ndarray | None = None
     """Cohesive traction in the local frame at each Gauss point.  Shape
     ``(n_iface_elems, n_gauss, 3)``."""
 
-    czm_energy_dissipated: Optional[float] = None
+    czm_energy_dissipated: float | None = None
     """Total cohesive energy dissipated across all interfaces (N*mm)."""
 
-    czm_energy_per_interface: Optional[Dict[int, float]] = None
+    czm_energy_per_interface: dict[int, float] | None = None
     """Per-interface dissipated energy keyed by ply-interface index."""
 
-    czm_crack_length_per_interface: Optional[Dict[int, float]] = None
+    czm_crack_length_per_interface: dict[int, float] | None = None
     """Per-interface crack length (in mm) keyed by ply-interface index.
     Computed as the in-plane area of elements with ``damage > 0.99``,
     divided by the mesh width (so the reported quantity has units of
     length along the wrinkle/crack direction)."""
 
-    czm_load_displacement: Optional[np.ndarray] = None
+    czm_load_displacement: np.ndarray | None = None
     """``(n_inc, 2)`` array of ``(lambda, ||u||)`` samples from the
     incremental Newton-Raphson run."""
 
-    czm_converged: Optional[bool] = None
+    czm_converged: bool | None = None
     """Whether every load increment converged."""
 
-    czm_interfaces_used: Optional[List[int]] = None
+    czm_interfaces_used: list[int] | None = None
     """Ply-interface indices that actually received cohesive elements."""
 
-    czm_delamination_report: Optional[LaminateFailureReport] = None
+    czm_delamination_report: LaminateFailureReport | None = None
     """Delamination failure report shaped like the other failure
     criteria, populated by :mod:`wrinklefe.failure.delamination`."""
 
-    czm_element_centroids: Optional[np.ndarray] = None
+    czm_element_centroids: np.ndarray | None = None
     """``(n_iface_elems, 2)`` array of in-plane ``(x, y)`` centroids of the
     cohesive interface elements, in the reference (undeformed) configuration.
 
@@ -1475,8 +1475,8 @@ class WrinkleAnalysis:
 
     def run(
         self,
-        analytical_only: Optional[bool] = None,
-        progress_callback: Optional[Callable[[str, float], None]] = None,
+        analytical_only: bool | None = None,
+        progress_callback: Callable[[str, float], None] | None = None,
     ) -> AnalysisResults:
         """Execute the complete analysis pipeline.
 
@@ -1703,7 +1703,7 @@ class WrinkleAnalysis:
         base_config: AnalysisConfig,
         morphologies: Sequence[str] = ("stack", "convex", "concave"),
         analytical_only: bool = False,
-    ) -> Dict[str, AnalysisResults]:
+    ) -> dict[str, AnalysisResults]:
         """Run the full FE analysis for multiple morphologies and compare.
 
         Parameters
@@ -1722,7 +1722,7 @@ class WrinkleAnalysis:
         dict[str, AnalysisResults]
             Mapping from morphology name to its results.
         """
-        all_results: Dict[str, AnalysisResults] = {}
+        all_results: dict[str, AnalysisResults] = {}
 
         for morph in morphologies:
             cfg = replace(base_config, morphology=morph)
@@ -1742,7 +1742,7 @@ class WrinkleAnalysis:
         parameter: str,
         values: Sequence[float],
         analytical_only: bool = False,
-    ) -> List[AnalysisResults]:
+    ) -> list[AnalysisResults]:
         """Sweep a single parameter over a range of values.
 
         Parameters
@@ -1775,7 +1775,7 @@ class WrinkleAnalysis:
                 f"AnalysisConfig has no field '{parameter}'"
             )
 
-        results_list: List[AnalysisResults] = []
+        results_list: list[AnalysisResults] = []
 
         # If domain_length was auto-derived from wavelength in the base
         # config (i.e. user left it at the sentinel 0.0), we must reset
@@ -1819,7 +1819,7 @@ class WrinkleAnalysis:
 
     def _resolve_cohesive_interfaces(
         self, laminate: Laminate, wrinkle_config: WrinkleConfiguration,
-    ) -> List[int]:
+    ) -> list[int]:
         """Resolve ``cfg.czm_interfaces`` to an explicit ply-interface list.
 
         Parameters
@@ -1904,7 +1904,7 @@ class WrinkleAnalysis:
         # matches the v1 spec).
         mat = laminate.plies[0].material
 
-        def _coalesce(cfg_val: Optional[float], mat_val) -> float:
+        def _coalesce(cfg_val: float | None, mat_val) -> float:
             if cfg_val is not None:
                 return float(cfg_val)
             if mat_val is None:
@@ -1931,9 +1931,9 @@ class WrinkleAnalysis:
         self,
         laminate: Laminate,
         wrinkle_config: WrinkleConfiguration,
-        iface_indices: List[int],
+        iface_indices: list[int],
         cohesive_props: CohesiveProperties,
-    ) -> Tuple[MeshData, List[Tuple[int, Cohesive8Element]], Dict[int, range]]:
+    ) -> tuple[MeshData, list[tuple[int, Cohesive8Element]], dict[int, range]]:
         """Build a wrinkled mesh with cohesive elements inserted.
 
         The flat (un-deformed) mesh is built first so that ply-interface
@@ -1980,8 +1980,8 @@ class WrinkleAnalysis:
         ply_z = laminate.z_coords()  # length n_plies + 1
         # ply-interface index ``i`` corresponds to the boundary between
         # plies ``i`` and ``i + 1`` => z = ply_z[i + 1].
-        elem_ranges: Dict[int, range] = {}
-        cohesive_elements: List[Tuple[int, Cohesive8Element]] = []
+        elem_ranges: dict[int, range] = {}
+        cohesive_elements: list[tuple[int, Cohesive8Element]] = []
         next_global_id = 0
         for iface_idx in iface_indices:
             z_iface = float(ply_z[iface_idx + 1])
@@ -2026,7 +2026,7 @@ class WrinkleAnalysis:
 
         # --- Step 4: refresh cohesive node_coords against the deformed
         # node array so the GlobalAssembler equality check passes -----
-        refreshed: List[Tuple[int, Cohesive8Element]] = []
+        refreshed: list[tuple[int, Cohesive8Element]] = []
         for gid, c_elem in cohesive_elements:
             new_coords = mesh.nodes[c_elem.node_ids]
             new_elem = Cohesive8Element(
@@ -2210,9 +2210,9 @@ class WrinkleAnalysis:
         # delta_f is mode-dependent.  We use the simpler bound
         # GIc * area * d_avg which is accurate for mode-I-dominated
         # failure and gives the right total in the fully-failed limit.
-        energy_per_iface: Dict[int, float] = {}
-        crack_len_per_iface: Dict[int, float] = {}
-        damage_per_iface: Dict[int, np.ndarray] = {}
+        energy_per_iface: dict[int, float] = {}
+        crack_len_per_iface: dict[int, float] = {}
+        damage_per_iface: dict[int, np.ndarray] = {}
 
         # Mesh width in y for crack-length estimation.  Use the bounding
         # box of the *original* (flat) coordinates which the cohesive
@@ -2466,9 +2466,9 @@ class WrinkleAnalysis:
 
     @staticmethod
     def _tension_knockdown_analytical(
-        theta: float, cfg: "AnalysisConfig",
+        theta: float, cfg: AnalysisConfig,
         _return_kd0_only: bool = False,
-    ) -> Tuple[float, dict]:
+    ) -> tuple[float, dict]:
         """Three-mechanism tension knockdown (LaRC04 + curved-beam OOP).
 
         Computes the laminate-level retention factor for tension loading
@@ -2693,7 +2693,7 @@ class WrinkleAnalysis:
         # whenever the raw energy-based onset is not already below it.
         # This guarantees the spec's requirement that onset KD < KD_oop
         # and onset KD < analytical_knockdown.
-        kd_onset_lam: Optional[float] = None
+        kd_onset_lam: float | None = None
         if kd_onset is not None:
             kd_onset_lam_raw = f_0 * kd_onset + (1.0 - f_0) * 1.0
             kd_onset_lam = min(kd_onset_lam_raw, float(kd_lam) * 0.999)

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from typing import List, Optional, Sequence
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -533,7 +533,7 @@ def _build_parser() -> argparse.ArgumentParser:
 # Subcommand handlers
 # ====================================================================== #
 
-def _parse_czm_interfaces(value: Optional[str]):
+def _parse_czm_interfaces(value: str | None):
     """Parse --czm-interfaces into the form ``AnalysisConfig`` expects.
 
     Accepts the two sentinel strings ``"near_crest"`` / ``"all"`` (passed
@@ -567,7 +567,7 @@ def _parse_czm_interfaces(value: Optional[str]):
         sys.exit(2)
 
 
-def _parse_angles(angles_str: Optional[str]) -> Optional[List[float]]:
+def _parse_angles(angles_str: str | None) -> list[float] | None:
     """Parse a layup string into a list of ply angles (degrees).
 
     Accepts both an explicit comma/semicolon/newline-separated list
@@ -919,7 +919,7 @@ def _configure_logging(verbose: bool) -> None:
     pkg_logger.setLevel(logging.DEBUG)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """Main CLI entry point.
 
     Parameters

--- a/src/wrinklefe/convergence.py
+++ b/src/wrinklefe/convergence.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 import logging
 import math
 import time
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
-from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -42,7 +42,7 @@ __all__ = [
 
 #: Default geometric-ish refinement multipliers applied to the selected
 #: mesh axes, level by level.
-DEFAULT_FACTORS: Tuple[float, ...] = (1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+DEFAULT_FACTORS: tuple[float, ...] = (1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
 
 
 def _qoi_max_fi(results: AnalysisResults) -> float:
@@ -99,7 +99,7 @@ class ConvergenceLevel:
     nz_per_ply: int
     n_dof: int
     qoi: float
-    delta_pct: Optional[float]
+    delta_pct: float | None
     """Relative change vs the previous level, in percent
     (``100 * |q_k - q_{k-1}| / |q_k|``); ``None`` for the first level."""
     runtime_s: float
@@ -109,15 +109,15 @@ class ConvergenceLevel:
 class ConvergenceStudy:
     """Result of :func:`mesh_convergence_study`."""
 
-    levels: List[ConvergenceLevel]
+    levels: list[ConvergenceLevel]
     qoi_name: str
     tolerance: float
-    recommended_config: Optional[AnalysisConfig]
+    recommended_config: AnalysisConfig | None
     """Coarsest level whose QoI agrees with the finest level within
     ``tolerance`` (relative). ``None`` if only the finest level
     satisfies the tolerance — refine further."""
-    recommended_level: Optional[int]
-    observed_rate: Optional[float]
+    recommended_level: int | None
+    observed_rate: float | None
     """Richardson-style observed convergence rate from the last three
     levels; ``None`` when the refinement ratio is not constant or the
     QoI differences do not allow it."""
@@ -167,7 +167,7 @@ class ConvergenceStudy:
 
 def _observed_rate(
     qois: Sequence[float], ratios: Sequence[float]
-) -> Optional[float]:
+) -> float | None:
     """Richardson-style rate from the last three QoIs, if the sequence allows."""
     if len(qois) < 3 or len(ratios) < 2:
         return None
@@ -185,9 +185,9 @@ def mesh_convergence_study(
     base_config: AnalysisConfig,
     levels: int = 4,
     refine: Sequence[str] = ("nx", "nz_per_ply"),
-    qoi: Union[str, Callable[[AnalysisResults], float]] = "max_fi",
+    qoi: str | Callable[[AnalysisResults], float] = "max_fi",
     tolerance: float = 0.01,
-    factors: Optional[Sequence[float]] = None,
+    factors: Sequence[float] | None = None,
 ) -> ConvergenceStudy:
     """Run the analysis at successively refined meshes and tabulate a QoI.
 
@@ -253,8 +253,8 @@ def mesh_convergence_study(
         )
     factors = tuple(float(f) for f in factors[:levels])
 
-    rows: List[ConvergenceLevel] = []
-    qois: List[float] = []
+    rows: list[ConvergenceLevel] = []
+    qois: list[float] = []
     for k, f in enumerate(factors):
         overrides = {
             axis: max(1, int(round(getattr(base_config, axis) * f)))
@@ -286,12 +286,12 @@ def mesh_convergence_study(
 
     # Recommendation: coarsest level within tolerance of the finest.
     q_ref = qois[-1]
-    recommended_level: Optional[int] = None
+    recommended_level: int | None = None
     for k in range(len(qois) - 1):
         if abs(qois[k] - q_ref) <= tolerance * max(abs(q_ref), 1e-30):
             recommended_level = k
             break
-    recommended_config: Optional[AnalysisConfig] = None
+    recommended_config: AnalysisConfig | None = None
     if recommended_level is not None:
         lv = rows[recommended_level]
         recommended_config = replace(

--- a/src/wrinklefe/core/layup.py
+++ b/src/wrinklefe/core/layup.py
@@ -19,7 +19,7 @@ Two notations are accepted:
 from __future__ import annotations
 
 import re
-from typing import List, Sequence, Tuple
+from collections.abc import Sequence
 
 __all__ = ["parse_layup", "to_contracted_layup"]
 
@@ -34,7 +34,7 @@ _PLY_TOKEN_RE = re.compile(
 )
 
 
-def _expand_ply_token(token: str) -> List[float]:
+def _expand_ply_token(token: str) -> list[float]:
     """Expand a single ply entry like ``0``, ``45_2``, ``±45``, or ``±30_2``."""
     token = token.strip()
     if not token:
@@ -49,7 +49,7 @@ def _expand_ply_token(token: str) -> List[float]:
     return [angle] * rep
 
 
-def _parse_contracted_layup(s: str) -> List[float]:
+def _parse_contracted_layup(s: str) -> list[float]:
     """Parse contracted notation like ``[0/45/-45/90]_3s`` or ``[0/±45/90]s``."""
     m = re.fullmatch(
         r"\s*\[\s*(?P<inner>[^\[\]]*)\]\s*_?\s*(?P<rep>\d+)?\s*(?P<sym>[sS])?\s*",
@@ -60,7 +60,7 @@ def _parse_contracted_layup(s: str) -> List[float]:
             f"Could not parse contracted layup {s!r}. "
             "Expected a form like '[0/45/-45/90]_3s'."
         )
-    plies: List[float] = []
+    plies: list[float] = []
     for tok in m.group("inner").split("/"):
         plies.extend(_expand_ply_token(tok))
     if not plies:
@@ -72,7 +72,7 @@ def _parse_contracted_layup(s: str) -> List[float]:
     return plies
 
 
-def parse_layup(s: str) -> List[float]:
+def parse_layup(s: str) -> list[float]:
     """Parse a layup string into a flat list of ply angles (degrees).
 
     Two notations are accepted:
@@ -89,7 +89,7 @@ def parse_layup(s: str) -> List[float]:
         raise ValueError("Layup is empty.")
     if "[" in s or "]" in s:
         return _parse_contracted_layup(s)
-    out: List[float] = []
+    out: list[float] = []
     for tok in s.replace(";", ",").replace("\n", ",").split(","):
         out.extend(_expand_ply_token(tok))
     if not out:
@@ -104,7 +104,7 @@ def _fmt_angle(angle: float) -> str:
 
 def _render_bracket(base: Sequence[float]) -> str:
     """Render a sublaminate as ``[a/b/...]``, collapsing ``a, -a`` to ``±a``."""
-    tokens: List[str] = []
+    tokens: list[str] = []
     i = 0
     while i < len(base):
         a = base[i]
@@ -117,7 +117,7 @@ def _render_bracket(base: Sequence[float]) -> str:
     return "[" + "/".join(tokens) + "]"
 
 
-def _smallest_repeat(seq: List[float]) -> Tuple[List[float], int]:
+def _smallest_repeat(seq: list[float]) -> tuple[list[float], int]:
     """Return the shortest base ``b`` and count ``k`` with ``seq == b * k``."""
     n = len(seq)
     for size in range(1, n + 1):
@@ -151,7 +151,7 @@ def to_contracted_layup(angles: Sequence[float]) -> str:
     if not plies:
         raise ValueError("Layup is empty.")
 
-    candidates: List[str] = []
+    candidates: list[str] = []
     n = len(plies)
     if n % 2 == 0 and plies == plies[::-1]:
         half_base, half_rep = _smallest_repeat(plies[: n // 2])

--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -18,7 +18,6 @@ import functools
 import json
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import Dict, List, Optional, Union
 
 import numpy as np
 
@@ -102,8 +101,8 @@ class OrthotropicMaterial:
     gamma_Y: float = 0.02
 
     # --- LaRC04/05 parameters ---
-    GIc: Optional[float] = None       # Mode I fracture toughness (N/mm)
-    GIIc: Optional[float] = None      # Mode II fracture toughness (N/mm)
+    GIc: float | None = None       # Mode I fracture toughness (N/mm)
+    GIIc: float | None = None      # Mode II fracture toughness (N/mm)
     beta_shear: float = 3.2e-8        # Ramberg-Osgood nonlinear shear coeff (1/MPa³)
     # Fracture plane angle under pure transverse compression (degrees)
     alpha_0: float = 53.0
@@ -293,7 +292,7 @@ class OrthotropicMaterial:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict) -> "OrthotropicMaterial":
+    def from_dict(cls, data: dict) -> OrthotropicMaterial:
         """Construct an OrthotropicMaterial from a dictionary.
 
         Parameters
@@ -358,7 +357,7 @@ class MaterialLibrary:
     """
 
     def __init__(self) -> None:
-        self._materials: Dict[str, OrthotropicMaterial] = {}
+        self._materials: dict[str, OrthotropicMaterial] = {}
         self._load_builtins()
 
     # ------------------------------------------------------------------
@@ -400,7 +399,7 @@ class MaterialLibrary:
         """
         self._materials[material.name] = material
 
-    def list_names(self) -> List[str]:
+    def list_names(self) -> list[str]:
         """Return a sorted list of all material names in the library.
 
         Returns
@@ -419,7 +418,7 @@ class MaterialLibrary:
     # JSON serialisation
     # ------------------------------------------------------------------
 
-    def to_json(self, path: Optional[Union[str, Path]] = None) -> str:
+    def to_json(self, path: str | Path | None = None) -> str:
         """Serialise the entire library to a JSON string.
 
         Parameters
@@ -441,7 +440,7 @@ class MaterialLibrary:
         return text
 
     @classmethod
-    def from_json(cls, source: Union[str, Path]) -> "MaterialLibrary":
+    def from_json(cls, source: str | Path) -> MaterialLibrary:
         """Create a library from a JSON file or string.
 
         If *source* is a path to an existing file it is read; otherwise

--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -658,7 +658,7 @@ class WrinkleMesh:
     def __init__(
         self,
         laminate: Laminate,
-        wrinkle_config: "WrinkleConfiguration | None" = None,
+        wrinkle_config: WrinkleConfiguration | None = None,
         Lx: float = 48.0,
         Ly: float = 20.0,
         nx: int = 50,
@@ -742,8 +742,8 @@ class WrinkleMesh:
         return mesh_data
 
     def _augment_inversion_error(
-        self, err: "MeshValidationError"
-    ) -> "MeshValidationError":
+        self, err: MeshValidationError
+    ) -> MeshValidationError:
         """Attach wrinkle parameters and tuning suggestions to an inversion error.
 
         Delegates to :func:`mesh_shear_diagnostics` so the post-failure

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -32,7 +32,7 @@ References
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 
@@ -42,7 +42,7 @@ from wrinklefe.core.wrinkle import WrinkleProfile, WrinkleSurface3D
 # Predefined morphology phases
 # ======================================================================
 
-MORPHOLOGY_PHASES: Dict[str, float] = {
+MORPHOLOGY_PHASES: dict[str, float] = {
     "stack": 0.0,
     "convex": np.pi / 2,
     "concave": -np.pi / 2,
@@ -65,7 +65,7 @@ Table 3 and the analytical model in Elhajjar (2025) Eq. 8.
 # Loading-dependent model parameters
 # ======================================================================
 
-_LOADING_PARAMS: Dict[str, Dict[str, float]] = {
+_LOADING_PARAMS: dict[str, dict[str, float]] = {
     "compression": {"alpha_asym": 0.288, "alpha_offset": 0.0},
     "tension": {"alpha_asym": 0.033, "alpha_offset": 0.183},
 }
@@ -120,7 +120,7 @@ class WrinklePlacement:
     Delta_x and lambda are in millimetres, phi is dimensionless.
     """
 
-    profile: Union[WrinkleProfile, WrinkleSurface3D]
+    profile: WrinkleProfile | WrinkleSurface3D
     ply_interface: int
     phase_offset: float = 0.0
 
@@ -252,7 +252,7 @@ class WrinkleConfiguration:
         decay_mode: str = "default",
         decay_floor: float = 0.0,
         amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant",
-        amplitude_profile_decay_length: Optional[float] = None,
+        amplitude_profile_decay_length: float | None = None,
         amplitude_profile_axis: Literal["x", "y"] = "x",
     ) -> None:
         if not wrinkles:
@@ -295,7 +295,7 @@ class WrinkleConfiguration:
                 f"got {amplitude_profile_decay_length}"
             )
         self.amplitude_profile: str = amplitude_profile
-        self.amplitude_profile_decay_length: Optional[float] = (
+        self.amplitude_profile_decay_length: float | None = (
             amplitude_profile_decay_length
         )
         self.amplitude_profile_axis: str = amplitude_profile_axis
@@ -970,12 +970,12 @@ class WrinkleConfiguration:
     @classmethod
     def dual_wrinkle(
         cls,
-        profile: Union[WrinkleProfile, WrinkleSurface3D],
+        profile: WrinkleProfile | WrinkleSurface3D,
         interface1: int,
         interface2: int,
         phase: float = 0.0,
         amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant",
-        amplitude_profile_decay_length: Optional[float] = None,
+        amplitude_profile_decay_length: float | None = None,
         amplitude_profile_axis: Literal["x", "y"] = "x",
     ) -> WrinkleConfiguration:
         """Create a standard dual-wrinkle configuration.
@@ -1040,12 +1040,12 @@ class WrinkleConfiguration:
     def from_morphology_name(
         cls,
         name: str,
-        profile: Union[WrinkleProfile, WrinkleSurface3D],
+        profile: WrinkleProfile | WrinkleSurface3D,
         interface1: int,
         interface2: int,
         decay_floor: float = 0.0,
         amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant",
-        amplitude_profile_decay_length: Optional[float] = None,
+        amplitude_profile_decay_length: float | None = None,
         amplitude_profile_axis: Literal["x", "y"] = "x",
     ) -> WrinkleConfiguration:
         """Create a dual-wrinkle configuration from a morphology name.

--- a/src/wrinklefe/core/wrinkle.py
+++ b/src/wrinklefe/core/wrinkle.py
@@ -26,7 +26,6 @@ laminates under multidirectional static loading. Thin-Walled Structures,
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Tuple
 
 import numpy as np
 from scipy.optimize import minimize_scalar
@@ -129,7 +128,7 @@ class WrinkleProfile(ABC):
 
     # ---- concrete helpers --------------------------------------------------
 
-    def domain(self) -> Tuple[float, float]:
+    def domain(self) -> tuple[float, float]:
         """Effective longitudinal extent covering 99.7 % of the Gaussian envelope.
 
         Returns ``(center - 3*width, center + 3*width)``.
@@ -367,7 +366,7 @@ class RectangularSinusoidal(WrinkleProfile):
             - env * k ** 2 * cos_term
         )
 
-    def domain(self) -> Tuple[float, float]:
+    def domain(self) -> tuple[float, float]:
         half = self.width / 2.0 + self.width / 4.0  # extend slightly beyond taper
         return (self.center - half, self.center + half)
 
@@ -471,7 +470,7 @@ class PureSinusoidal(WrinkleProfile):
         k = 2.0 * np.pi / self.wavelength
         return -self.amplitude * k ** 2 * np.cos(k * dx)
 
-    def domain(self) -> Tuple[float, float]:
+    def domain(self) -> tuple[float, float]:
         """Default domain: 3 wavelengths on each side of center."""
         return (self.center - 3.0 * self.wavelength, self.center + 3.0 * self.wavelength)
 
@@ -661,7 +660,7 @@ class WrinkleSurface3D:
         y = np.asarray(y, dtype=float)
         return self.profile.displacement(x) * self._f_y(y)
 
-    def gradient(self, x: np.ndarray, y: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def gradient(self, x: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Surface gradient (dz/dx, dz/dy).
 
         Parameters

--- a/src/wrinklefe/failure/base.py
+++ b/src/wrinklefe/failure/base.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any
 
 import numpy as np
 
@@ -86,7 +86,7 @@ class FailureCriterion(ABC):
         self,
         stress_local: np.ndarray,
         material: OrthotropicMaterial,
-        context: Optional[Dict[str, Any]] = None,
+        context: dict[str, Any] | None = None,
     ) -> FailureResult:
         """Evaluate the failure criterion at a single material point.
 
@@ -124,7 +124,7 @@ class FailureCriterion(ABC):
         self,
         stress_field: np.ndarray,
         material: OrthotropicMaterial,
-        contexts: Optional[list] = None,
+        contexts: list | None = None,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Evaluate the failure criterion over an array of stress states.
 

--- a/src/wrinklefe/failure/delamination.py
+++ b/src/wrinklefe/failure/delamination.py
@@ -31,7 +31,7 @@ actual CZM physics lives in
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 
 import numpy as np
 

--- a/src/wrinklefe/failure/evaluator.py
+++ b/src/wrinklefe/failure/evaluator.py
@@ -25,8 +25,8 @@ References
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Mapping, Sequence, Union
 
 import numpy as np
 
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 # Type alias for per-ply context input.  Either a sequence indexable by
 # integer ply index, or a mapping from ply index to a context dict.
-PlyContexts = Union[Sequence[Union[dict, None]], Mapping[int, Union[dict, None]], None]
+PlyContexts = Sequence[dict | None] | Mapping[int, dict | None] | None
 
 
 def _ply_context(ply_contexts: PlyContexts, k: int) -> dict | None:

--- a/src/wrinklefe/failure/larc05.py
+++ b/src/wrinklefe/failure/larc05.py
@@ -50,7 +50,7 @@ References
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import numpy as np
 
@@ -134,7 +134,7 @@ class LaRC05Criterion(FailureCriterion):
     def _in_situ_strengths(
         self,
         material: OrthotropicMaterial,
-        ply_thickness: Optional[float] = None,
+        ply_thickness: float | None = None,
     ) -> tuple[float, float]:
         """Compute in-situ transverse tensile and shear strengths.
 
@@ -422,7 +422,7 @@ class LaRC05Criterion(FailureCriterion):
         self,
         stress_local: np.ndarray,
         material: OrthotropicMaterial,
-        context: Optional[Dict[str, Any]] = None,
+        context: dict[str, Any] | None = None,
     ) -> FailureResult:
         """Evaluate the LaRC04/05 criterion at a single material point.
 

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
 # ====================================================================== #
 
 def export_results_json(
-    results: "AnalysisResults",
-    filepath: Union[str, Path],
+    results: AnalysisResults,
+    filepath: str | Path,
 ) -> None:
     """Export an :class:`~wrinklefe.analysis.AnalysisResults` object to JSON.
 
@@ -138,9 +138,9 @@ def export_results_json(
 # ====================================================================== #
 
 def export_abaqus_inp(
-    mesh: "MeshData",
-    laminate: "Laminate",
-    filepath: Union[str, Path],
+    mesh: MeshData,
+    laminate: Laminate,
+    filepath: str | Path,
 ) -> None:
     """Export mesh and laminate data to Abaqus ``.inp`` format.
 
@@ -211,9 +211,9 @@ def export_abaqus_inp(
 # ====================================================================== #
 
 def export_vtk(
-    mesh: "MeshData",
-    field_results: Optional["FieldResults"],
-    filepath: Union[str, Path],
+    mesh: MeshData,
+    field_results: FieldResults | None,
+    filepath: str | Path,
 ) -> None:
     """Export mesh and field data to VTK legacy format for ParaView.
 
@@ -402,7 +402,7 @@ def recommend_disposition(
     knockdown: float,
     damage_index: float,
     *,
-    loading: Optional[str] = None,
+    loading: str | None = None,
 ) -> dict:
     """Classify wrinkle severity and recommend a (non-binding) MRB path.
 
@@ -493,10 +493,10 @@ def build_analysis_summary(
     *,
     defect: dict,
     engineering: dict,
-    reference: Optional[str] = None,
-    prepared_by: Optional[str] = None,
-    notes: Optional[str] = None,
-    tool_version: Optional[str] = None,
+    reference: str | None = None,
+    prepared_by: str | None = None,
+    notes: str | None = None,
+    tool_version: str | None = None,
 ) -> dict:
     """Assemble a wrinkle-analysis validation summary for an NCR.
 
@@ -535,7 +535,7 @@ def build_analysis_summary(
         The structured validation summary.  JSON-serialisable.
     """
 
-    def _clean(val: Optional[str], default: str) -> str:
+    def _clean(val: str | None, default: str) -> str:
         if val is None or (isinstance(val, str) and not val.strip()):
             return default
         return str(val).strip()
@@ -549,7 +549,7 @@ def build_analysis_summary(
     disposition = recommend_disposition(kd, di, loading=loading)
 
     fe = engineering.get("fe") or None
-    fe_block: Optional[dict] = None
+    fe_block: dict | None = None
     criteria = [
         "WrinkleFE closed-form knockdown model (effective fibre-"
         "misalignment / morphology-factor formulation) — analytical "
@@ -648,7 +648,7 @@ def build_analysis_summary(
     return summary
 
 
-def _contracted_or_none(layup: Any) -> Optional[str]:
+def _contracted_or_none(layup: Any) -> str | None:
     """Contracted notation for an angle list, or ``None`` if unavailable."""
     if not layup:
         return None
@@ -932,7 +932,7 @@ def render_summary_pdf(summary: dict) -> bytes:
             )
 
     buf = _io.BytesIO()
-    fig: Optional[Any] = None
+    fig: Any | None = None
     cursor = 0.0  # inches consumed from the top of the usable area
 
     def _new_page(pdf: Any) -> Any:
@@ -982,7 +982,7 @@ def render_summary_pdf(summary: dict) -> bytes:
 
 def export_summary(
     summary: dict,
-    filepath: Union[str, Path],
+    filepath: str | Path,
     *,
     fmt: str = "md",
 ) -> None:

--- a/src/wrinklefe/io/results.py
+++ b/src/wrinklefe/io/results.py
@@ -31,7 +31,7 @@ import csv
 import json
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -120,7 +120,7 @@ def _array_or_summary(arr: Any) -> Any:
 # Config + results -> dict
 # ----------------------------------------------------------------------
 
-def _config_to_dict(cfg: "AnalysisConfig") -> dict:
+def _config_to_dict(cfg: AnalysisConfig) -> dict:
     """Serialise an :class:`AnalysisConfig` to a plain JSON-able dict.
 
     The material is reduced to its name (full property tables are not
@@ -148,7 +148,7 @@ def _config_to_dict(cfg: "AnalysisConfig") -> dict:
     return out
 
 
-def _per_ply_rows(results: "AnalysisResults") -> list[dict]:
+def _per_ply_rows(results: AnalysisResults) -> list[dict]:
     """Build the per-ply summary table.
 
     One row per ply with:
@@ -212,7 +212,7 @@ def _per_ply_rows(results: "AnalysisResults") -> list[dict]:
     return rows
 
 
-def _first_ply_failure(results: "AnalysisResults") -> dict | None:
+def _first_ply_failure(results: AnalysisResults) -> dict | None:
     """First-ply failure summary across all criteria (lowest load factor)."""
     rep = results.failure_report
     if rep is None or not getattr(rep, "fpf", None):
@@ -231,7 +231,7 @@ def _first_ply_failure(results: "AnalysisResults") -> dict | None:
     }
 
 
-def _knockdown_factors(results: "AnalysisResults") -> dict:
+def _knockdown_factors(results: AnalysisResults) -> dict:
     """Bundle the analytical + FE knockdown / retention factors."""
     out: dict = {
         "analytical": _f(results.analytical_knockdown),
@@ -251,7 +251,7 @@ def _knockdown_factors(results: "AnalysisResults") -> dict:
     return out
 
 
-def _load_factor(results: "AnalysisResults") -> float:
+def _load_factor(results: AnalysisResults) -> float:
     """Top-level "load factor" surfaced in the export.
 
     For a wrinkled laminate the most useful single number is the FPF
@@ -268,7 +268,7 @@ def _load_factor(results: "AnalysisResults") -> float:
     return _f(results.analytical_knockdown)
 
 
-def _stress_field_summary(results: "AnalysisResults") -> dict | None:
+def _stress_field_summary(results: AnalysisResults) -> dict | None:
     """Reduce the (n_elem, n_gauss, 6) stress tensor to summary stats."""
     fr = results.field_results
     if fr is None or fr.stress_global is None:
@@ -288,7 +288,7 @@ def _stress_field_summary(results: "AnalysisResults") -> dict | None:
     return out
 
 
-def results_to_dict(results: "AnalysisResults") -> dict:
+def results_to_dict(results: AnalysisResults) -> dict:
     """Build the JSON-shaped dict for :func:`export_results_json`.
 
     Exposed so callers (CLI, Streamlit, tests) can introspect the same
@@ -347,8 +347,8 @@ def results_to_dict(results: "AnalysisResults") -> dict:
 # ----------------------------------------------------------------------
 
 def export_results_json(
-    results: "AnalysisResults",
-    path: Union[str, Path],
+    results: AnalysisResults,
+    path: str | Path,
 ) -> None:
     """Write an :class:`AnalysisResults` as a schema-versioned JSON file.
 
@@ -397,8 +397,8 @@ _CSV_COLUMNS = (
 
 
 def export_results_csv(
-    results: "AnalysisResults",
-    path: Union[str, Path],
+    results: AnalysisResults,
+    path: str | Path,
 ) -> None:
     """Write the per-ply summary table as a Pandas-friendly CSV.
 

--- a/src/wrinklefe/solver/arclength.py
+++ b/src/wrinklefe/solver/arclength.py
@@ -113,9 +113,9 @@ class ArcLengthSolver:
 
     def __init__(
         self,
-        assembler: "GlobalAssembler",
-        bc_handler: "BoundaryHandler",
-        boundary_conditions: "list[BoundaryCondition] | None" = None,
+        assembler: GlobalAssembler,
+        bc_handler: BoundaryHandler,
+        boundary_conditions: list[BoundaryCondition] | None = None,
         n_arc_steps: int = 50,
         arc_length: float = 0.1,
         max_newton_iter: int = 25,

--- a/src/wrinklefe/solver/nonlinear.py
+++ b/src/wrinklefe/solver/nonlinear.py
@@ -82,9 +82,9 @@ class NewtonRaphsonSolver:
 
     def __init__(
         self,
-        assembler: "GlobalAssembler",
-        bc_handler: "BoundaryHandler",
-        boundary_conditions: "list[BoundaryCondition] | None" = None,
+        assembler: GlobalAssembler,
+        bc_handler: BoundaryHandler,
+        boundary_conditions: list[BoundaryCondition] | None = None,
         n_increments: int = 10,
         max_newton_iter: int = 25,
         tol_residual: float = 1e-4,

--- a/src/wrinklefe/solver/static.py
+++ b/src/wrinklefe/solver/static.py
@@ -738,9 +738,9 @@ class StaticSolver:
             matches = np.flatnonzero(sign_match)
             if matches.size != 1:
                 raise RuntimeError(
-                    "Failed to pair hex8 VTK node {} with a unique 2x2x2 "
-                    "Gauss point (matches={}). Did the GP or node ordering "
-                    "convention change?".format(j, matches.tolist())
+                    f"Failed to pair hex8 VTK node {j} with a unique 2x2x2 "
+                    f"Gauss point (matches={matches.tolist()}). Did the GP or node ordering "
+                    "convention change?"
                 )
             node_to_gp[j] = int(matches[0])
 

--- a/src/wrinklefe/viz/plots_2d.py
+++ b/src/wrinklefe/viz/plots_2d.py
@@ -28,7 +28,8 @@ Budiansky, B. & Fleck, N.A. (1993). J. Mech. Phys. Solids, 41(1), 183-211.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping, Optional, Sequence
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -62,8 +63,8 @@ if TYPE_CHECKING:
 # ======================================================================
 
 def plot_wrinkle_profile(
-    profile: "WrinkleProfile",
-    ax: Optional[Axes] = None,
+    profile: WrinkleProfile,
+    ax: Axes | None = None,
     n_points: int = 500,
 ) -> Axes:
     """Plot the out-of-plane displacement z(x) of a single wrinkle profile.
@@ -99,8 +100,8 @@ def plot_wrinkle_profile(
 
 
 def plot_dual_wrinkle_profiles(
-    config: "WrinkleConfiguration",
-    ax: Optional[Axes] = None,
+    config: WrinkleConfiguration,
+    ax: Axes | None = None,
     n_points: int = 500,
     show_gap: bool = True,
 ) -> Axes:
@@ -182,7 +183,7 @@ def plot_dual_wrinkle_profiles(
 
 def plot_morphology_factor(
     loading: str = "compression",
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     n_points: int = 361,
 ) -> Axes:
     """Plot morphology factor M_f as a function of phase offset phi.
@@ -242,7 +243,7 @@ def plot_morphology_factor(
 
 def plot_kinkband_concavity(
     gamma_Y: float = 0.02,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     theta_max_deg: float = 25.0,
     n_points: int = 500,
 ) -> Axes:
@@ -319,7 +320,7 @@ def plot_kinkband_concavity(
 
 def plot_strength_vs_amplitude(
     results_list: Sequence[dict],
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """Plot predicted strength versus wrinkle amplitude from a parametric sweep.
 
@@ -384,8 +385,8 @@ def plot_strength_vs_amplitude(
 
 
 def plot_strength_distribution(
-    mc_results: "MonteCarloResults",
-    ax: Optional[Axes] = None,
+    mc_results: MonteCarloResults,
+    ax: Axes | None = None,
     n_bins: int = 50,
     show_kde: bool = True,
     by_morphology: bool = False,
@@ -474,8 +475,8 @@ def plot_strength_distribution(
 
 
 def plot_jensen_gap(
-    jensen_result: "JensenGapResult",
-    ax: Optional[Axes] = None,
+    jensen_result: JensenGapResult,
+    ax: Axes | None = None,
 ) -> Axes:
     """Plot a bar chart of the Jensen gap broken down by morphology.
 
@@ -539,7 +540,7 @@ def plot_jensen_gap(
 
 def plot_failure_envelope(
     envelope_data: Sequence[dict],
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """Plot a 2D failure envelope (e.g., amplitude vs. wavelength).
 
@@ -619,11 +620,11 @@ def plot_failure_envelope(
 # ======================================================================
 
 def plot_stress_through_thickness(
-    field_results: "FieldResults",
+    field_results: FieldResults,
     x: float,
     y: float,
     component: int = 0,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """Plot a stress component through the laminate thickness.
 
@@ -677,9 +678,9 @@ def plot_stress_through_thickness(
 
 
 def plot_damage_contour(
-    mesh: "MeshData",
+    mesh: MeshData,
     damage_field: np.ndarray,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """Plot a 2D contour of damage at the laminate midplane.
 
@@ -777,8 +778,8 @@ def plot_damage_contour(
 def plot_traction_separation(
     separation_history: np.ndarray,
     traction_history: np.ndarray,
-    ax: Optional[Axes] = None,
-    label: Optional[str] = None,
+    ax: Axes | None = None,
+    label: str | None = None,
     beta: float = 1.0,
 ) -> Axes:
     """Plot the traction-separation trajectory at a single cohesive Gauss point.
@@ -858,8 +859,8 @@ def plot_traction_separation(
 
 def plot_load_displacement(
     load_displacement: np.ndarray,
-    ax: Optional[Axes] = None,
-    label: Optional[str] = None,
+    ax: Axes | None = None,
+    label: str | None = None,
 ) -> Axes:
     """Plot the load-displacement response from a CZM Newton-Raphson run.
 
@@ -921,7 +922,7 @@ def plot_load_displacement(
 
 def plot_damage_histogram(
     damage: np.ndarray,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     bins: int = 20,
 ) -> Axes:
     """Plot a histogram of the cohesive damage variable.
@@ -981,7 +982,7 @@ def plot_damage_histogram(
 def plot_interface_damage_field(
     damage_per_elem: np.ndarray,
     xy_centroids: np.ndarray,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     cmap: str = "viridis",
 ) -> Axes:
     """Scatter the per-element damage on the interface (x, y) plane.
@@ -1048,7 +1049,7 @@ def plot_interface_damage_field(
 
 def plot_energy_per_interface(
     energy_per_interface: Mapping[int, float],
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """Bar chart of cohesive energy dissipated, broken down by interface.
 
@@ -1107,7 +1108,7 @@ def plot_energy_per_interface(
     return ax
 
 
-def czm_overview_figure(results: "AnalysisResults") -> Figure:
+def czm_overview_figure(results: AnalysisResults) -> Figure:
     """Build a 2x2 dashboard of CZM outputs from an ``AnalysisResults``.
 
     Panels:

--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -42,7 +42,7 @@ Elhajjar, R. (2025). Scientific Reports, 15, 25977.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -95,7 +95,7 @@ _HEX_FACE_SIDE = np.array([0, 1, 0, 1, 0, 1], dtype=np.int64)  # 0 = min, 1 = ma
 # Helper functions
 # ======================================================================
 
-def _sample_elements(mesh: "MeshData", max_elements: int = 2000) -> np.ndarray:
+def _sample_elements(mesh: MeshData, max_elements: int = 2000) -> np.ndarray:
     """Select a subset of element indices for rendering.
 
     For large meshes, rendering every element is prohibitively slow.
@@ -120,7 +120,7 @@ def _sample_elements(mesh: "MeshData", max_elements: int = 2000) -> np.ndarray:
     return np.arange(0, n_elem, step)
 
 
-def _is_full_structured_set(mesh: "MeshData", elem_indices: np.ndarray) -> bool:
+def _is_full_structured_set(mesh: MeshData, elem_indices: np.ndarray) -> bool:
     """Return True if ``elem_indices`` covers the full structured mesh.
 
     The fast structured-mesh boundary-culling shortcut is only valid when
@@ -146,7 +146,7 @@ def _is_full_structured_set(mesh: "MeshData", elem_indices: np.ndarray) -> bool:
     return bool(np.array_equal(elem_indices, np.arange(expected)))
 
 
-def _structured_boundary_mask(mesh: "MeshData") -> np.ndarray:
+def _structured_boundary_mask(mesh: MeshData) -> np.ndarray:
     """Boolean mask over ``(n_elements, 6)`` marking boundary faces.
 
     Uses the structured-grid rule: face ``f`` of element ``(i, j, k)`` is
@@ -182,7 +182,7 @@ def _structured_boundary_mask(mesh: "MeshData") -> np.ndarray:
 
 
 def _general_boundary_mask(
-    mesh: "MeshData", elem_indices: np.ndarray
+    mesh: MeshData, elem_indices: np.ndarray
 ) -> np.ndarray:
     """Boolean mask over ``(len(elem_indices), 6)`` for arbitrary subsets.
 
@@ -210,11 +210,11 @@ def _general_boundary_mask(
 
 
 def _gather_boundary_faces(
-    mesh: "MeshData",
+    mesh: MeshData,
     elem_indices: np.ndarray,
     nodes: np.ndarray,
-    elem_scalar: Optional[np.ndarray] = None,
-) -> tuple[np.ndarray, Optional[np.ndarray]]:
+    elem_scalar: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray | None]:
     """Return boundary-face vertices (and optional per-face scalars).
 
     Combines structured-mesh culling (when the full mesh is selected) with
@@ -261,7 +261,7 @@ def _gather_boundary_faces(
 
     face_verts = face_verts_all[mask]                 # (n_bnd, 4, 3)
 
-    face_scalar: Optional[np.ndarray] = None
+    face_scalar: np.ndarray | None = None
     if elem_scalar is not None:
         if _is_full_structured_set(mesh, elem_indices):
             elem_vals = elem_scalar
@@ -281,8 +281,8 @@ def _gather_boundary_faces(
 # ======================================================================
 
 def plot_mesh_3d(
-    mesh: "MeshData",
-    ax: Optional[Axes] = None,
+    mesh: MeshData,
+    ax: Axes | None = None,
     max_elements: int = 2000,
     show_edges: bool = True,
     face_alpha: float = 0.15,
@@ -352,12 +352,12 @@ def plot_mesh_3d(
 # ======================================================================
 
 def plot_displacement_3d(
-    field_results: "FieldResults",
+    field_results: FieldResults,
     component: int = 2,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     max_elements: int = 2000,
     scale: float = 1.0,
-    cmap: Optional[str] = None,
+    cmap: str | None = None,
 ) -> Axes:
     """Plot the deformed mesh colored by a displacement component.
 
@@ -469,12 +469,12 @@ def plot_displacement_3d(
 # ======================================================================
 
 def plot_stress_contour_3d(
-    field_results: "FieldResults",
+    field_results: FieldResults,
     component: int = 0,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     max_elements: int = 2000,
     coord: str = "global",
-    cmap: Optional[str] = None,
+    cmap: str | None = None,
 ) -> Axes:
     """Plot stress contour on the deformed mesh.
 
@@ -589,12 +589,12 @@ def plot_stress_contour_3d(
 # ======================================================================
 
 def plot_buckling_mode(
-    buckling_result: "BucklingResult",
+    buckling_result: BucklingResult,
     mode: int = 0,
     scale: float = 1.0,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     max_elements: int = 2000,
-    cmap: Optional[str] = None,
+    cmap: str | None = None,
 ) -> Axes:
     """Plot a buckling mode shape on the deformed mesh.
 

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -17,8 +17,9 @@ Elhajjar, R. (2025). Scientific Reports, 15, 25977.
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Iterator, Optional, Union
+from typing import Any
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -236,9 +237,9 @@ def get_morphology_style(morph: str) -> dict:
 
 
 def ensure_axes(
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     figsize: tuple[float, float] = FIGSIZE_SINGLE_COLUMN,
-    projection: Optional[str] = None,
+    projection: str | None = None,
 ) -> Axes:
     """Return the given Axes or create a new figure with one.
 
@@ -266,8 +267,8 @@ def ensure_axes(
 
 def set_axes_equal_aspect(
     ax: Axes,
-    mins: "np.ndarray",
-    maxs: "np.ndarray",
+    mins: np.ndarray,
+    maxs: np.ndarray,
 ) -> None:
     """Set a 3D axes box aspect to match physical data extents.
 
@@ -299,8 +300,8 @@ def set_axes_equal_aspect(
 
 
 def save_figure(
-    ax_or_fig: Union[Axes, Figure],
-    path: Union[str, "os.PathLike[str]"],
+    ax_or_fig: Axes | Figure,
+    path: str | os.PathLike[str],
     *,
     close: bool = True,
     dpi: int = 300,
@@ -340,7 +341,7 @@ def save_figure(
 
 
 @contextmanager
-def figure_context(ax_or_fig: Union[Axes, Figure]) -> Iterator[Figure]:
+def figure_context(ax_or_fig: Axes | Figure) -> Iterator[Figure]:
     """Context manager that closes an internally-created figure on exit.
 
     Use this to wrap a ``plot_*`` call in leak-prone batch loops when you are

--- a/tests/test_analysis_progress.py
+++ b/tests/test_analysis_progress.py
@@ -11,8 +11,6 @@ identically.
 
 from __future__ import annotations
 
-from typing import List, Tuple
-
 import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
@@ -61,7 +59,7 @@ def _tiny_fe_config() -> AnalysisConfig:
     )
 
 
-def _assert_progress_trace_valid(trace: List[Tuple[str, float]]) -> None:
+def _assert_progress_trace_valid(trace: list[tuple[str, float]]) -> None:
     """Common invariants every progress trace must satisfy."""
     assert len(trace) >= 2, (
         f"progress_callback should fire at least twice (got {len(trace)}): {trace}"
@@ -93,7 +91,7 @@ def _assert_progress_trace_valid(trace: List[Tuple[str, float]]) -> None:
 
 def test_progress_callback_analytical_only():
     """Callback fires through the analytical-only path and ends at 1.0."""
-    trace: List[Tuple[str, float]] = []
+    trace: list[tuple[str, float]] = []
 
     def cb(label: str, fraction: float) -> None:
         trace.append((label, fraction))
@@ -106,7 +104,7 @@ def test_progress_callback_analytical_only():
 
 def test_progress_callback_full_fe_path():
     """Callback fires through every FE phase boundary and ends at 1.0."""
-    trace: List[Tuple[str, float]] = []
+    trace: list[tuple[str, float]] = []
 
     def cb(label: str, fraction: float) -> None:
         trace.append((label, fraction))


### PR DESCRIPTION
Refs #87 — third and final autofixable widening of CI's enforced Ruff scope (follows #287 E/W/I and #288 F).

## What
- **UP045/UP007:** `Optional[X]` → `X | None` and `Union[...]` → `|` unions (124 sites), including the runtime `PlyContexts` type alias — safe at runtime on the py310 floor (PEP 604).
- **UP006/UP035:** `typing.List/Dict/Tuple` → builtin generics (84 sites, PEP 585); the typing imports left dead by the rewrite were removed and import blocks re-sorted, keeping the already-enforced F and I families clean.
- **UP037:** 47 quoted annotations unquoted (all under `from __future__ import annotations`).
- **UP032:** one `.format()` → f-string.
- **CI:** lint job now enforces `E,W,I,F,UP` — everything in `pyproject.toml`'s configured select **except N** (scientific naming, ~1343 violations, which needs a per-file noqa policy before anyone renames domain identifiers like `E1`/`Q11`/`sigma_x`).

## Verification
- Full local test suite minus the heavy CZM-validation integration directory: **1275 passed, 9 skipped**.
- `scripts/validate.py`: zero drift on all pinned baselines.
- `sphinx-build -W` clean; CLI smoke run OK.
- `ruff check --select E,W,I,F,UP .` clean repo-wide.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_