### PR TITLE
types: bring failure/ and solver/ under mypy, widen CI scope (#87 follow-up)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,9 @@ jobs:
         run: ruff check .
 
       # Walking outward module-by-module (expand-mypy-coverage skill):
-      # core/ and elements/ are clean; failure/, solver/, viz/, sweep/,
-      # io/, analysis.py, and cli.py still carry errors (mostly numpy
-      # `Any` returns) and are the next passes.
-      - name: Mypy (scope - package init + core + elements)
-        run: mypy src/wrinklefe/__init__.py src/wrinklefe/core src/wrinklefe/elements
+      # core/, elements/, failure/, and solver/ are clean; viz/, sweep/,
+      # io/, analysis.py, and cli.py are the next passes.
+      - name: Mypy (scope - init + core + elements + failure + solver)
+        run: >-
+          mypy src/wrinklefe/__init__.py src/wrinklefe/core
+          src/wrinklefe/elements src/wrinklefe/failure src/wrinklefe/solver

--- a/src/wrinklefe/failure/hashin.py
+++ b/src/wrinklefe/failure/hashin.py
@@ -191,7 +191,7 @@ class HashinCriterion(FailureCriterion):
             "matrix_tension": fi_mt,
             "matrix_compression": fi_mc,
         }
-        dominant = max(modes, key=modes.get)
+        dominant = max(modes, key=lambda m: modes[m])
         fi_max = modes[dominant]
 
         if fi_max <= 0:
@@ -395,4 +395,4 @@ def _quadratic_reserve_factor(A: float, B: float) -> float:
     candidates = [r for r in (r_plus, r_minus) if r > 0.0]
     if not candidates:
         return float("inf")
-    return min(candidates)
+    return float(min(candidates))

--- a/src/wrinklefe/failure/kinkband.py
+++ b/src/wrinklefe/failure/kinkband.py
@@ -150,7 +150,7 @@ class BudianskyFleckKinkBand(FailureCriterion):
         float
             Knockdown factor in (0, 1].
         """
-        return (1.0 - self.damage_index) ** 1.5
+        return float((1.0 - self.damage_index) ** 1.5)
 
     def combined_knockdown(
         self,

--- a/src/wrinklefe/failure/larc05.py
+++ b/src/wrinklefe/failure/larc05.py
@@ -223,7 +223,7 @@ class LaRC05Criterion(FailureCriterion):
         fi = (s1 / material.Xt) ** 2 + (t12 / material.S12) ** 2
         if material.S13 > 0:
             fi += (t13 / material.S13) ** 2
-        return np.sqrt(max(fi, 0.0))
+        return float(np.sqrt(max(fi, 0.0)))
 
     # ------------------------------------------------------------------
     # Fibre kinking with misalignment frame + nonlinear shear

--- a/src/wrinklefe/failure/progressive.py
+++ b/src/wrinklefe/failure/progressive.py
@@ -386,7 +386,9 @@ class ContinuumDamage(ProgressiveDamageModel):
     @property
     def is_damaged(self) -> bool:
         """Whether any damage variable is non-zero."""
-        return self.d_fiber > 0.0 or self.d_matrix > 0.0 or self.d_shear > 0.0
+        return bool(
+            self.d_fiber > 0.0 or self.d_matrix > 0.0 or self.d_shear > 0.0
+        )
 
     def reset(self) -> None:
         """Reset all damage variables to zero (undamaged state)."""

--- a/src/wrinklefe/failure/tsai_hill.py
+++ b/src/wrinklefe/failure/tsai_hill.py
@@ -110,7 +110,7 @@ class TsaiHillCriterion(FailureCriterion):
             "shear_13": term_s13,
             "shear_23": term_s23,
         }
-        mode = max(mode_terms, key=mode_terms.get)
+        mode = max(mode_terms, key=lambda m: mode_terms[m])
 
         # ``fi`` is the quadratic Tsai-Hill invariant (FI=1 at failure, paper
         # convention).  Every contributing term is purely quadratic in stress,

--- a/src/wrinklefe/solver/arclength.py
+++ b/src/wrinklefe/solver/arclength.py
@@ -66,7 +66,7 @@ and buckling problems."  Int. J. Solids Struct. 15: 529-551.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from scipy import sparse
@@ -524,7 +524,7 @@ class ArcLengthSolver:
     def _assemble_tangent(self, u: np.ndarray) -> sparse.csc_matrix:
         tan = getattr(self.assembler, "assemble_tangent", None)
         if callable(tan):
-            return tan(u)
+            return cast(sparse.csc_matrix, tan(u))
         cohesive = getattr(self.assembler, "cohesive_elements", None)
         if cohesive:
             raise RuntimeError(
@@ -540,7 +540,9 @@ class ArcLengthSolver:
             self.assembler, "assemble_residual_and_tangent", None
         )
         if callable(combined):
-            return combined(u)
+            return cast(
+                "tuple[sparse.csc_matrix, np.ndarray]", combined(u)
+            )
         F_int = self.assembler.assemble_internal_force(u)
         K_t = self._assemble_tangent(u)
         return K_t, F_int
@@ -559,4 +561,6 @@ class ArcLengthSolver:
         n_dof = K.shape[0]
         diag_data = np.zeros(n_dof, dtype=np.float64)
         diag_data[dofs_arr] = alpha
-        return (K + sparse.diags(diag_data, 0, format="csc")).tocsc()
+        return sparse.csc_matrix(
+            (K + sparse.diags(diag_data, 0, format="csc")).tocsc()
+        )

--- a/src/wrinklefe/solver/assembler.py
+++ b/src/wrinklefe/solver/assembler.py
@@ -313,11 +313,11 @@ class GlobalAssembler:
         coo_vals = np.empty(total_entries, dtype=np.float64)
 
         # Local row/col index pairs for a 24x24 matrix (reused every element)
-        local_ii, local_jj = np.meshgrid(
+        local_ii_g, local_jj_g = np.meshgrid(
             np.arange(24), np.arange(24), indexing="ij"
         )
-        local_ii = local_ii.ravel()  # (576,)
-        local_jj = local_jj.ravel()  # (576,)
+        local_ii = local_ii_g.ravel()  # (576,)
+        local_jj = local_jj_g.ravel()  # (576,)
 
         for e in range(n_elem):
             if e % 1000 == 0:
@@ -410,7 +410,7 @@ class GlobalAssembler:
             ),
             shape=(n_dof, n_dof),
         ).tocsc()
-        return (K + K_coh).tocsc()
+        return sparse.csc_matrix((K + K_coh).tocsc())
 
     def assemble_residual_and_tangent(
         self, u: np.ndarray

--- a/src/wrinklefe/solver/boundary.py
+++ b/src/wrinklefe/solver/boundary.py
@@ -168,7 +168,7 @@ def _quad_areas(nodes: np.ndarray, quads: np.ndarray) -> np.ndarray:
     cross2 = np.cross(p2 - p0, p3 - p0)
     a1 = 0.5 * np.linalg.norm(cross1, axis=1)
     a2 = 0.5 * np.linalg.norm(cross2, axis=1)
-    return a1 + a2
+    return np.asarray(a1 + a2)
 
 
 # ======================================================================
@@ -259,6 +259,11 @@ class BoundaryCondition:
         """
         if self.node_ids is not None:
             return np.asarray(self.node_ids, dtype=np.intp)
+        if self.face is None:
+            raise ValueError(
+                "BoundaryCondition needs either node_ids or face to "
+                "resolve its node set"
+            )
         return mesh.nodes_on_face(self.face)
 
     def effective_dofs(self) -> list[int]:
@@ -566,8 +571,10 @@ class BoundaryHandler:
         # Extract sub-matrices using sparse indexing
         # K_ff: free x free, K_fc: free x constrained
         K_csr = K.tocsr()
-        K_ff = K_csr[np.ix_(free_dofs, free_dofs)].tocsc()
-        K_fc = K_csr[np.ix_(free_dofs, c_dofs_sorted)]
+        # scipy-stubs does not model ndarray fancy indexing on sparse
+        # matrices; the runtime supports it.
+        K_ff = K_csr[np.ix_(free_dofs, free_dofs)].tocsc()  # type: ignore[index]
+        K_fc = K_csr[np.ix_(free_dofs, c_dofs_sorted)]  # type: ignore[index]
 
         # Build reduced RHS: F_f - K_fc * u_c
         F_free = F[free_dofs].copy()

--- a/src/wrinklefe/solver/nonlinear.py
+++ b/src/wrinklefe/solver/nonlinear.py
@@ -28,7 +28,7 @@ definiteness once damage starts accumulating.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from scipy import sparse
@@ -316,6 +316,7 @@ class NewtonRaphsonSolver:
                     return u, it, True
 
             try:
+                assert K_bc is not None  # only_residual=False above
                 du = spla.spsolve(K_bc, -R_bc)
             except RuntimeError:
                 self._revert_state()
@@ -469,7 +470,7 @@ class NewtonRaphsonSolver:
     def _assemble_tangent(self, u: np.ndarray) -> sparse.csc_matrix:
         tan = getattr(self.assembler, "assemble_tangent", None)
         if callable(tan):
-            return tan(u)
+            return cast(sparse.csc_matrix, tan(u))
         # Fall back to linear stiffness only when the assembler has no
         # cohesive elements registered; otherwise the linear path is
         # silently wrong for nonlinear CZM problems.
@@ -498,7 +499,9 @@ class NewtonRaphsonSolver:
             self.assembler, "assemble_residual_and_tangent", None
         )
         if callable(combined):
-            return combined(u)
+            return cast(
+                "tuple[sparse.csc_matrix, np.ndarray]", combined(u)
+            )
         # This IS the fallback for assemblers without the combined API
         # — calling through :meth:`_assemble_internal_force` here would
         # infinitely recurse (that shim routes back through the combined
@@ -517,13 +520,13 @@ class NewtonRaphsonSolver:
         """
         direct = getattr(self.assembler, "assemble_internal_force", None)
         if callable(direct):
-            return direct(u)
+            return cast(np.ndarray, direct(u))
         combined = getattr(
             self.assembler, "assemble_residual_and_tangent", None
         )
         if callable(combined):
             _K, F_int = combined(u)
-            return F_int
+            return cast(np.ndarray, F_int)
         raise AttributeError(
             "Assembler must implement either assemble_internal_force(u) "
             "or assemble_residual_and_tangent(u); neither found."

--- a/src/wrinklefe/solver/results.py
+++ b/src/wrinklefe/solver/results.py
@@ -20,6 +20,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import numpy as np
+
+try:  # numpy >= 2.0
+    from numpy import trapezoid as _trapezoid
+except ImportError:  # pragma: no cover — numpy 1.x fallback
+    from numpy import trapz as _trapezoid  # type: ignore[attr-defined, no-redef]
 from scipy import sparse
 
 from wrinklefe.core.laminate import Laminate
@@ -322,8 +327,8 @@ class FieldResults:
             if z_vals.size < 2:
                 continue
             # Trapezoidal integration
-            N[idx] = np.trapz(s_vals, z_vals)
-            M[idx] = np.trapz(s_vals * z_vals, z_vals)
+            N[idx] = _trapezoid(s_vals, z_vals)
+            M[idx] = _trapezoid(s_vals * z_vals, z_vals)
 
         return N, M
 

--- a/src/wrinklefe/solver/static.py
+++ b/src/wrinklefe/solver/static.py
@@ -810,5 +810,5 @@ class StaticSolver:
             )
 
         N_inv, _node_to_gp = self._build_hex8_extrapolation()
-        nodal = N_inv @ gauss_values
+        nodal = np.asarray(N_inv @ gauss_values)
         return nodal[:, 0] if squeeze else nodal


### PR DESCRIPTION
Follow-up to #87's mypy half (continues #291) — modules 3 and 4 of the `expand-mypy-coverage` walk. mypy is now clean on `src/wrinklefe/{core,elements,failure,solver}` (34 source files under strict `warn_return_any`).

## failure/ (6 errors)
Two `max(d, key=d.get)` overload clashes → lambda lookups; four numpy scalar `Any`-leaks wrapped (`float()`/`bool()`).

## solver/ (18 errors)
- **Real latent bug:** `solver/results.py` called `np.trapz`, which **numpy 2.0 removed** — the stress-resultants path would `AttributeError` on the installed numpy 2.4. Replaced with a `trapezoid` import shim supporting the `numpy>=1.24` floor.
- `boundary.py`: node-set resolution now raises a clear `ValueError` when a BC has neither `node_ids` nor `face` (previously a confusing downstream `AttributeError`); sparse fancy indexing gets targeted `type: ignore[index]` (scipy-stubs gap, runtime fine).
- Duck-typed assembler delegation in `nonlinear`/`arclength` (the `getattr` plugin points) `cast` at the boundary; `K_bc` narrowed with an assert before `spsolve` (`only_residual=False` at that call site).
- meshgrid→ravel renames in `assembler`; `csc_matrix` re-wraps for sparse arithmetic returns; `np.asarray` for the extrapolation product.

## CI
`lint.yml`'s mypy step now checks `init + core + elements + failure + solver`; remaining: `viz/`, `sweep/`, `io/`, `analysis.py`, `cli.py`.

## Verification
- `mypy` clean on the new scope.
- 364 tests pass: solver, failure, CZM, cohesive mesh, validation ledger (zero drift), multi-wrinkle FE, integration analysis.
- Full-config `ruff check .` clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_