### PR TITLE
types: whole src/wrinklefe package now mypy-clean and CI-checked (#87 follow-up)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,10 +35,8 @@ jobs:
       - name: Ruff (full pyproject config)
         run: ruff check .
 
-      # Walking outward module-by-module (expand-mypy-coverage skill):
-      # core/, elements/, failure/, and solver/ are clean; viz/, sweep/,
-      # io/, analysis.py, and cli.py are the next passes.
-      - name: Mypy (scope - init + core + elements + failure + solver)
-        run: >-
-          mypy src/wrinklefe/__init__.py src/wrinklefe/core
-          src/wrinklefe/elements src/wrinklefe/failure src/wrinklefe/solver
+      # The whole src/wrinklefe package is mypy-clean (expand-mypy-coverage
+      # skill, issue #87 follow-up). app.py and streamlit_viz.py at the
+      # repo root remain for a later pass.
+      - name: Mypy (scope - src/wrinklefe)
+        run: mypy src/wrinklefe

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -40,6 +40,7 @@ import logging
 import math
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, fields, replace
+from typing import Any, Literal, cast
 
 import numpy as np
 
@@ -59,6 +60,7 @@ from wrinklefe.core.wrinkle import (
 from wrinklefe.elements.cohesive8 import (
     Cohesive8Element,
     CohesiveProperties,
+    make_initial_state,
 )
 from wrinklefe.failure.delamination import build_delamination_report
 from wrinklefe.failure.evaluator import FailureEvaluator, LaminateFailureReport
@@ -856,7 +858,7 @@ class AnalysisConfig:
             self.material = MaterialLibrary().get("IM7_8552")
         if self.angles is None:
             # Quasi-isotropic [0/45/-45/90]_3s → 24 plies
-            base = [0, 45, -45, 90]
+            base: list[float] = [0, 45, -45, 90]
             self.angles = (base * 3) + list(reversed(base * 3))
 
         # Auto-derive interior interface indices when the user did not
@@ -885,6 +887,8 @@ class AnalysisConfig:
         misconfiguration surfaces at construction time rather than as an
         obscure traceback deep in the solver/mesh path.
         """
+        # ``angles`` is filled in __post_init__ before _validate runs.
+        assert self.angles is not None
         # --- Wrinkle geometry -----------------------------------------
         # amplitude == 0 is a legitimate "no wrinkle" (flat) case: the
         # mid-surface profile z(x) = A * envelope reduces to 0, so the
@@ -1293,6 +1297,7 @@ class AnalysisResults:
     analytical_onset_knockdown: float | None = None
     analytical_strength_MPa: float = 0.0
     gamma_Y_eff: float = 0.02  # layup-dependent effective yield strain
+    # Tension mechanism decomposition (only for tension loading)
     tension_mechanisms: dict | None = None  # {kd_fiber, kd_matrix, kd_oop, mode, ...}
 
     # FE results
@@ -1307,9 +1312,6 @@ class AnalysisResults:
 
     # Modulus retention (E_wrinkled / E_pristine from FE)
     modulus_retention: float = 1.0
-
-    # Tension mechanism decomposition (only for tension loading)
-    tension_mechanisms: dict | None = None  # {kd_fiber, kd_matrix, kd_oop, ...}
 
     # ------------------------------------------------------------------
     # CZM results — only populated when AnalysisConfig.enable_czm = True.
@@ -1511,6 +1513,14 @@ class WrinkleAnalysis:
             Complete results from all analysis steps.
         """
         cfg = self.config
+        # interface_1 / interface_2 are filled in __post_init__.
+        assert cfg.interface_1 is not None and cfg.interface_2 is not None
+        # _validate constrained these to the literal sets that
+        # WrinkleConfiguration expects.
+        amp_profile = cast(
+            Literal["constant", "gaussian", "linear"], cfg.amplitude_profile
+        )
+        amp_axis = cast(Literal["x", "y"], cfg.amplitude_profile_axis)
         if analytical_only is None:
             analytical_only = cfg.analytical_only
 
@@ -1580,9 +1590,9 @@ class WrinkleAnalysis:
                 placements,
                 decay_mode="graded" if is_graded else "default",
                 decay_floor=cfg.decay_floor if is_graded else 0.0,
-                amplitude_profile=cfg.amplitude_profile,
+                amplitude_profile=amp_profile,
                 amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
-                amplitude_profile_axis=cfg.amplitude_profile_axis,
+                amplitude_profile_axis=amp_axis,
             )
             results.wrinkle_config = wrinkle_config
         else:
@@ -1602,9 +1612,9 @@ class WrinkleAnalysis:
                     interface1=cfg.interface_1,
                     interface2=cfg.interface_2,
                     phase=float(cfg.phase),
-                    amplitude_profile=cfg.amplitude_profile,
+                    amplitude_profile=amp_profile,
                     amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
-                    amplitude_profile_axis=cfg.amplitude_profile_axis,
+                    amplitude_profile_axis=amp_axis,
                 )
                 wrinkle_config.decay_floor = max(0.0, min(1.0, cfg.decay_floor))
             else:
@@ -1613,9 +1623,9 @@ class WrinkleAnalysis:
                     interface1=cfg.interface_1,
                     interface2=cfg.interface_2,
                     decay_floor=cfg.decay_floor,
-                    amplitude_profile=cfg.amplitude_profile,
+                    amplitude_profile=amp_profile,
                     amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
-                    amplitude_profile_axis=cfg.amplitude_profile_axis,
+                    amplitude_profile_axis=amp_axis,
                 )
             results.wrinkle_config = wrinkle_config
 
@@ -1790,7 +1800,7 @@ class WrinkleAnalysis:
         )
 
         for val in values:
-            overrides = {parameter: val}
+            overrides: dict[str, Any] = {parameter: val}
             if reset_domain_length:
                 overrides["domain_length"] = 0.0
             cfg = replace(base_config, **overrides)
@@ -1807,6 +1817,9 @@ class WrinkleAnalysis:
 
     def _build_laminate(self) -> Laminate:
         """Build the Laminate from config."""
+        # material / angles are filled in __post_init__.
+        assert self.config.angles is not None
+        assert self.config.material is not None
         return Laminate.from_angles(
             self.config.angles,
             self.config.material,
@@ -2173,13 +2186,15 @@ class WrinkleAnalysis:
         u = outcome["displacement"]
         # Iterate in the same order as `cohesive_elements` was built.
         for row, (gid, c_elem) in enumerate(cohesive_elements):
-            # Damage from the assembler-committed state.
+            # Damage from the assembler-committed state.  Fall back to
+            # virgin Gauss-point states (d = 0) for elements the
+            # assembler never committed; ``_law_local`` requires a real
+            # ``CohesiveState`` (a ``None`` entry would crash it).
             state = assembler.cohesive_state.get(
-                gid, [None] * c_elem.n_gp
+                gid, make_initial_state(c_elem.n_gp)
             )
             for g in range(c_elem.n_gp):
-                s = state[g]
-                damage[row, g] = float(s.d) if s is not None else 0.0
+                damage[row, g] = float(state[g].d)
 
             # Recompute the local separation and traction at each GP
             # from the final displacement.  ``tangent_and_force`` returns
@@ -2290,13 +2305,16 @@ class WrinkleAnalysis:
         theta_eff = theta_max * mf
 
         # Compute layup-dependent effective gamma_Y from confinement
-        angles = cfg.angles if cfg.angles else [0, 45, -45, 90] * 6
+        angles: list[float] = (
+            cfg.angles if cfg.angles else [0.0, 45.0, -45.0, 90.0] * 6
+        )
         gamma_Y_eff = _effective_gamma_Y(angles)
 
         # Compression KD (CLT-weighted Budiansky-Fleck) — computed for
         # both loading modes: used directly for compression, and as a
         # physical floor for tension (tension cannot be worse than compression).
         mat = cfg.material
+        assert mat is not None  # filled in __post_init__
         E11 = mat.E1
         E22 = mat.E2
         G12 = mat.G12
@@ -2404,11 +2422,11 @@ class WrinkleAnalysis:
                 if kd < kd_compression:
                     kd = kd_compression
                     mechanisms["mode"] = mechanisms["mode"] + " (capped)"
-                ref_strength = cfg.material.Xt
+                ref_strength = mat.Xt
                 results.tension_mechanisms = mechanisms
             else:
                 kd = kd_compression
-                ref_strength = cfg.material.Xc
+                ref_strength = mat.Xc
                 results.tension_mechanisms = None
         else:
             # Non-graded: peak-angle BF at the critical cross-section,
@@ -2422,11 +2440,11 @@ class WrinkleAnalysis:
                 if kd < kd_compression:
                     kd = kd_compression
                     mechanisms["mode"] = mechanisms["mode"] + " (capped)"
-                ref_strength = cfg.material.Xt
+                ref_strength = mat.Xt
                 results.tension_mechanisms = mechanisms
             else:
                 kd = kd_compression
-                ref_strength = cfg.material.Xc
+                ref_strength = mat.Xc
                 results.tension_mechanisms = None
         results.gamma_Y_eff = gamma_Y_eff
 
@@ -2492,10 +2510,15 @@ class WrinkleAnalysis:
         - Timoshenko & Gere (1961), Theory of Elastic Stability (curved beam)
         - Elhajjar (2025) Scientific Reports 15:25977 (experimental data)
         """
+        # Filled in __post_init__.  (The previous ``if mat is None:
+        # return 1.0`` guard returned a bare float from a function whose
+        # callers always unpack a (kd, mechanisms) tuple, so it could
+        # never have worked anyway.)
         mat = cfg.material
-        if mat is None:
-            return 1.0
-        angles = cfg.angles if cfg.angles else [0, 45, -45, 90] * 6
+        assert mat is not None
+        angles: list[float] = (
+            cfg.angles if cfg.angles else [0.0, 45.0, -45.0, 90.0] * 6
+        )
 
         E11 = mat.E1
         E22 = mat.E2
@@ -2765,6 +2788,8 @@ class WrinkleAnalysis:
         A retention of 1.0 means no knockdown; 0.5 means 50% strength retained.
         """
         cfg = self.config
+        # interface_1 / interface_2 are filled in __post_init__.
+        assert cfg.interface_1 is not None and cfg.interface_2 is not None
 
         if results.failure_indices is None:
             return
@@ -2848,6 +2873,9 @@ class WrinkleAnalysis:
             if applied_strain == 0.0:
                 results.modulus_retention = 1.0
             else:
+                # Set by the FE path before retention factors run; if it
+                # were ever None the except below restores the default.
+                assert results.field_results is not None
                 stress_w = results.field_results.stress_local  # (n_elem, n_gauss, 6)
                 stress_p = flat_field.stress_local
 

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -803,7 +803,7 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
     results = WrinkleAnalysis.parametric_sweep(
         config,
         parameter=args.parameter,
-        values=values,
+        values=values.tolist(),
         analytical_only=args.analytical_only,
     )
 

--- a/src/wrinklefe/convergence.py
+++ b/src/wrinklefe/convergence.py
@@ -27,6 +27,7 @@ import math
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
+from typing import Any
 
 import numpy as np
 
@@ -256,7 +257,7 @@ def mesh_convergence_study(
     rows: list[ConvergenceLevel] = []
     qois: list[float] = []
     for k, f in enumerate(factors):
-        overrides = {
+        overrides: dict[str, Any] = {
             axis: max(1, int(round(getattr(base_config, axis) * f)))
             for axis in refine
         }
@@ -277,7 +278,9 @@ def mesh_convergence_study(
             ConvergenceLevel(
                 level=k,
                 nx=cfg.nx, ny=cfg.ny, nz_per_ply=cfg.nz_per_ply,
-                n_dof=int(results.mesh.n_dof),
+                n_dof=(
+                    int(results.mesh.n_dof) if results.mesh is not None else 0
+                ),
                 qoi=q,
                 delta_pct=delta,
                 runtime_s=runtime,

--- a/src/wrinklefe/viz/plots_2d.py
+++ b/src/wrinklefe/viz/plots_2d.py
@@ -36,6 +36,7 @@ import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
+from wrinklefe.core.wrinkle import WrinkleSurface3D
 from wrinklefe.viz.style import (
     ACCENT_GRAY,
     FIGSIZE_DOUBLE_COLUMN,
@@ -54,13 +55,29 @@ if TYPE_CHECKING:
     from wrinklefe.core.morphology import WrinkleConfiguration
     from wrinklefe.core.wrinkle import WrinkleProfile
     from wrinklefe.solver.results import FieldResults
-    from wrinklefe.statistics.jensen import JensenGapResult
-    from wrinklefe.statistics.montecarlo import MonteCarloResults
+
+    # The wrinklefe.statistics package does not exist yet; these
+    # annotation-only imports document the intended result types for
+    # plot_strength_distribution / plot_jensen_gap.
+    from wrinklefe.statistics.jensen import JensenGapResult  # type: ignore[import-not-found]
+    from wrinklefe.statistics.montecarlo import MonteCarloResults  # type: ignore[import-not-found]
 
 
 # ======================================================================
 # Wrinkle geometry plots
 # ======================================================================
+
+def _base_profile(profile: WrinkleProfile | WrinkleSurface3D) -> WrinkleProfile:
+    """Return the underlying 1-D profile, unwrapping a 3-D surface.
+
+    The 2-D profile plots draw the longitudinal section z(x); for a
+    :class:`WrinkleSurface3D` that is its inner 1-D ``profile`` (the
+    same convention as :mod:`wrinklefe.core.morphology`).
+    """
+    if isinstance(profile, WrinkleSurface3D):
+        return profile.profile
+    return profile
+
 
 def plot_wrinkle_profile(
     profile: WrinkleProfile,
@@ -133,7 +150,7 @@ def plot_dual_wrinkle_profiles(
     if config.n_wrinkles() < 2:
         # Fall back to single profile
         wrinkle = config.wrinkles[0]
-        profile = wrinkle.profile
+        profile = _base_profile(wrinkle.profile)
         xlo, xhi = profile.domain()
         x = np.linspace(xlo, xhi, n_points)
         z = profile.displacement(x)
@@ -146,8 +163,8 @@ def plot_dual_wrinkle_profiles(
 
     w_upper = config.wrinkles[0]
     w_lower = config.wrinkles[1]
-    p_upper = w_upper.profile
-    p_lower = w_lower.profile
+    p_upper = _base_profile(w_upper.profile)
+    p_lower = _base_profile(w_lower.profile)
 
     # Use union of domains
     xlo_u, xhi_u = p_upper.domain()

--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -42,12 +42,13 @@ Elhajjar, R. (2025). Scientific Reports, 15, 25977.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection  # type: ignore[import-untyped]
+from mpl_toolkits.mplot3d.axes3d import Axes3D  # type: ignore[import-untyped]
 
 from wrinklefe.viz.style import (
     FIGSIZE_DOUBLE_COLUMN,
@@ -58,7 +59,10 @@ from wrinklefe.viz.style import (
 
 if TYPE_CHECKING:
     from wrinklefe.core.mesh import MeshData
-    from wrinklefe.solver.buckling import BucklingResult
+
+    # wrinklefe.solver.buckling does not exist yet; the annotation-only
+    # import documents the intended result type for plot_buckling_mode.
+    from wrinklefe.solver.buckling import BucklingResult  # type: ignore[import-not-found]
     from wrinklefe.solver.results import FieldResults
 
 
@@ -178,7 +182,7 @@ def _structured_boundary_mask(mesh: MeshData) -> np.ndarray:
         coord_on_axis == 0,
         coord_on_axis == max_on_axis[np.newaxis, :],
     )
-    return boundary
+    return np.asarray(boundary)
 
 
 def _general_boundary_mask(
@@ -206,7 +210,7 @@ def _general_boundary_mask(
         flat_keys, axis=0, return_inverse=True, return_counts=True
     )
     boundary_flat = counts[inverse] == 1
-    return boundary_flat.reshape(elem_indices.size, 6)
+    return np.asarray(boundary_flat.reshape(elem_indices.size, 6))
 
 
 def _gather_boundary_faces(
@@ -312,6 +316,9 @@ def plot_mesh_3d(
     """
     set_publication_style()
     ax = ensure_axes(ax, figsize=FIGSIZE_DOUBLE_COLUMN, projection="3d")
+    # ``ax`` is a 3-D axes (projection="3d"); the cast exposes the
+    # 3-D-only API that the base-Axes stubs do not cover.
+    ax3d = cast(Axes3D, ax)
 
     if mesh.n_elements == 0:
         return ax
@@ -327,7 +334,7 @@ def plot_mesh_3d(
         edgecolors=edge_color,
         linewidths=0.2,
     )
-    ax.add_collection3d(poly)
+    ax3d.add_collection3d(poly)
 
     # Set axis limits from node extents
     mins = mesh.nodes.min(axis=0)
@@ -335,14 +342,14 @@ def plot_mesh_3d(
     pad = 0.05 * (maxs - mins + 1e-10)
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
-    ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    ax3d.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
     set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
-    ax.set_zlabel("$z$ (mm)", labelpad=8)
+    ax3d.set_zlabel("$z$ (mm)", labelpad=8)
     ax.set_title("3D Mesh")
-    ax.view_init(elev=25, azim=-60)
+    ax3d.view_init(elev=25, azim=-60)
 
     return ax
 
@@ -384,6 +391,8 @@ def plot_displacement_3d(
     """
     set_publication_style()
     ax = ensure_axes(ax, figsize=FIGSIZE_DOUBLE_COLUMN, projection="3d")
+    # See plot_mesh_3d: cast exposes the 3-D-only Axes3D API.
+    ax3d = cast(Axes3D, ax)
 
     mesh = field_results.mesh
     disp = field_results.displacement
@@ -433,7 +442,7 @@ def plot_displacement_3d(
         edgecolors="0.5",
         linewidths=0.1,
     )
-    ax.add_collection3d(poly)
+    ax3d.add_collection3d(poly)
 
     # Axis limits from deformed mesh
     mins = deformed_nodes.min(axis=0)
@@ -441,12 +450,12 @@ def plot_displacement_3d(
     pad = 0.05 * (maxs - mins + 1e-10)
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
-    ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    ax3d.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
     set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
-    ax.set_zlabel("$z$ (mm)", labelpad=8)
+    ax3d.set_zlabel("$z$ (mm)", labelpad=8)
 
     scale_str = f" (x{scale:.0f})" if scale != 1.0 else ""
     ax.set_title(f"Displacement {comp_label}{scale_str}")
@@ -455,11 +464,12 @@ def plot_displacement_3d(
     sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap_obj)
     sm.set_array([])
     fig = ax.get_figure()
+    assert fig is not None  # an Axes always belongs to a figure
     cbar = fig.colorbar(sm, ax=ax, shrink=0.6, pad=0.1)
     cbar.set_label(f"{comp_label} (mm)", fontsize=9)
     cbar.ax.tick_params(labelsize=8)
 
-    ax.view_init(elev=25, azim=-60)
+    ax3d.view_init(elev=25, azim=-60)
 
     return ax
 
@@ -505,6 +515,8 @@ def plot_stress_contour_3d(
     """
     set_publication_style()
     ax = ensure_axes(ax, figsize=FIGSIZE_DOUBLE_COLUMN, projection="3d")
+    # See plot_mesh_3d: cast exposes the 3-D-only Axes3D API.
+    ax3d = cast(Axes3D, ax)
 
     mesh = field_results.mesh
 
@@ -557,29 +569,30 @@ def plot_stress_contour_3d(
         edgecolors="0.5",
         linewidths=0.1,
     )
-    ax.add_collection3d(poly)
+    ax3d.add_collection3d(poly)
 
     mins = deformed_nodes.min(axis=0)
     maxs = deformed_nodes.max(axis=0)
     pad = 0.05 * (maxs - mins + 1e-10)
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
-    ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    ax3d.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
     set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
-    ax.set_zlabel("$z$ (mm)", labelpad=8)
+    ax3d.set_zlabel("$z$ (mm)", labelpad=8)
     ax.set_title(f"Stress {comp_label} ({coord})")
 
     sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap_obj)
     sm.set_array([])
     fig = ax.get_figure()
+    assert fig is not None  # an Axes always belongs to a figure
     cbar = fig.colorbar(sm, ax=ax, shrink=0.6, pad=0.1)
     cbar.set_label(f"{comp_label} (MPa)", fontsize=9)
     cbar.ax.tick_params(labelsize=8)
 
-    ax.view_init(elev=25, azim=-60)
+    ax3d.view_init(elev=25, azim=-60)
 
     return ax
 
@@ -625,11 +638,13 @@ def plot_buckling_mode(
     """
     set_publication_style()
     ax = ensure_axes(ax, figsize=FIGSIZE_DOUBLE_COLUMN, projection="3d")
+    # See plot_mesh_3d: cast exposes the 3-D-only Axes3D API.
+    ax3d = cast(Axes3D, ax)
 
     mesh = buckling_result.mesh
 
     if mesh.n_elements == 0 or buckling_result.n_modes == 0:
-        ax.text2D(
+        ax3d.text2D(
             0.5, 0.5, "No buckling modes available",
             transform=ax.transAxes, ha="center", va="center",
             fontsize=10, color="0.5",
@@ -637,7 +652,7 @@ def plot_buckling_mode(
         return ax
 
     if mode < 0 or mode >= buckling_result.n_modes:
-        ax.text2D(
+        ax3d.text2D(
             0.5, 0.5, f"Mode {mode} out of range (0-{buckling_result.n_modes - 1})",
             transform=ax.transAxes, ha="center", va="center",
             fontsize=10, color="0.5",
@@ -682,19 +697,19 @@ def plot_buckling_mode(
         edgecolors="0.5",
         linewidths=0.1,
     )
-    ax.add_collection3d(poly)
+    ax3d.add_collection3d(poly)
 
     mins = deformed_nodes.min(axis=0)
     maxs = deformed_nodes.max(axis=0)
     pad = 0.05 * (maxs - mins + 1e-10)
     ax.set_xlim(mins[0] - pad[0], maxs[0] + pad[0])
     ax.set_ylim(mins[1] - pad[1], maxs[1] + pad[1])
-    ax.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
+    ax3d.set_zlim(mins[2] - pad[2], maxs[2] + pad[2])
     set_axes_equal_aspect(ax, mins, maxs)
 
     ax.set_xlabel("$x$ (mm)", labelpad=8)
     ax.set_ylabel("$y$ (mm)", labelpad=8)
-    ax.set_zlabel("$z$ (mm)", labelpad=8)
+    ax3d.set_zlabel("$z$ (mm)", labelpad=8)
 
     eigenvalue = buckling_result.eigenvalues[mode]
     ax.set_title(
@@ -704,11 +719,12 @@ def plot_buckling_mode(
     sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap_obj)
     sm.set_array([])
     fig = ax.get_figure()
+    assert fig is not None  # an Axes always belongs to a figure
     cbar = fig.colorbar(sm, ax=ax, shrink=0.6, pad=0.1)
     cbar.set_label("$u_z$ (mm, scaled)", fontsize=9)
     cbar.ax.tick_params(labelsize=8)
 
-    ax.view_init(elev=25, azim=-60)
+    ax3d.view_init(elev=25, azim=-60)
 
     return ax
 
@@ -737,7 +753,9 @@ def _require_pyvista():
         If PyVista is not installed.
     """
     try:
-        import pyvista as pv  # type: ignore[import-untyped]
+        # Both ignore codes are needed: pyvista ships no stubs where it
+        # is installed (CI) and may be absent entirely (pared-down envs).
+        import pyvista as pv  # type: ignore[import-untyped, import-not-found]
     except ImportError as exc:  # pragma: no cover - exercised in sparse envs
         raise ImportError(
             "PyVista is required for 3D cohesive-zone visualizations. "

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -19,15 +19,16 @@ from __future__ import annotations
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
-from matplotlib.image import AxesImage
+from mpl_toolkits.mplot3d.axes3d import Axes3D  # type: ignore[import-untyped]
 
 # ======================================================================
 # Morphology visual encoding
@@ -184,7 +185,7 @@ def set_publication_style() -> None:
 
 def colorbar_setup(
     ax: Axes,
-    mappable: AxesImage,
+    mappable: ScalarMappable,
     label: str,
     orientation: str = "vertical",
 ) -> Colorbar:
@@ -194,8 +195,9 @@ def colorbar_setup(
     ----------
     ax : matplotlib.axes.Axes
         The axes containing the mappable.
-    mappable : matplotlib.image.AxesImage
-        The image or contour set to create the colorbar for.
+    mappable : matplotlib.cm.ScalarMappable
+        The image, scatter collection, or contour set to create the
+        colorbar for.
     label : str
         Colorbar label text.
     orientation : str, optional
@@ -207,6 +209,7 @@ def colorbar_setup(
         The created colorbar instance.
     """
     fig = ax.get_figure()
+    assert fig is not None  # an Axes always belongs to a figure
     cbar = fig.colorbar(mappable, ax=ax, orientation=orientation, pad=0.02)
     cbar.set_label(label, fontsize=9)
     cbar.ax.tick_params(labelsize=8)
@@ -296,7 +299,9 @@ def set_axes_equal_aspect(
     # Guard against zero (or negative due to numerical noise) extents that
     # would make set_box_aspect crash.
     safe = np.where(extents > 0, extents, 1.0)
-    ax.set_box_aspect(tuple(safe))
+    # The tuple overload of set_box_aspect only exists on the 3-D axes
+    # subclass, which the base-Axes stubs do not know about.
+    cast(Axes3D, ax).set_box_aspect(tuple(safe))
 
 
 def save_figure(
@@ -334,6 +339,9 @@ def save_figure(
         :meth:`~matplotlib.figure.Figure.savefig` (e.g. ``bbox_inches='tight'``).
     """
     fig = ax_or_fig if isinstance(ax_or_fig, Figure) else ax_or_fig.figure
+    # The plot_* functions always draw on a top-level Figure (never a
+    # SubFigure), so the Axes.figure union narrows to Figure here.
+    assert isinstance(fig, Figure)
     savefig_kwargs.setdefault("bbox_inches", "tight")
     fig.savefig(path, dpi=dpi, **savefig_kwargs)
     if close:
@@ -367,6 +375,8 @@ def figure_context(ax_or_fig: Axes | Figure) -> Iterator[Figure]:
         The parent figure, guaranteed closed when the ``with`` block exits.
     """
     fig = ax_or_fig if isinstance(ax_or_fig, Figure) else ax_or_fig.figure
+    # See save_figure: plot_* axes always live on a top-level Figure.
+    assert isinstance(fig, Figure)
     try:
         yield fig
     finally:


### PR DESCRIPTION
Follow-up to #87's mypy half (completes the `expand-mypy-coverage` walk after #291/#292) — **`mypy src/wrinklefe` is now clean across the whole package** (47 source files, strict `warn_return_any`), and CI's mypy step checks the entire package. Only `app.py`/`streamlit_viz.py` at the repo root remain for a later pass.

## Fix classes
- **analysis.py (~40):** assert-narrowing for Optional config fields that `__post_init__` always fills (`material`/`angles`/`interface_1/2`); the duplicate `tension_mechanisms` dataclass field removed (it re-bound the same `None` default); `Literal` casts for validated fields; typed `replace()` overrides; float-literal QI fallback layups.
- **viz/ (~44):** `cast(Axes3D, ax)` once per 3-D plot function (the 3-D-only Axes API missing from base stubs); `colorbar_setup` widened from `AxesImage` to `ScalarMappable` (its actual requirement); figure-handle narrowing; a `_base_profile()` helper unwrapping `WrinkleSurface3D` in plots_2d mirroring `core/morphology` (3-D surfaces previously crashed there); dual-code ignore for the pyvista import (untyped in CI, absent in minimal envs).
- **convergence.py / cli.py:** typed `replace()` overrides, mesh None-guard, ndarray→list for `parametric_sweep` values.

## Three real defects surfaced by the checker
1. `_tension_knockdown_analytical`'s `if mat is None: return 1.0` guard returned a bare float from a `tuple[float, dict]` function — every caller unpacks two values, so that branch could only ever crash.
2. The CZM path fed `[None] * n_gp` placeholder states into `_law_local` (which dereferences `.mode_ratio_init`) for elements missing from `cohesive_state` — now uses `make_initial_state(n_gp)` (virgin states, identical damage output, no crash).
3. `TYPE_CHECKING` imports reference modules that **never existed in git history** (`wrinklefe.solver.buckling`, `wrinklefe.statistics.*`) — `plot_buckling_mode` / `plot_strength_distribution` / `plot_jensen_gap` are annotated against types with no implementation behind them. Documented with targeted ignores; may deserve an issue.

## Verification
- `mypy src/wrinklefe` clean; full-config `ruff check .` clean.
- 192 tests pass across validation ledger (zero drift), CLI, convergence, progress, integration analysis, viz-CZM, CZM, and sweep suites; `sphinx -W` clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_