### PR TITLE
cli: add --output-json/--output-csv to sweep and compare (fixes #266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- `wrinklefe sweep` and `wrinklefe compare` gained `--output-json` and
+  `--output-csv`: machine-readable batch results (a JSON array of
+  per-run objects matching `analyze --output-json`, and a tidy
+  one-row-per-run CSV with full float precision). The stdout tables are
+  unchanged.
 - `examples/` directory of runnable workflow scripts (basic knockdown,
   parametric sweep, morphology comparison, CZM delamination, export
   round-trip, custom material, mesh convergence), executed in CI.

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -21,8 +21,12 @@ import argparse
 import logging
 import sys
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from wrinklefe.analysis import AnalysisResults
 
 from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.morphology import MORPHOLOGY_PHASES, SINGLE_WRINKLE_MODES
@@ -347,6 +351,22 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_compare.add_argument(
+        "--output-json", type=str, default=None, dest="output_json",
+        help=(
+            "Write the comparison results to a JSON file (array of "
+            "per-run objects matching 'analyze --output-json'); the "
+            "stdout table is still printed"
+        ),
+    )
+    p_compare.add_argument(
+        "--output-csv", type=str, default=None, dest="output_csv",
+        help=(
+            "Write the comparison results to a tidy CSV (one row per "
+            "morphology, full float precision); the stdout table is "
+            "still printed"
+        ),
+    )
+    p_compare.add_argument(
         "-v", "--verbose", action="store_true", default=False,
         help=(
             "Show detailed pipeline progress (sets the 'wrinklefe' "
@@ -380,6 +400,21 @@ def _build_parser() -> argparse.ArgumentParser:
     p_sweep.add_argument(
         "--steps", type=int, default=10,
         help="Number of sweep steps (default: 10)",
+    )
+    p_sweep.add_argument(
+        "--output-json", type=str, default=None, dest="output_json",
+        help=(
+            "Write the sweep results to a JSON file (array of per-run "
+            "objects matching 'analyze --output-json'); the stdout "
+            "table is still printed"
+        ),
+    )
+    p_sweep.add_argument(
+        "--output-csv", type=str, default=None, dest="output_csv",
+        help=(
+            "Write the sweep results to a tidy CSV (one row per run, "
+            "full float precision); the stdout table is still printed"
+        ),
     )
     p_sweep.add_argument(
         "--morphology", type=str, default="stack",
@@ -788,6 +823,87 @@ def _cmd_compare(args: argparse.Namespace) -> None:
         print(f"    {i}. {morph:<10} {r.analytical_strength_MPa:.1f} MPa")
     print()
 
+    _write_batch_outputs(
+        [
+            ("morphology", morph, morph, all_results[morph])
+            for morph in ("stack", "convex", "concave")
+        ],
+        args.output_json,
+        args.output_csv,
+    )
+
+
+def _write_batch_outputs(
+    rows: list[tuple[str, float | str, str, AnalysisResults]],
+    output_json: str | None,
+    output_csv: str | None,
+) -> None:
+    """Write sweep/compare batch results to JSON and/or CSV (issue #266).
+
+    Parameters
+    ----------
+    rows : list of (parameter_name, parameter_value, morphology, results)
+        One entry per run, in output order.
+    output_json : str or None
+        Path for a JSON array of per-run objects, each matching the
+        ``analyze --output-json`` schema (:func:`analysis_results_to_dict`).
+    output_csv : str or None
+        Path for a tidy CSV (one row per run, full float precision):
+        ``parameter_name, parameter_value, morphology, knockdown,
+        predicted_strength_MPa, max_failure_index, governing_criterion``.
+    """
+    if output_json is None and output_csv is None:
+        return
+
+    import csv
+    import json
+    from pathlib import Path
+
+    from wrinklefe.io.export import analysis_results_to_dict
+
+    if output_json is not None:
+        payload = [analysis_results_to_dict(r) for _, _, _, r in rows]
+        path = Path(output_json)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nResults written to: {path}")
+
+    if output_csv is not None:
+        fieldnames = [
+            "parameter_name", "parameter_value", "morphology",
+            "knockdown", "predicted_strength_MPa",
+            "max_failure_index", "governing_criterion",
+        ]
+        path = Path(output_csv)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for name, value, morphology, r in rows:
+                fi = None
+                if r.failure_indices:
+                    fi = max(
+                        float(np.max(arr))
+                        for arr in r.failure_indices.values()
+                    )
+                crit = getattr(
+                    r.failure_report, "critical_criterion", None
+                ) if r.failure_report is not None else None
+                writer.writerow({
+                    "parameter_name": name,
+                    "parameter_value": value,
+                    "morphology": morphology,
+                    # repr() keeps full float precision; rounding stays a
+                    # display-only concern of the stdout table.
+                    "knockdown": repr(float(r.analytical_knockdown)),
+                    "predicted_strength_MPa": repr(
+                        float(r.analytical_strength_MPa)
+                    ),
+                    "max_failure_index": "" if fi is None else repr(fi),
+                    "governing_criterion": crit or "",
+                })
+        print(f"\nResults written to: {path}")
+
 
 def _cmd_sweep(args: argparse.Namespace) -> None:
     """Handle the ``sweep`` subcommand."""
@@ -847,6 +963,15 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
         )
 
     print("=" * 60)
+
+    _write_batch_outputs(
+        [
+            (args.parameter, float(val), args.morphology, r)
+            for val, r in zip(values, results)
+        ],
+        args.output_json,
+        args.output_csv,
+    )
 
 
 def _cmd_materials(args: argparse.Namespace) -> None:

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -74,22 +74,24 @@ def build_provenance(solver: dict | None = None) -> dict:
 # JSON export
 # ====================================================================== #
 
-def export_results_json(
-    results: AnalysisResults,
-    filepath: str | Path,
-) -> None:
-    """Export an :class:`~wrinklefe.analysis.AnalysisResults` object to JSON.
+def analysis_results_to_dict(results: AnalysisResults) -> dict:
+    """Serialise an :class:`~wrinklefe.analysis.AnalysisResults` to a dict.
 
-    Serialises the configuration, analytical predictions, and summary
-    statistics.  Large array data (FE fields, Monte Carlo samples) is
-    summarised rather than written in full.
+    The per-run schema used by :func:`export_results_json` — shared so
+    batch consumers (the CLI ``sweep``/``compare`` ``--output-json``
+    arrays, issue #266) stay schema-identical with single-run exports.
+    Large array data (FE fields, Monte Carlo samples) is summarised
+    rather than written in full.
 
     Parameters
     ----------
     results : AnalysisResults
-        The analysis results to export.
-    filepath : str or Path
-        Output JSON file path.
+        The analysis results to serialise.
+
+    Returns
+    -------
+    dict
+        JSON-serialisable per-run dictionary.
     """
     cfg = results.config
     data: dict = {
@@ -172,6 +174,25 @@ def export_results_json(
             "mean_angle_rad": float(jg.mean_angle),
         }
 
+    return data
+
+
+def export_results_json(
+    results: AnalysisResults,
+    filepath: str | Path,
+) -> None:
+    """Export an :class:`~wrinklefe.analysis.AnalysisResults` object to JSON.
+
+    Thin writer over :func:`analysis_results_to_dict`.
+
+    Parameters
+    ----------
+    results : AnalysisResults
+        The analysis results to export.
+    filepath : str or Path
+        Output JSON file path.
+    """
+    data = analysis_results_to_dict(results)
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
     filepath.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,81 @@ def test_sweep_validation_runs_before_solve():
 
 
 # --------------------------------------------------------------------------- #
+# sweep/compare: --output-json / --output-csv (issue #266)
+# --------------------------------------------------------------------------- #
+
+
+def test_sweep_output_csv_and_json(tmp_path, capsys):
+    """A coarse analytical sweep writes a tidy CSV and a JSON array of
+    per-run objects matching the analyze --output-json schema; the
+    stdout table is still printed."""
+    import csv
+    import json
+
+    csv_path = tmp_path / "sweep.csv"
+    json_path = tmp_path / "sweep.json"
+    cli_main([
+        "sweep", "--parameter", "amplitude",
+        "--min", "0.1", "--max", "0.3", "--steps", "3",
+        "--output-csv", str(csv_path),
+        "--output-json", str(json_path),
+    ])
+
+    # stdout table unchanged by default.
+    out = capsys.readouterr().out
+    assert "WrinkleFE Parametric Sweep" in out
+
+    rows = list(csv.DictReader(csv_path.open()))
+    assert [r["parameter_name"] for r in rows] == ["amplitude"] * 3
+    assert [float(r["parameter_value"]) for r in rows] == [0.1, 0.2, 0.3]
+    assert all(0.0 < float(r["knockdown"]) <= 1.0 for r in rows)
+    # Full precision in files (more digits than the 4dp stdout table).
+    assert len(rows[0]["knockdown"].split(".")[-1]) > 4
+    # Analytical-only: FE-derived columns are empty, not bogus.
+    assert rows[0]["max_failure_index"] == ""
+
+    arr = json.loads(json_path.read_text())
+    assert len(arr) == 3
+    # Per-run schema parity with analyze --output-json.
+    for entry in arr:
+        assert {"wrinklefe_version", "provenance", "configuration",
+                "analytical_predictions"} <= set(entry)
+    assert [e["configuration"]["amplitude_mm"] for e in arr] == [0.1, 0.2, 0.3]
+
+
+def test_compare_output_csv_and_json(tmp_path):
+    import csv
+    import json
+
+    csv_path = tmp_path / "cmp.csv"
+    json_path = tmp_path / "cmp.json"
+    cli_main([
+        "compare",
+        "--output-csv", str(csv_path),
+        "--output-json", str(json_path),
+    ])
+
+    rows = list(csv.DictReader(csv_path.open()))
+    assert [r["morphology"] for r in rows] == ["stack", "convex", "concave"]
+    assert all(r["parameter_name"] == "morphology" for r in rows)
+
+    arr = json.loads(json_path.read_text())
+    assert [e["configuration"]["morphology"] for e in arr] == [
+        "stack", "convex", "concave"
+    ]
+
+
+def test_sweep_without_output_flags_writes_nothing(tmp_path, monkeypatch):
+    """Default behaviour (stdout only) is preserved: no files appear."""
+    monkeypatch.chdir(tmp_path)
+    cli_main([
+        "sweep", "--parameter", "amplitude",
+        "--min", "0.1", "--max", "0.2", "--steps", "2",
+    ])
+    assert list(tmp_path.iterdir()) == []
+
+
+# --------------------------------------------------------------------------- #
 # argparse exit codes for invalid input
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Fixes #266.

The single-run `analyze` command was machine-readable (`--output-json`), but the two *batch* commands — whose whole purpose is producing data series — only emitted fixed-width stdout tables: an implicit, untested output contract that loses precision and forces composites engineers through screen-scraping.

## What
- **`export_results_json` refactored** into `analysis_results_to_dict()` (the per-run schema) plus a thin writer, so batch and single-run JSON can never drift.
- **`--output-json`** on `sweep` and `compare` writes an array of per-run objects in exactly that schema — each entry carries its own `configuration` (with the swept value / morphology) plus the #261 `provenance` block.
- **`--output-csv`** writes a tidy one-row-per-run CSV: `parameter_name, parameter_value, morphology, knockdown, predicted_strength_MPa, max_failure_index, governing_criterion`. Floats use `repr()` for full precision (rounding stays a display-only concern of the stdout table); FE-derived columns are empty for analytical-only runs; compare rows use `parameter_name="morphology"`.
- Both flags combinable with the stdout tables, which are **unchanged and remain the default**.

## Acceptance criteria
- [x] `sweep ... --output-csv` produces a tidy CSV loadable by `csv.DictReader`/`pandas.read_csv` with the documented columns; same for `compare`.
- [x] `--output-json` array entries match the `analyze --output-json` per-run schema (shared builder + schema-parity test).
- [x] stdout table unchanged by default (covered by a no-files-written test).
- [x] CLI tests cover both flags on coarse fast analytical runs.

## Verification
- 104 CLI + export tests pass (3 new CLI tests); whole-tree mypy clean; full-config ruff clean; CHANGELOG `[Unreleased]` updated.

https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWrC5UUU3At2WpQj3hqis)_