### PR TITLE
lint: enforce ruff's full pyproject config in CI (closes #87)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,12 +27,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      # Enforced scope: E (pycodestyle errors), W (warnings), I (isort),
-      # F (pyflakes), UP (pyupgrade). The one remaining family from
-      # pyproject.toml's full config is N (~1343, scientific naming --
-      # needs a per-file noqa policy before any renaming); see issue #87.
-      - name: Ruff (enforced scope - E,W,I,F,UP)
-        run: ruff check --select E,W,I,F,UP .
+      # Full config: CI now runs ruff's complete pyproject.toml ruleset
+      # (E, F, W, I, N, UP) with no --select override, completing the
+      # incremental widening tracked in issue #87. The scientific-naming
+      # codes that clash with composite-mechanics notation (N802/803/806/
+      # 815/816) are documented ignores in pyproject's [tool.ruff.lint].
+      - name: Ruff (full pyproject config)
+        run: ruff check .
 
       # Starter scope: package `__init__` only. Broader src/wrinklefe has ~102
       # mypy errors today (mostly numpy `Any` returns + missing stubs); fixing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,20 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP"]
+# WrinkleFE follows established composite-mechanics / FE notation
+# throughout (E1, G12, Q11, Ke, B, J, T, sigma_x, gamma_Y, GIc, eta_BK,
+# Voigt indices, ...). The pep8-naming codes that clash with that
+# convention are ignored project-wide rather than fought with hundreds
+# of per-line noqa or by renaming domain terms (issue #87, and the
+# `fix-ruff-violations` guidance to prefer ignores over renames here):
+#   N802 function name / N803 argument name / N806 local variable —
+#     math-symbol identifiers in functions, args, and bodies.
+#   N815 mixedCase class attribute / N816 mixedCase global —
+#     unit- and mode-suffixed fields like analytical_strength_MPa,
+#     czm_GIc, mode_ratio_init_FE.
+# N801 (class names) stays enforced: it caught a genuinely off-convention
+# test class with no domain justification.
+ignore = ["N802", "N803", "N806", "N815", "N816"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_morphology_apply_nodes.py
+++ b/tests/test_morphology_apply_nodes.py
@@ -560,7 +560,7 @@ _VALID_K_N_INTERFACE = [
 ]
 
 
-class TestIssue17_18DefaultDecayBC:
+class TestIssue1718DefaultDecayBC:
     """Regression tests pinning the contract from issues #17 and #18.
 
     Issue #17: in default decay mode the through-thickness displacement


### PR DESCRIPTION
Closes #87 — final step of the incremental lint widening (follows #287 E/W/I, #288 F, #289 UP).

## What
The N (pep8-naming) family is ~1247 violations, **essentially all established composite-mechanics / FE notation** — `E1`, `Q11`, `Ke`, `B`, `J`, `T`, `sigma_x`, `gamma_Y`, `GIc`, `eta_BK`, Voigt indices. Per the `fix-ruff-violations` guidance to *prefer ignores over renaming domain terms*, the five codes that clash with that convention are now documented project-wide ignores in `pyproject.toml`'s `[tool.ruff.lint]`:

- **N802** function name, **N803** argument name, **N806** local variable
- **N815** mixedCase class attribute, **N816** mixedCase global

I reviewed the low-count codes individually rather than blanket-ignoring all of N: every N815/N816 hit is a genuine domain name (`czm_GIc`, `gamma_Y`, `delta_T`, `mode_ratio_init_FE`, …). **N801 (class names) stays enforced** and it caught the one genuine violation with no domain justification — the test class `TestIssue17_18DefaultDecayBC` (underscore between issue numbers broke CapWords) → `TestIssue1718DefaultDecayBC`.

With the repo passing ruff's full configured ruleset, `lint.yml` drops its incremental `--select` override and simply runs **`ruff check .`** (E, F, W, I, N, UP). CI's enforced scope now matches `pyproject.toml` exactly — the stated goal of #87.

## Verification
- `ruff check .` (full pyproject config) clean repo-wide.
- `tests/test_morphology_apply_nodes.py` (home of the renamed class): 74 passed.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_