### PR TITLE
types: bring app.py + streamlit_viz.py under mypy — whole tree type-checked (#87)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Ruff (full pyproject config)
         run: ruff check .
 
-      # The whole src/wrinklefe package is mypy-clean (expand-mypy-coverage
-      # skill, issue #87 follow-up). app.py and streamlit_viz.py at the
-      # repo root remain for a later pass.
-      - name: Mypy (scope - src/wrinklefe)
-        run: mypy src/wrinklefe
+      # Whole-tree mypy: the src/wrinklefe package plus the repo-root
+      # Streamlit entry points (app.py, streamlit_viz.py). Completes the
+      # mypy-coverage walk tracked as a follow-up to issue #87; streamlit
+      # and plotly are unstubbed and ignored via pyproject [tool.mypy].
+      - name: Mypy (whole tree)
+        run: mypy src/wrinklefe app.py streamlit_viz.py

--- a/app.py
+++ b/app.py
@@ -1077,6 +1077,9 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             }
         mesh = result.mesh
         fr = result.field_results
+        # The FE path populates mesh and field_results together; the
+        # outer guard checked field_results, so mesh is non-None here.
+        assert mesh is not None
         nodes_arr = np.asarray(mesh.nodes, dtype=np.float64)
         elements_arr = np.asarray(mesh.elements, dtype=np.int64)
         stress_per_elem = np.asarray(fr.stress_local).mean(axis=1)
@@ -1311,6 +1314,8 @@ def _render_czm_results(czm: dict) -> None:
         try:
             from wrinklefe.viz import czm_overview_figure as _czm_fig
 
+            # damage_missing above guarantees result_obj is not None here.
+            assert result_obj is not None
             fig = _czm_fig(result_obj)
             st.pyplot(fig, clear_figure=True)
         except Exception as exc:
@@ -1921,11 +1926,13 @@ with tab_results:
                     """
                     if y_unique.size <= 1:
                         return None
-                    return st.select_slider(
-                        "y-station [mm]",
-                        options=[float(y) for y in y_unique],
-                        value=float(y_unique[len(y_unique) // 2]),
-                        key="viz_y_station",
+                    return float(
+                        st.select_slider(
+                            "y-station [mm]",
+                            options=[float(y) for y in y_unique],
+                            value=float(y_unique[len(y_unique) // 2]),
+                            key="viz_y_station",
+                        )
                     )
 
                 if view_mode == "Stress contour":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,11 @@ addopts = "-v --tb=short"
 python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
+
+# streamlit and plotly ship no type stubs (and none exist on PyPI), so
+# the Streamlit entry points (app.py, streamlit_viz.py) cannot resolve
+# their imports under mypy. Scope the missing-imports allowance to
+# exactly those packages — everything else stays strictly checked.
+[[tool.mypy.overrides]]
+module = ["streamlit", "streamlit.*", "plotly", "plotly.*"]
+ignore_missing_imports = true


### PR DESCRIPTION
Final module of the `expand-mypy-coverage` walk — completes the mypy half of #87. With `src/wrinklefe` already clean (PRs #291–#293), this brings the two repo-root Streamlit entry points under mypy, so **CI now type-checks the entire codebase (49 source files)**.

## What
- **Scoped import override:** streamlit and plotly ship no type stubs (and none exist on PyPI), so a `[[tool.mypy.overrides]]` block sets `ignore_missing_imports` for exactly `streamlit.*` / `plotly.*` — the skill's one sanctioned override; every other import stays strictly resolved.
- **Real narrowings in `app.py`:**
  - the FE-results block dereferenced `result.mesh` (`MeshData | None`) — asserted non-None inside the existing `field_results` guard that already implies it;
  - the CZM overview path asserted `result_obj` non-None under the `damage_missing` short-circuit;
  - the y-station slider wrapped `st.select_slider` (untyped `Any`) in `float()` to honor its `float | None` return.
- `lint.yml`'s mypy step now runs `mypy src/wrinklefe app.py streamlit_viz.py`.

## The arc this closes
The mypy half of #87 went from package-`__init__`-only to the whole tree, walked module-by-module across five PRs: core/elements → failure/solver → io/sweep/convergence/cli → analysis/viz → app/streamlit_viz. Along the way mypy caught **two genuine latent crashes** (the `np.trapz` removal in numpy 2.0; `WrinkleSurface3D` attribute access in `max_angle`/`fiber_angles_at_nodes`).

## Verification
- `mypy src/wrinklefe app.py streamlit_viz.py` clean (49 files).
- `ruff check .` (full config) clean.
- 32 layup/streamlit/app tests pass (7 skipped without streamlit, as on CI's minimal-deps job).
- `scripts/validate.py` zero drift; `sphinx-build -W` clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_