### PR TITLE
github: add issue forms, PR template, and config (fixes #274)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something in WrinkleFE behaves incorrectly or crashes.
+title: "bug: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please include enough to reproduce — a
+        results JSON's `provenance` block (added in #261) has the
+        version and environment fields if you have one.
+  - type: input
+    id: version
+    attributes:
+      label: WrinkleFE version
+      description: "`python -c \"import wrinklefe; print(wrinklefe.__version__)\"`, or the version shown in the app footer / a results JSON `provenance.wrinklefe`."
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How are you running it?
+      options:
+        - PyPI install (pip install wrinklefe)
+        - From source (cloned repo)
+        - Hosted Streamlit app
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: What did you run?
+      description: The exact CLI command, the Python/`AnalysisConfig` snippet, or the Streamlit inputs (material, layup, amplitude/wavelength/width, loading).
+      placeholder: |
+        wrinklefe analyze --amplitude 0.5 --wavelength 12 --morphology concave
+        # or
+        AnalysisConfig(amplitude=0.5, wavelength=12.0, width=8.0, morphology="concave")
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual
+      description: What you expected to happen, and what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / traceback
+      description: Paste the full traceback or error message, if any. Re-run with `-v` for the CLI to capture pipeline logs.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS and Python version (and numpy/scipy if known — all in a results JSON `provenance` block).
+      placeholder: "Linux x86_64, Python 3.12, numpy 2.1, scipy 1.14"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Keep the blank-issue option: the maintainer's own detailed Where/What/
+# Acceptance write-ups should not be forced through a form.
+blank_issues_enabled: true
+contact_links:
+  - name: Try the hosted Streamlit app
+    url: https://wrinklefe.streamlit.app/
+    about: Run an analysis in the browser before filing — no install required.
+  - name: Documentation
+    url: https://wrinklefe.readthedocs.io
+    about: API reference, user guide, and the validation ledger.
+  - name: Usage question
+    url: https://github.com/elhajjar1/wrinkleFE/discussions
+    about: For "how do I…" questions about the science or the API, start a discussion.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,45 @@
+name: Enhancement
+description: Propose a new capability or improvement.
+title: "<area>: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This project's issues follow a **Where / What / Suggested
+        approach / Acceptance criteria** structure with file:line
+        evidence. The fields below pre-seed that skeleton.
+  - type: textarea
+    id: where
+    attributes:
+      label: Where
+      description: The module(s), function(s), and `file.py:line` the change touches or relates to.
+      placeholder: |
+        - `src/wrinklefe/analysis.py:1472` — the single/dual dispatch in `WrinkleAnalysis.run`.
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: The capability or improvement, and why it matters for this tool's users (composites engineers, validation work).
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Suggested approach
+      description: A sketch of the implementation — APIs, data flow, staging. Optional but speeds triage.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of what "done" looks like (tests, behavior, docs).
+      placeholder: |
+        - [ ] ...
+        - [ ] Unit test covering ...
+        - [ ] README/docs updated.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/validation_discrepancy.yml
+++ b/.github/ISSUE_TEMPLATE/validation_discrepancy.yml
@@ -1,0 +1,64 @@
+name: Validation / physics discrepancy
+description: A predicted knockdown/strength disagrees with experiment or another model.
+title: "validation: <material/system> — <short summary>"
+labels: ["validation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        These reports produce the project's most valuable issues. The
+        more of the wrinkle geometry and measured data you can give, the
+        more likely it lands in the validation ledger (`VALIDATION.md`).
+  - type: input
+    id: material
+    attributes:
+      label: Material system
+      description: Fibre/matrix and, if it maps to a built-in, the `MaterialLibrary` name.
+      placeholder: "S-glass/epoxy (AC318_S6C10)"
+    validations:
+      required: true
+  - type: input
+    id: layup
+    attributes:
+      label: Layup
+      description: Stacking sequence (contracted notation accepted) and ply thickness.
+      placeholder: "[0]_14, ply 0.44 mm"
+    validations:
+      required: true
+  - type: input
+    id: geometry
+    attributes:
+      label: Wrinkle geometry
+      description: Amplitude A, wavelength λ, and peak angle θ_max (and width/morphology if known).
+      placeholder: "A = 1.5 mm, λ = 12.9 mm, θ_max ≈ 20°, mid-plane embedded"
+    validations:
+      required: true
+  - type: dropdown
+    id: loading
+    attributes:
+      label: Loading
+      options:
+        - Compression
+        - Tension
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: values
+    attributes:
+      label: Measured vs. predicted
+      description: The experimental strength/knockdown and what WrinkleFE predicted (analytical and/or FE), ideally as a small table.
+      placeholder: |
+        | quantity        | measured | WrinkleFE |
+        |-----------------|----------|-----------|
+        | strength (MPa)  | 211.1    | ...       |
+        | knockdown       | 0.629    | ...       |
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Data source / reference
+      description: Paper DOI, dataset, or test report the measured values come from.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Thanks for contributing to WrinkleFE. -->
+
+## Linked issue
+
+Fixes #<!-- issue number, or "Refs #N" for partial work -->
+
+## Summary
+
+<!-- What changed and why. Note any behavior change to numeric outputs. -->
+
+## Checklist
+
+- [ ] Tests added or updated for the change
+- [ ] `pytest` green (use `-m "not slow"` to skip FE integration solves)
+- [ ] `ruff check .` clean
+- [ ] `mypy src/wrinklefe` clean
+- [ ] Docs/README updated if user-facing
+- [ ] `python scripts/validate.py` shows no validation-ledger drift (or the change is intentional and re-pinned)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,21 @@ Thank you for your interest in contributing to WrinkleFE! This document provides
 
 ## Reporting Issues
 
-- Use the [GitHub Issues](https://github.com/elhajjar1/wrinkleFE/issues) tracker
-- Include a minimal reproducible example when reporting bugs
-- Describe your environment (OS, Python version, package versions)
-- For feature requests, describe the use case and expected behavior
+Open a new issue and pick the form that fits — the
+[**New issue**](https://github.com/elhajjar1/wrinkleFE/issues/new/choose)
+chooser offers three:
+
+- **Bug report** — for incorrect behavior or crashes (asks for version
+  and a reproduction).
+- **Enhancement** — pre-seeded with the project's
+  Where / What / Suggested approach / Acceptance criteria skeleton.
+- **Validation / physics discrepancy** — when a predicted knockdown or
+  strength disagrees with experiment or another model (material, layup,
+  wrinkle geometry, measured vs. predicted, data source).
+
+Blank issues stay enabled for anything that doesn't fit a form. A
+results JSON's `provenance` block carries the version and environment
+fields a bug report needs.
 
 ## Development Setup
 


### PR DESCRIPTION
Fixes #274.

The repo runs an issue-driven process where reports follow a consistent **Where / What / Suggested approach / Acceptance criteria** structure with file:line evidence — but that lived only by convention. With the hosted Streamlit app as the main entry point, filers increasingly aren't code-readers, so an unstructured text box pushes triage cost onto the maintainer. This codifies the house style.

## What
- **`.github/ISSUE_TEMPLATE/`** — three GitHub issue forms (YAML):
  - **bug_report.yml** — requires WrinkleFE version + install method + a reproduction (CLI command / `AnalysisConfig` snippet / app inputs) and expected-vs-actual; points at the results-JSON `provenance` block (#261) for version/env fields.
  - **enhancement.yml** — pre-seeds the Where/What/Suggested-approach/Acceptance-criteria skeleton.
  - **validation_discrepancy.yml** — tailored to this project: material, layup, wrinkle geometry (A/λ/θ_max), measured-vs-predicted table, data source — the report type behind the #161-class issues and the validation ledger.
- **config.yml** keeps `blank_issues_enabled: true` (the maintainer's own detailed write-ups shouldn't be forced through a form) and links the Streamlit app, docs, and Discussions.
- **PULL_REQUEST_TEMPLATE.md** with linked-issue + the project checklist (tests, pytest, ruff, mypy, ledger drift), aligning with the #87 lint/type scopes.
- **CONTRIBUTING.md** "Reporting Issues" now references the forms instead of duplicating the guidance.

## Acceptance criteria
- [x] Three issue forms; bug form enforces version + reproduction fields. (Validated against the GitHub issue-form schema: `name`/`description`/`body`, typed elements, required fields.)
- [x] Blank issues remain enabled.
- [x] PR template with the project checklist.
- [x] CONTRIBUTING references the templates instead of duplicating them.

Docs/infra only — no source or test paths touched; `ruff check .` still clean.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_