### PR TITLE
types: bring core/ and elements/ under mypy, widen CI scope (#87 follow-up)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Ruff (full pyproject config)
         run: ruff check .
 
-      # Starter scope: package `__init__` only. Broader src/wrinklefe has ~102
-      # mypy errors today (mostly numpy `Any` returns + missing stubs); fixing
-      # those is tracked as a follow-up to issue #87.
-      - name: Mypy (starter scope - package init)
-        run: mypy src/wrinklefe/__init__.py
+      # Walking outward module-by-module (expand-mypy-coverage skill):
+      # core/ and elements/ are clean; failure/, solver/, viz/, sweep/,
+      # io/, analysis.py, and cli.py still carry errors (mostly numpy
+      # `Any` returns) and are the next passes.
+      - name: Mypy (scope - package init + core + elements)
+        run: mypy src/wrinklefe/__init__.py src/wrinklefe/core src/wrinklefe/elements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest-cov>=4.0",
     "ruff>=0.1",
     "mypy>=1.5",
+    "scipy-stubs>=1.14",
 ]
 docs = [
     "sphinx>=8.0",

--- a/src/wrinklefe/core/laminate.py
+++ b/src/wrinklefe/core/laminate.py
@@ -145,7 +145,7 @@ class Ply:
     @property
     def angle_rad(self) -> float:
         """Fiber angle in radians."""
-        return np.deg2rad(self.angle)
+        return float(np.deg2rad(self.angle))
 
     def Q(self) -> np.ndarray:
         """Reduced stiffness matrix [Q] in material (1-2) coordinates.
@@ -341,7 +341,7 @@ class Laminate:
             Midplane z-coordinate (mm).
         """
         zc = self.z_coords()
-        return 0.5 * (zc[i] + zc[i + 1])
+        return float(0.5 * (zc[i] + zc[i + 1]))
 
     @property
     def is_symmetric(self) -> bool:
@@ -529,7 +529,7 @@ class Laminate:
             NM[0:3] += NT
             NM[3:6] += MT
 
-        return self.abd_inverse() @ NM
+        return np.asarray(self.abd_inverse() @ NM)
 
     def _ply_z(self, ply_idx: int, position: Literal['top', 'mid', 'bottom'] = 'mid') -> float:
         """Return the z-coordinate for a given position within a ply.
@@ -550,11 +550,11 @@ class Laminate:
         z_bot = zc[ply_idx]
         z_top = zc[ply_idx + 1]
         if position == 'bottom':
-            return z_bot
+            return float(z_bot)
         elif position == 'top':
-            return z_top
+            return float(z_top)
         else:
-            return 0.5 * (z_bot + z_top)
+            return float(0.5 * (z_bot + z_top))
 
     def ply_strains(
         self,
@@ -616,7 +616,7 @@ class Laminate:
         """
         eps = self.ply_strains(load, ply_idx, position)
         Qb = self.plies[ply_idx].Q_bar()
-        return Qb @ eps
+        return np.asarray(Qb @ eps)
 
     def ply_stresses_local(
         self,
@@ -646,7 +646,7 @@ class Laminate:
         sig_global = self.ply_stresses_global(load, ply_idx, position)
         theta = self.plies[ply_idx].angle_rad
         T = self._stress_transformation_matrix(theta)
-        return T @ sig_global
+        return np.asarray(T @ sig_global)
 
     @staticmethod
     def _stress_transformation_matrix(theta: float) -> np.ndarray:
@@ -724,19 +724,19 @@ class Laminate:
         Computed from the extensional compliance: E_x = 1 / (a_11 * h).
         """
         h = self.total_thickness
-        return 1.0 / (self._a_matrix[0, 0] * h)
+        return float(1.0 / (self._a_matrix[0, 0] * h))
 
     @cached_property
     def Ey(self) -> float:
         """Effective laminate Young's modulus in y-direction (MPa)."""
         h = self.total_thickness
-        return 1.0 / (self._a_matrix[1, 1] * h)
+        return float(1.0 / (self._a_matrix[1, 1] * h))
 
     @cached_property
     def Gxy(self) -> float:
         """Effective laminate shear modulus (MPa)."""
         h = self.total_thickness
-        return 1.0 / (self._a_matrix[2, 2] * h)
+        return float(1.0 / (self._a_matrix[2, 2] * h))
 
     @cached_property
     def nu_xy(self) -> float:
@@ -744,7 +744,7 @@ class Laminate:
 
         Defined as nu_xy = -a_12 / a_11.
         """
-        return -self._a_matrix[0, 1] / self._a_matrix[0, 0]
+        return float(-self._a_matrix[0, 1] / self._a_matrix[0, 0])
 
     # ----- String representation -------------------------------------------
 

--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -53,7 +53,17 @@ class MeshValidationError(ValueError):
     centroid).  Catching ``ValueError`` also catches this exception
     for backwards compatibility with callers that previously relied on
     ``WrinkleMesh.generate()`` only ever raising ``ValueError``.
+
+    Attributes
+    ----------
+    inverted_element_indices : np.ndarray or None
+        Indices of the inverted/degenerate elements, attached at raise.
+    detJ : np.ndarray or None
+        Per-element centroid Jacobian determinants, attached at raise.
     """
+
+    inverted_element_indices: np.ndarray | None = None
+    detJ: np.ndarray | None = None
 
 
 # Through-thickness wrinkle-decay ratio (``nz_per_ply * amplitude /
@@ -215,12 +225,12 @@ class MeshData:
     @property
     def n_nodes(self) -> int:
         """Total number of nodes."""
-        return self.nodes.shape[0]
+        return int(self.nodes.shape[0])
 
     @property
     def n_elements(self) -> int:
         """Total number of elements."""
-        return self.elements.shape[0]
+        return int(self.elements.shape[0])
 
     @property
     def n_dof(self) -> int:
@@ -250,7 +260,7 @@ class MeshData:
         np.ndarray
             Shape ``(8, 3)`` coordinate array.
         """
-        return self.nodes[self.elements[elem_idx]]
+        return np.asarray(self.nodes[self.elements[elem_idx]])
 
     def element_center(self, elem_idx: int) -> np.ndarray:
         """Return the ``(3,)`` centroid of an element.
@@ -265,7 +275,7 @@ class MeshData:
         np.ndarray
             Shape ``(3,)`` centroid coordinates (mm).
         """
-        return self.element_nodes(elem_idx).mean(axis=0)
+        return np.asarray(self.element_nodes(elem_idx).mean(axis=0))
 
     def element_fiber_angle(self, elem_idx: int) -> float:
         """Return the average fiber misalignment angle for an element (radians).
@@ -293,7 +303,7 @@ class MeshData:
         np.ndarray
             Shape ``(n_elements,)`` array of mean fiber angles (radians).
         """
-        return self.fiber_angles[self.elements].mean(axis=1)
+        return np.asarray(self.fiber_angles[self.elements].mean(axis=1))
 
     # ---- boundary / set queries --------------------------------------------
 
@@ -391,15 +401,15 @@ class MeshData:
         nyp = self.ny + 1
 
         def node_id(i: np.ndarray, j: np.ndarray, k: np.ndarray) -> np.ndarray:
-            return k * (nyp * nxp) + j * nxp + i
+            return np.asarray(k * (nyp * nxp) + j * nxp + i)
 
         if face in ("x_min", "x_max"):
             i_fix = 0 if face == "x_min" else self.nx
             ej = np.arange(self.ny)
             ek = np.arange(self.nz)
-            kk, jj = np.meshgrid(ek, ej, indexing="ij")
-            kk = kk.ravel()
-            jj = jj.ravel()
+            kk_g, jj_g = np.meshgrid(ek, ej, indexing="ij")
+            kk = kk_g.ravel()
+            jj = jj_g.ravel()
             ii = np.full_like(jj, i_fix)
             # CCW viewed from outside (+x or -x normal)
             n0 = node_id(ii, jj, kk)
@@ -410,9 +420,9 @@ class MeshData:
             j_fix = 0 if face == "y_min" else self.ny
             ei = np.arange(self.nx)
             ek = np.arange(self.nz)
-            kk, ii = np.meshgrid(ek, ei, indexing="ij")
-            kk = kk.ravel()
-            ii = ii.ravel()
+            kk_g, ii_g = np.meshgrid(ek, ei, indexing="ij")
+            kk = kk_g.ravel()
+            ii = ii_g.ravel()
             jj = np.full_like(ii, j_fix)
             n0 = node_id(ii, jj, kk)
             n1 = node_id(ii + 1, jj, kk)
@@ -422,9 +432,9 @@ class MeshData:
             k_fix = 0 if face == "z_min" else self.nz
             ei = np.arange(self.nx)
             ej = np.arange(self.ny)
-            jj, ii = np.meshgrid(ej, ei, indexing="ij")
-            jj = jj.ravel()
-            ii = ii.ravel()
+            jj_g, ii_g = np.meshgrid(ej, ei, indexing="ij")
+            jj = jj_g.ravel()
+            ii = ii_g.ravel()
             kk = np.full_like(ii, k_fix)
             n0 = node_id(ii, jj, kk)
             n1 = node_id(ii + 1, jj, kk)
@@ -875,14 +885,14 @@ class WrinkleMesh:
         ek = np.arange(self.nz)
 
         # 3-D index arrays — shape (nz, ny, nx) with k slowest, j middle, i fastest
-        ki, ji, ii = np.meshgrid(ek, ej, ei, indexing="ij")
-        ki = ki.ravel()
-        ji = ji.ravel()
-        ii = ii.ravel()
+        ki_g, ji_g, ii_g = np.meshgrid(ek, ej, ei, indexing="ij")
+        ki = ki_g.ravel()
+        ji = ji_g.ravel()
+        ii = ii_g.ravel()
 
         def node_id(i: np.ndarray, j: np.ndarray, k: np.ndarray) -> np.ndarray:
             """Convert (i, j, k) grid indices to flat node index."""
-            return k * (nyp * nxp) + j * nxp + i
+            return np.asarray(k * (nyp * nxp) + j * nxp + i)
 
         n0 = node_id(ii, ji, ki)
         n1 = node_id(ii + 1, ji, ki)

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -536,7 +536,13 @@ class WrinkleConfiguration:
         float
             Maximum misalignment angle theta_max [radians].
         """
-        return max(w.profile.max_angle() for w in self.wrinkles)
+        angles = []
+        for w in self.wrinkles:
+            profile = w.profile
+            if isinstance(profile, WrinkleSurface3D):
+                profile = profile.profile
+            angles.append(profile.max_angle())
+        return max(angles)
 
     def effective_angle(self, loading: str = "compression") -> float:
         """Effective fiber misalignment angle accounting for morphology.
@@ -769,7 +775,7 @@ class WrinkleConfiguration:
             p_mid = (n_plies - 1) / 2.0
             raw = 1.0 - np.abs(p - p_mid) / p_mid  # 1 at mid, 0 at surface
             decay = self.decay_floor + (1.0 - self.decay_floor) * raw
-            return np.maximum(0.0, decay)
+            return np.asarray(np.maximum(0.0, decay))
 
         # Default per-ply linear decay shared with ``_ply_decay``.
         if n_plies <= 1:
@@ -867,7 +873,7 @@ class WrinkleConfiguration:
 
             deformed[:, 2] += dz
 
-        return deformed
+        return np.asarray(deformed)
 
     def fiber_angles_at_nodes(
         self,
@@ -950,11 +956,20 @@ class WrinkleConfiguration:
             k = wrinkle.ply_interface
 
             # Convert phase offset to geometric longitudinal shift
-            delta_x = wrinkle.phase_offset * profile.wavelength / (2.0 * np.pi)
+            if isinstance(profile, WrinkleSurface3D):
+                wavelength = profile.profile.wavelength
+            else:
+                wavelength = profile.wavelength
+            delta_x = wrinkle.phase_offset * wavelength / (2.0 * np.pi)
             x_shifted = x - delta_x
 
-            # 1-D profile slope is broadcast over all nodes in C.
-            slope = profile.slope(x_shifted)
+            # 1-D profile slope is broadcast over all nodes in C; a 3-D
+            # surface contributes the x-gradient of its own displacement
+            # field (mirrors the apply_to_nodes composition).
+            if isinstance(profile, WrinkleSurface3D):
+                slope = profile.gradient(x_shifted, y)[0]
+            else:
+                slope = profile.slope(x_shifted)
 
             amp_scale = self._amplitude_scale_vec(wrinkle, x, y)
             decay = self._through_thickness_decay(ply_ids, k, n_plies) * amp_scale

--- a/src/wrinklefe/core/transforms.py
+++ b/src/wrinklefe/core/transforms.py
@@ -203,7 +203,7 @@ def strain_transformation_3d(angle_rad: float, axis: str = 'z') -> np.ndarray:
     R = np.diag([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
     R_inv = np.diag([1.0, 1.0, 1.0, 0.5, 0.5, 0.5])
 
-    return R @ T_sigma @ R_inv
+    return np.asarray(R @ T_sigma @ R_inv)
 
 
 def rotate_stiffness_3d(
@@ -249,7 +249,7 @@ def rotate_stiffness_3d(
     T_epsilon = strain_transformation_3d(angle_rad, axis=axis)
     T_sigma_inv = np.linalg.inv(T_sigma)
 
-    return T_sigma_inv @ C @ T_epsilon
+    return np.asarray(T_sigma_inv @ C @ T_epsilon)
 
 
 def reduced_stiffness_matrix(

--- a/src/wrinklefe/core/wrinkle.py
+++ b/src/wrinklefe/core/wrinkle.py
@@ -148,7 +148,7 @@ class WrinkleProfile(ABC):
         numpy.ndarray
             Fiber angle at each *x* location (radians).
         """
-        return np.arctan(self.slope(np.asarray(x, dtype=float)))
+        return np.asarray(np.arctan(self.slope(np.asarray(x, dtype=float))))
 
     def max_angle(self) -> float:
         """Numerical maximum fiber misalignment angle (radians).
@@ -182,7 +182,7 @@ class WrinkleProfile(ABC):
         xlo, xhi = self.domain()
 
         def abs_slope_arr(xv: np.ndarray) -> np.ndarray:
-            return np.abs(self.slope(np.asarray(xv, dtype=float)))
+            return np.asarray(np.abs(self.slope(np.asarray(xv, dtype=float))))
 
         # Dense grid sweep to locate the global argmax robustly.  4096 pts
         # over a <=6-wavelength support => hundreds of samples per wrinkle
@@ -658,7 +658,7 @@ class WrinkleSurface3D:
         """
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
-        return self.profile.displacement(x) * self._f_y(y)
+        return np.asarray(self.profile.displacement(x) * self._f_y(y))
 
     def gradient(self, x: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Surface gradient (dz/dx, dz/dy).
@@ -725,4 +725,4 @@ class WrinkleSurface3D:
             Misalignment angle (radians).
         """
         dz_dx, _ = self.gradient(x, y)
-        return np.arctan(dz_dx)
+        return np.asarray(np.arctan(dz_dx))

--- a/src/wrinklefe/elements/cohesive8.py
+++ b/src/wrinklefe/elements/cohesive8.py
@@ -241,7 +241,7 @@ class Cohesive8Element:
         self.elem_id = elem_id
 
         self._gp_points, self._gp_weights = _gauss_points_quad(order=2)
-        self._n_gp = self._gp_points.shape[0]
+        self._n_gp: int = int(self._gp_points.shape[0])
 
         # Pre-compute local frame and 2D detJ at each Gauss point from the
         # bottom-face reference geometry — these are constant for the

--- a/src/wrinklefe/elements/hex8.py
+++ b/src/wrinklefe/elements/hex8.py
@@ -113,7 +113,7 @@ def _detJ_at_centroid_batch(elem_coords: np.ndarray) -> np.ndarray:
         )
     # J has shape (n_elem, 3, 3); broadcast _DN_CENTROID across n_elem.
     J = np.einsum("ij,njk->nik", _DN_CENTROID, elem_coords)
-    return np.linalg.det(J)
+    return np.asarray(np.linalg.det(J))
 
 
 class Hex8Element:
@@ -296,7 +296,7 @@ class Hex8Element:
             Shape ``(3, 3)`` — the Jacobian matrix ``dx/d(xi)``.
         """
         dN = self.shape_derivatives(xi, eta, zeta)  # (3, 8)
-        return dN @ self.node_coords  # (3, 8) @ (8, 3) = (3, 3)
+        return np.asarray(dN @ self.node_coords)  # (3, 8) @ (8, 3) = (3, 3)
 
     def B_matrix(self, xi: float, eta: float, zeta: float) -> np.ndarray:
         """Strain-displacement matrix (6 x 24) in Voigt notation.

--- a/src/wrinklefe/elements/hex8i.py
+++ b/src/wrinklefe/elements/hex8i.py
@@ -383,7 +383,7 @@ class Hex8IElement(Hex8Element):
         self._K_aa_inv = K_aa_inv
         self._K_au = K_au
 
-        return K_condensed
+        return np.asarray(K_condensed)
 
     # ------------------------------------------------------------------
     # Internal DOF recovery


### PR DESCRIPTION
Follow-up to #87 (the mypy half noted in `lint.yml`) — first two modules of the `expand-mypy-coverage` walk. mypy is now clean on `src/wrinklefe/core` and `src/wrinklefe/elements` (14 source files under the strict `warn_return_any` config), up from the package-init-only starter scope.

## Fix classes (skill priority order)
- **scipy-stubs** added to the `dev` extra — resolves the `scipy.optimize` import-untyped error properly instead of ignoring it.
- **numpy `Any`-leak returns (33 sites):** `float()`/`int()` for scalar returns; `np.asarray()` (no-copy on ndarray input) for array returns from ufuncs, `@`-products, `det`/`einsum`, and fancy indexing; `cohesive8._n_gp` annotated `int` at assignment.
- **meshgrid→ravel reassignments (9 sites):** grid-shaped intermediates get their own `*_g` names instead of being reassigned to 1-D under the same variable.
- **`MeshValidationError.inverted_element_indices` / `.detJ`** declared as class attributes (None defaults) instead of attached dynamically at raise.
- **Two genuine latent bugs exposed by `[union-attr]`:** `WrinkleConfiguration.max_angle()` and `fiber_angles_at_nodes()` would have raised `AttributeError` on a `WrinkleSurface3D` placement (it has no `.max_angle`/`.wavelength`/`.slope`). Both now unwrap to the inner 1-D profile exactly as `apply_to_nodes` already did, and the surface's slope comes from its own `gradient(x, y)[0]` — consistent with the composed-field convention from #252.

## CI
`lint.yml`'s mypy step now checks `__init__` + `core/` + `elements/`, with the remaining modules (`failure/`, `solver/`, `viz/`, `sweep/`, `io/`, `analysis.py`, `cli.py`) documented as the next passes.

## Verification
- `mypy src/wrinklefe/__init__.py src/wrinklefe/core src/wrinklefe/elements` clean.
- 645 tests pass: wrinkle, laminate, mesh, morphology (incl. every parity suite), elements, transforms, material, validation ledger (zero drift), multi-wrinkle FE, solver, CZM, integration analysis.
- `ruff check .` (full config) clean; `sphinx-build -W` clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_