### PR TITLE
io: stamp real version + provenance block on exports (fixes #261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ compact. The CSV is one row per ply with columns `ply_index,
 angle_deg, max_FI, min_RF, critical_mode, critical_criterion`, suitable
 for `pandas.read_csv` or `csv.DictReader`.
 
+Every JSON export carries a `provenance` block recording the installed
+WrinkleFE version (never a hardcoded literal), the Python/numpy/scipy
+versions, the platform, a UTC timestamp, and a solver snapshot — so a
+result file can be audited and reproduced against the validation
+ledger. The NCR validation summary (`build_analysis_summary`) embeds
+the same block, and the top-level `wrinklefe_version` field reflects
+the real installed version.
+
 The Streamlit web app exposes the same exports as **Download results as
 JSON** and **Download per-ply results as CSV** buttons on the Export
 tab.

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -15,12 +15,15 @@ VTK File Formats, Kitware (legacy unstructured grid format).
 from __future__ import annotations
 
 import json
+import platform
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import scipy
 
+from wrinklefe import __version__ as _wrinklefe_version
 from wrinklefe.core.layup import to_contracted_layup
 
 if TYPE_CHECKING:
@@ -28,6 +31,43 @@ if TYPE_CHECKING:
     from wrinklefe.core.laminate import Laminate
     from wrinklefe.core.mesh import MeshData
     from wrinklefe.solver.results import FieldResults
+
+
+# ====================================================================== #
+# Provenance — shared by every export path so they can't drift
+# ====================================================================== #
+
+def build_provenance(solver: dict | None = None) -> dict:
+    """Environment/reproducibility block stamped onto exported results.
+
+    Records the installed WrinkleFE version (never a hardcoded literal —
+    issue #261) alongside the numerics stack and platform, so a results
+    file can support a reproducibility claim against the validation
+    ledger. Shared by :func:`export_results_json` and
+    :func:`build_analysis_summary` so the two paths can never disagree.
+
+    Parameters
+    ----------
+    solver : dict, optional
+        Solver settings snapshot (e.g. ``{"type": "direct"}``) folded
+        into the block under the ``"solver"`` key when provided.
+
+    Returns
+    -------
+    dict
+        JSON-serialisable provenance block.
+    """
+    prov: dict[str, Any] = {
+        "wrinklefe": _wrinklefe_version,
+        "python": platform.python_version(),
+        "numpy": np.__version__,
+        "scipy": scipy.__version__,
+        "platform": platform.platform(aliased=True, terse=True),
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    if solver is not None:
+        prov["solver"] = solver
+    return prov
 
 
 # ====================================================================== #
@@ -53,7 +93,11 @@ def export_results_json(
     """
     cfg = results.config
     data: dict = {
-        "wrinklefe_version": "0.1.0",
+        # Real installed version, not a literal (issue #261). Retained
+        # as a top-level key for backward compatibility; the full
+        # environment lives in "provenance" below.
+        "wrinklefe_version": _wrinklefe_version,
+        "provenance": build_provenance(solver={"type": cfg.solver}),
         "configuration": {
             "amplitude_mm": cfg.amplitude,
             "wavelength_mm": cfg.wavelength,
@@ -527,7 +571,9 @@ def build_analysis_summary(
     notes : str, optional
         Free-text engineering notes.
     tool_version : str, optional
-        WrinkleFE version string, recorded for traceability.
+        WrinkleFE version string, recorded for traceability. Defaults to
+        the real installed version (``wrinklefe.__version__``); pass an
+        explicit value only to override it (e.g. in tests).
 
     Returns
     -------
@@ -592,8 +638,11 @@ def build_analysis_summary(
             "date": date,
             "reference": _clean(reference, "(not specified)"),
             "prepared_by": _clean(prepared_by, "(not specified)"),
-            "tool_version": _clean(tool_version, "(unspecified)"),
+            # Default to the real installed version; the parameter is
+            # kept as an explicit override (e.g. for tests) — issue #261.
+            "tool_version": _clean(tool_version, _wrinklefe_version),
         },
+        "provenance": build_provenance(),
         "wrinkle_geometry": {
             "amplitude_mm": defect.get("amplitude_mm"),
             "wavelength_mm": defect.get("wavelength_mm"),

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -97,6 +97,34 @@ class TestJSONExport:
         assert "configuration" in data
         assert "analytical_predictions" in data
 
+    def test_version_is_real_not_hardcoded(self, analysis_result, tmp_path):
+        """Issue #261: the stamped version is the installed one, never
+        the old hardcoded '0.1.0' literal."""
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as _md_version
+
+        out = tmp_path / "results.json"
+        export_results_json(analysis_result, out)
+        data = json.loads(out.read_text())
+        assert data["wrinklefe_version"] != "0.1.0"
+        try:
+            expected = _md_version("wrinklefe")
+        except PackageNotFoundError:  # running from source, not installed
+            from wrinklefe import __version__ as expected
+        assert data["wrinklefe_version"] == expected
+        assert data["provenance"]["wrinklefe"] == expected
+
+    def test_provenance_block(self, analysis_result, tmp_path):
+        """Issue #261: provenance block carries the full env, typed."""
+        out = tmp_path / "results.json"
+        export_results_json(analysis_result, out)
+        prov = json.loads(out.read_text())["provenance"]
+        for key in ("wrinklefe", "python", "numpy", "scipy",
+                    "platform", "timestamp_utc"):
+            assert key in prov and isinstance(prov[key], str) and prov[key]
+        # The solver snapshot reflects the analysis config.
+        assert prov["solver"]["type"] == analysis_result.config.solver
+
     def test_configuration_fields(self, analysis_result, tmp_path):
         """Configuration section has expected fields."""
         out = tmp_path / "results.json"
@@ -475,6 +503,27 @@ class TestBuildAnalysisSummary:
             "disclaimer",
         ):
             assert key in s
+
+    def test_provenance_matches_json_export(self, summary_inputs):
+        """Issue #261: NCR summary and JSON export share one provenance
+        helper, so their blocks agree on keys and version."""
+        from wrinklefe.io.export import build_provenance
+
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        ref = build_provenance()
+        assert set(s["provenance"]) == set(ref)
+        assert s["provenance"]["wrinklefe"] == ref["wrinklefe"]
+        # tool_version defaults to the real version, not "(unspecified)".
+        assert s["header"]["tool_version"] == ref["wrinklefe"]
+
+    def test_tool_version_override_still_honored(self, summary_inputs):
+        """The explicit override path (used by tests) still wins."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect, engineering=engineering, tool_version="9.9.9-rc1"
+        )
+        assert s["header"]["tool_version"] == "9.9.9-rc1"
 
     def test_no_qms_admin_or_mrb_signoff(self, summary_inputs):
         """The attachment must not carry NCR/part admin or sign-off."""


### PR DESCRIPTION
Fixes #261.

## The bug
`export_results_json` hardcoded `"wrinklefe_version": "0.1.0"`, so **every results file ever written claimed it came from 0.1.0** regardless of the installed version — actively misleading when triaging old results ("was this before or after the decay_floor fix?"). And neither export path recorded the numerics stack that a reproducibility claim against the validation ledger needs.

## The fix
One shared helper, `build_provenance()`, stamps both export paths so they cannot drift:
- **wrinklefe version** from `wrinklefe.__version__` (importlib.metadata when installed; the in-repo `1.0.0` fallback from source) — no literal anywhere.
- python / numpy / scipy versions, platform, UTC timestamp, and an optional solver snapshot.

`export_results_json`: top-level `wrinklefe_version` now reflects the real version (kept for backward compatibility) and gains a `provenance` block carrying the solver type. `build_analysis_summary`: `tool_version` defaults to the real version instead of `"(unspecified)"` (the parameter stays as an explicit override for tests) and embeds the same block.

## Acceptance criteria
- [x] No hardcoded version literals in `io/export.py` — guarded by a test comparing the exported field against `importlib.metadata`.
- [x] JSON export and NCR summary carry the same provenance block from one shared helper (parity test).
- [x] Round-trip test asserts presence and types of all provenance keys.
- [x] README documents the new block.

## Verification
- 75 export tests pass; whole-tree mypy clean; full-config ruff clean; validation ledger zero drift; `sphinx -W` clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_