### PR TITLE
cli: validate sweep inputs and catch errors cleanly (fixes #298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ version produced a given file.
 - GitHub issue forms, pull-request template, and this changelog.
 
 ### Fixed
+- `wrinklefe sweep` now validates its inputs: an unknown `--parameter`,
+  `--min >= --max`, or `--steps < 2` print a one-line error and exit
+  non-zero (code 2) before any solve, instead of a raw traceback or a
+  silently degenerate sweep. The `--parameter` help no longer implies
+  only amplitude/wavelength/width are accepted.
 - Graded-morphology compression knockdown now honours `decay_floor`
   (previously inert in compression while honoured in tension).
 - JSON export stamps the real installed version instead of a hardcoded

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -364,7 +364,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_sweep.add_argument(
         "--parameter", type=str, required=True,
-        help="Parameter to sweep: amplitude, wavelength, or width",
+        help=(
+            "Numeric AnalysisConfig field to sweep "
+            "(e.g. amplitude, wavelength, width, applied_strain)"
+        ),
     )
     p_sweep.add_argument(
         "--min", type=float, required=True, dest="sweep_min",
@@ -790,6 +793,21 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
     """Handle the ``sweep`` subcommand."""
     from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 
+    # Validate the range/steps before burning any compute (issue #298).
+    if args.sweep_min >= args.sweep_max:
+        print(
+            f"error: --min ({args.sweep_min}) must be less than --max "
+            f"({args.sweep_max})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if args.steps < 2:
+        print(
+            f"error: --steps must be >= 2 (got {args.steps})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     values = np.linspace(args.sweep_min, args.sweep_max, args.steps)
 
     config = AnalysisConfig(
@@ -800,12 +818,19 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
         verbose=args.verbose,
     )
 
-    results = WrinkleAnalysis.parametric_sweep(
-        config,
-        parameter=args.parameter,
-        values=values.tolist(),
-        analytical_only=args.analytical_only,
-    )
+    # parametric_sweep raises AttributeError for an unknown field name;
+    # catch it (and any config/solve error) and exit cleanly with a
+    # message instead of a raw traceback, matching _cmd_analyze.
+    try:
+        results = WrinkleAnalysis.parametric_sweep(
+            config,
+            parameter=args.parameter,
+            values=values.tolist(),
+            analytical_only=args.analytical_only,
+        )
+    except (AttributeError, ValueError, NotImplementedError) as exc:
+        print(f"error: sweep failed: {exc}", file=sys.stderr)
+        sys.exit(2)
 
     print("=" * 60)
     print(f"  WrinkleFE Parametric Sweep: {args.parameter}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,68 @@ def test_sweep_no_analytical_only_runs_full_fe():
 
 
 # --------------------------------------------------------------------------- #
+# sweep: input validation and error handling (issue #298)
+# --------------------------------------------------------------------------- #
+
+
+def test_sweep_unknown_parameter_exits_cleanly(capsys):
+    """A bad --parameter prints a one-line error and exits non-zero —
+    no raw traceback (the AttributeError from parametric_sweep is
+    caught)."""
+    with pytest.raises(SystemExit) as exc:
+        cli_main([
+            "sweep", "--parameter", "not_a_field",
+            "--min", "0.1", "--max", "0.5",
+        ])
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "error:" in err and "not_a_field" in err
+    assert "Traceback" not in err
+
+
+def test_sweep_min_not_less_than_max_rejected(capsys):
+    for lo, hi in (("0.5", "0.1"), ("0.2", "0.2")):
+        with pytest.raises(SystemExit) as exc:
+            cli_main([
+                "sweep", "--parameter", "amplitude",
+                "--min", lo, "--max", hi,
+            ])
+        assert exc.value.code == 2
+        assert "--min" in capsys.readouterr().err
+
+
+def test_sweep_steps_below_two_rejected(capsys):
+    for steps in ("1", "0", "-3"):
+        with pytest.raises(SystemExit) as exc:
+            cli_main([
+                "sweep", "--parameter", "amplitude",
+                "--min", "0.1", "--max", "0.5", "--steps", steps,
+            ])
+        assert exc.value.code == 2
+        assert "--steps" in capsys.readouterr().err
+
+
+def test_sweep_validation_runs_before_solve():
+    """A degenerate range is rejected before parametric_sweep is ever
+    called (no compute burned)."""
+    called = {"n": 0}
+
+    def fake_sweep(*a, **k):
+        called["n"] += 1
+        return []
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.parametric_sweep",
+        new=staticmethod(fake_sweep),
+    ), pytest.raises(SystemExit):
+        cli_main([
+            "sweep", "--parameter", "amplitude",
+            "--min", "0.5", "--max", "0.1",
+        ])
+    assert called["n"] == 0
+
+
+# --------------------------------------------------------------------------- #
 # argparse exit codes for invalid input
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Fixes #298.

The `sweep` handler was the only command with no error handling, giving two rough edges plus misleading help.

## What
- **Unknown `--parameter`** — `parametric_sweep`'s `AttributeError("AnalysisConfig has no field 'foo'")` propagated through `main()`'s bare `handler(args)` call as a full traceback. Now caught (with `ValueError`/`NotImplementedError`) and reported as a one-line `error: sweep failed: ...` with exit code 2, matching `_cmd_analyze`.
- **Degenerate ranges** ran silently or crashed: `--min >= --max` produced a descending/constant sweep; `--steps < 2` a single/empty sweep or a `np.linspace` traceback. Both are now rejected with a clear message and exit 2 **before any compute**.
- **Misleading help** — `--parameter` claimed only "amplitude, wavelength, or width" though `parametric_sweep` accepts any numeric `AnalysisConfig` field (e.g. `applied_strain`); reworded. (An argparse `choices=` would be *wrong* here — too restrictive.)

Pure CLI-layer change; the analysis API already validated the field name correctly.

## Acceptance criteria
- [x] `wrinklefe sweep --parameter foo ...` prints a one-line error and exits non-zero (no traceback).
- [x] `--min >= --max` and `--steps < 2` rejected with a clear message before any solve.
- [x] `--parameter` help no longer implies only three values are valid.
- [x] A CLI test covers each rejection path (incl. one asserting validation runs *before* `parametric_sweep` is called).

## Verification
- 26 CLI tests pass (4 new); whole-tree mypy clean; full-config ruff clean; CHANGELOG `[Unreleased]` updated.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_