### PR TITLE
Add acknowledgment gate + optional Google-Sheets usage logging to the Streamlit app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ venv/
 .venv/
 env/
 
+# Streamlit secrets (service-account keys for usage logging — NEVER commit).
+# Keep the committed .streamlit/secrets.toml.example template.
+.streamlit/secrets.toml
+
 # IDE
 .vscode/
 .idea/

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,42 @@
+# WrinkleFE — Streamlit secrets template for acknowledgment-gate usage logging.
+#
+# Copy this file to `.streamlit/secrets.toml` for local testing, OR paste the
+# same content into Streamlit Community Cloud:
+#   Manage app -> Settings -> Secrets.
+#
+# The real `.streamlit/secrets.toml` is gitignored — NEVER commit credentials.
+# If `usage_tracking.py` finds no [gcp_service_account] section, the app still
+# runs and the gate still works; only the Google-Sheets logging is skipped.
+#
+# ----------------------------------------------------------------------------
+# One-time setup (≈10 min):
+#   1. Google Cloud Console -> create a project (or reuse one).
+#   2. Enable the "Google Sheets API" and "Google Drive API".
+#   3. Create a Service Account -> add a JSON key -> download the JSON file.
+#   4. Create a Google Sheet to receive the rows. From its URL copy the id:
+#        https://docs.google.com/spreadsheets/d/<THIS_IS_THE_SHEET_KEY>/edit
+#   5. Share that Sheet with the service account's `client_email` as EDITOR.
+#   6. Paste the JSON fields below and set `sheet_key`.
+# ----------------------------------------------------------------------------
+
+[gcp_service_account]
+type = "service_account"
+project_id = "your-gcp-project-id"
+private_key_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# Keep the literal \n escapes from the downloaded JSON; do not reformat.
+private_key = "-----BEGIN PRIVATE KEY-----\nMIIEv...\n...==\n-----END PRIVATE KEY-----\n"
+client_email = "wrinklefe-logger@your-gcp-project-id.iam.gserviceaccount.com"
+client_id = "000000000000000000000"
+auth_uri = "https://accounts.google.com/o/oauth2/auth"
+token_uri = "https://oauth2.googleapis.com/token"
+auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+client_x509_cert_url = "https://www.googleapis.com/robot/v1/metadata/x509/wrinklefe-logger%40your-gcp-project-id.iam.gserviceaccount.com"
+universe_domain = "googleapis.com"
+
+[usage_log]
+# Use the Sheet id from its URL (preferred) ...
+sheet_key = "your-google-sheet-id"
+# ... or, instead of sheet_key, the full URL:
+# sheet_url = "https://docs.google.com/spreadsheets/d/your-google-sheet-id/edit"
+# Optional: a specific tab name. Defaults to the first worksheet.
+# worksheet = "log"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ title: "WrinkleFE"
 version: 1.0.0
 date-released: 2025-03-24
 license: MIT
-repository-code: "https://github.com/ranipdx-glitch/wrinkleFE"
-url: "https://github.com/ranipdx-glitch/wrinkleFE"
+repository-code: "https://github.com/elhajjar1/wrinklefe"
+url: "https://github.com/elhajjar1/wrinklefe"
 abstract: >-
   WrinkleFE is a Python finite element package for predicting strength
   and stiffness knockdown in composite laminates containing fiber waviness

--- a/DEPLOYMENT_STREAMLIT.md
+++ b/DEPLOYMENT_STREAMLIT.md
@@ -109,6 +109,49 @@ Implications for WrinkleFE:
 - Configure a custom domain in Streamlit Cloud's settings.
 - Add CI to run `streamlit run --headless` smoke tests on every PR.
 
+## 10. Acknowledgment gate + usage logging (optional)
+
+The app opens with a one-time **acknowledgment gate** (`usage_tracking.py`):
+visitors are asked to cite / star the repo and may optionally leave an email
+before the tool unlocks. Acknowledgment is remembered per browser session via
+`st.session_state`, so repeat users see it only once.
+
+This is a **soft gate** by design. The app is public and MIT-licensed, so it
+can't *enforce* citation (anyone can `git clone` and run locally) — the gate
+makes the request visible and captures interested users. It works with **no
+configuration**: with no secrets set, the gate still shows and the rest of the
+app runs; only the logging is skipped.
+
+To also capture signups + run events in a **Google Sheet**:
+
+1. In Google Cloud Console, create a project and enable the **Google Sheets
+   API** and **Google Drive API**.
+2. Create a **Service Account**, add a **JSON key**, and download it.
+3. Create a Google Sheet to collect rows. Copy its id from the URL
+   (`.../spreadsheets/d/<SHEET_KEY>/edit`).
+4. **Share** that Sheet with the service account's `client_email` as **Editor**.
+5. Paste the credentials into Streamlit secrets. Locally, copy
+   [`.streamlit/secrets.toml.example`](.streamlit/secrets.toml.example) to
+   `.streamlit/secrets.toml` (gitignored — never commit it). On Streamlit
+   Cloud, paste the same content into **Manage app → Settings → Secrets**.
+
+The sheet gets one row per event with columns
+`timestamp_utc, event, email, session_id, props`:
+
+| event    | when                              | useful columns                              |
+|----------|-----------------------------------|---------------------------------------------|
+| `signup` | visitor clicks **Enter the app**  | `email` (blank if they skipped it)          |
+| `run`    | an analysis completes             | `props` → morphology, loading, n_plies, …   |
+
+`session_id` is a random per-session token (no identity, no IP) so you can
+tell repeat runs from distinct visits. Logging is **fail-soft**: a missing
+dependency, unshared sheet, or network blip is swallowed and never interrupts
+an analysis. The required `gspread` / `google-auth` packages are already in
+`requirements.txt`.
+
+> **Privacy:** you're storing emails and basic usage. The gate shows a short
+> notice, keeps email optional, and collects nothing else — keep it that way.
+
 ## App features
 
 Once the app is running, the sidebar offers three features worth calling out

--- a/DEPLOYMENT_STREAMLIT.md
+++ b/DEPLOYMENT_STREAMLIT.md
@@ -122,6 +122,10 @@ makes the request visible and captures interested users. It works with **no
 configuration**: with no secrets set, the gate still shows and the rest of the
 app runs; only the logging is skipped.
 
+To turn the gate **off** (e.g. a self-hosted internal deploy), set the env var
+`WRINKLEFE_DISABLE_GATE=1` — on Streamlit Cloud, add it under *Manage app →
+Settings*. The test suite sets the same switch so `AppTest` can drive the app.
+
 To also capture signups + run events in a **Google Sheet**:
 
 1. In Google Cloud Console, create a project and enable the **Google Sheets

--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ if _SRC.is_dir() and str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 import streamlit_viz  # noqa: E402
+import usage_tracking  # noqa: E402
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis  # noqa: E402
 from wrinklefe.core.layup import parse_layup  # noqa: E402
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial  # noqa: E402
@@ -59,6 +60,11 @@ st.set_page_config(
     page_icon=":dna:",
     layout="wide",
 )
+
+# Soft acknowledgment gate: shows a one-time cite/star screen and halts the
+# app (via st.stop) until the visitor agrees. No-op on later reruns once the
+# session is acknowledged. See usage_tracking.py.
+usage_tracking.render_gate()
 
 st.title("WrinkleFE — Composite Laminate Wrinkle Analysis")
 st.caption(
@@ -1469,6 +1475,21 @@ if run_clicked or _demo_pending:
 
     st.session_state["results"] = results
     st.session_state["cfg_payload"] = cfg_payload
+
+    # Best-effort usage log of the completed run (fail-soft; see usage_tracking).
+    _cfg_logged = dict(cfg_payload)
+    _angles_logged = _cfg_logged.get("angles_tuple", ())
+    usage_tracking.log_event(
+        "run",
+        props={
+            "morphology": _cfg_logged.get("morphology"),
+            "loading": _cfg_logged.get("loading"),
+            "analytical_only": _cfg_logged.get("analytical_only"),
+            "n_plies": len(_angles_logged) if isinstance(_angles_logged, (tuple, list)) else 0,
+            "demo": bool(_demo_pending),
+        },
+    )
+
     if _demo_pending:
         st.success(
             "✓ Demo analysis complete with sensible defaults "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ ignore_missing_imports = true
 
 # Optional usage-logging deps in usage_tracking.py (imported lazily). They are
 # not installed in the lint job ([dev] only) and ship no stubs, so allow the
-# missing-import resolution exactly like streamlit/plotly above.
+# missing-import resolution exactly like streamlit/plotly above. Patterns match
+# the actual imports: `import gspread` and `from google.oauth2.service_account`.
 [[tool.mypy.overrides]]
-module = ["gspread", "gspread.*", "google.oauth2", "google.oauth2.*"]
+module = ["gspread", "google.oauth2.*"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,10 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 module = ["streamlit", "streamlit.*", "plotly", "plotly.*"]
 ignore_missing_imports = true
+
+# Optional usage-logging deps in usage_tracking.py (imported lazily). They are
+# not installed in the lint job ([dev] only) and ship no stubs, so allow the
+# missing-import resolution exactly like streamlit/plotly above.
+[[tool.mypy.overrides]]
+module = ["gspread", "gspread.*", "google.oauth2", "google.oauth2.*"]
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,10 @@ matplotlib>=3.9,<4
 # Keep versions in sync with the `streamlit` extra in pyproject.toml.
 streamlit>=1.57.0
 plotly>=6.7.0
+
+# --- Optional: acknowledgment-gate usage logging to Google Sheets ---
+# Used by usage_tracking.py. Import is fail-soft: if these are absent or no
+# gcp_service_account secret is configured, the app still runs and logging is
+# silently skipped (see usage_tracking.py and DEPLOYMENT_STREAMLIT.md).
+gspread>=6.0
+google-auth>=2.0

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -176,7 +176,10 @@ def set_publication_style() -> None:
         "savefig.bbox": "tight",
         "savefig.pad_inches": 0.05,
     }
-    mpl.rcParams.update(params)
+    # matplotlib>=3.11 stubs type rcParams.update() with Literal rc-key keys,
+    # which a plain dict[str, object] literal can't satisfy. The mapping is
+    # valid at runtime; suppress the stub-only key mismatch.
+    mpl.rcParams.update(params)  # type: ignore[arg-type]
 
 
 # ======================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 """Shared pytest fixtures for WrinkleFE Phase 1 core module tests."""
 
+import os
+
 import pytest
+
+# Disable the app's acknowledgment gate for the whole suite. The gate halts
+# app.py with st.stop() until a visitor acknowledges, which is True even under
+# streamlit.testing AppTest (it starts a Runtime), so without this every
+# AppTest-driven test would see an empty page. See usage_tracking.render_gate.
+os.environ.setdefault("WRINKLEFE_DISABLE_GATE", "1")
 
 from wrinklefe.core.laminate import Laminate
 from wrinklefe.core.material import OrthotropicMaterial

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -5,10 +5,10 @@ page with ``st.stop()`` until a visitor acknowledges. These tests guard the
 contract that lets the rest of the suite (and Streamlit's ``AppTest``) drive
 the app at all:
 
-1. The gate is *inactive* outside a real ``streamlit run`` server — both for a
-   bare ``import app`` and under ``AppTest`` — so it can never halt the test
-   harness. This is the exact regression that an earlier guard (keyed on the
-   script-run context, which ``AppTest`` sets) caused.
+1. The gate honours the ``WRINKLEFE_DISABLE_GATE`` off-switch — set globally
+   by ``tests/conftest.py`` — so it can never halt the test harness. This is
+   the exact regression that earlier runtime-context guards failed to prevent
+   (``AppTest`` starts a Runtime, so it looks like a served app).
 2. ``log_event`` is fail-soft: with no logging dependency / secret configured
    it is a silent no-op and never raises into a running analysis.
 """
@@ -30,14 +30,27 @@ pytest.importorskip("streamlit", reason="Streamlit not installed.")
 import usage_tracking  # noqa: E402  - test-time import after path/skip setup.
 
 
-def test_gate_inactive_outside_served_app():
-    """No server Runtime exists under pytest/AppTest, so the gate must no-op."""
-    assert usage_tracking._running_in_served_app() is False
-
-
-def test_render_gate_is_noop_under_test():
-    """render_gate() must return (not call st.stop()) when not served."""
+def test_gate_disabled_via_env_var(monkeypatch):
+    """With the off-switch set, the gate is disabled and render_gate no-ops."""
+    monkeypatch.setenv("WRINKLEFE_DISABLE_GATE", "1")
+    assert usage_tracking._gate_disabled() is True
     # Would raise streamlit's StopException if the gate fired here.
+    usage_tracking.render_gate()
+
+
+def test_gate_off_switch_is_falsey_aware(monkeypatch):
+    """A blank/0 value must NOT count as 'disabled' (avoid the 0-means-on trap)."""
+    monkeypatch.setenv("WRINKLEFE_DISABLE_GATE", "0")
+    assert usage_tracking._gate_disabled() is False
+    monkeypatch.delenv("WRINKLEFE_DISABLE_GATE", raising=False)
+    assert usage_tracking._gate_disabled() is False
+
+
+def test_render_gate_noop_for_bare_import(monkeypatch):
+    """Even without the off-switch, the gate must no-op outside a served app."""
+    monkeypatch.delenv("WRINKLEFE_DISABLE_GATE", raising=False)
+    # No Streamlit server Runtime in the bare pytest thread.
+    assert usage_tracking._running_in_served_app() is False
     usage_tracking.render_gate()
 
 

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -1,0 +1,46 @@
+"""Tests for the acknowledgment-gate / usage-logging helpers.
+
+``usage_tracking.render_gate()`` runs at the top of ``app.py`` and halts the
+page with ``st.stop()`` until a visitor acknowledges. These tests guard the
+contract that lets the rest of the suite (and Streamlit's ``AppTest``) drive
+the app at all:
+
+1. The gate is *inactive* outside a real ``streamlit run`` server — both for a
+   bare ``import app`` and under ``AppTest`` — so it can never halt the test
+   harness. This is the exact regression that an earlier guard (keyed on the
+   script-run context, which ``AppTest`` sets) caused.
+2. ``log_event`` is fail-soft: with no logging dependency / secret configured
+   it is a silent no-op and never raises into a running analysis.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``usage_tracking.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+
+import usage_tracking  # noqa: E402  - test-time import after path/skip setup.
+
+
+def test_gate_inactive_outside_served_app():
+    """No server Runtime exists under pytest/AppTest, so the gate must no-op."""
+    assert usage_tracking._running_in_served_app() is False
+
+
+def test_render_gate_is_noop_under_test():
+    """render_gate() must return (not call st.stop()) when not served."""
+    # Would raise streamlit's StopException if the gate fired here.
+    usage_tracking.render_gate()
+
+
+def test_log_event_noop_without_configuration():
+    """log_event swallows the missing dependency/secret case without raising."""
+    usage_tracking.log_event("run", email="", props={"morphology": "stack"})

--- a/usage_tracking.py
+++ b/usage_tracking.py
@@ -34,6 +34,7 @@ Share the target Google Sheet with the service account's ``client_email``
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -49,15 +50,27 @@ _SCOPES = (
 REPO_URL = "https://github.com/elhajjar1/wrinklefe"
 
 
-def _running_in_served_app() -> bool:
-    """True only when a real Streamlit *server* Runtime is active.
+_DISABLE_ENV = "WRINKLEFE_DISABLE_GATE"
 
-    Uses ``streamlit.runtime.exists()``, which is ``True`` under a live
-    ``streamlit run`` but ``False`` both for a bare ``import app`` (pytest
-    importing the module) and under ``streamlit.testing`` ``AppTest`` — the
-    latter runs the script with a ``ScriptRunContext`` but never starts a
-    server Runtime. That keeps the gate, and its ``st.stop()``, out of every
-    test context while still firing for end users.
+
+def _gate_disabled() -> bool:
+    """True when the gate is explicitly switched off via env var.
+
+    Set ``WRINKLEFE_DISABLE_GATE=1`` to suppress the gate entirely — used by
+    the test suite (``tests/conftest.py``) so ``AppTest`` can drive the app,
+    and available to operators self-hosting the app who don't want the gate.
+    """
+    return os.environ.get(_DISABLE_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _running_in_served_app() -> bool:
+    """True when a Streamlit script-run context is active.
+
+    ``False`` for a bare ``import app`` (pytest importing the module for its
+    constants), so :func:`render_gate` can't call ``st.stop()`` at import
+    time. NOTE: this is ``True`` under ``streamlit.testing`` ``AppTest`` too
+    (it starts a Runtime), so it does not gate out the test harness on its
+    own — :func:`_gate_disabled` (set by ``tests/conftest.py``) does that.
     """
     try:
         from streamlit.runtime import exists
@@ -163,10 +176,12 @@ def render_gate() -> None:
     Once the visitor agrees, an ``_wf_acknowledged`` flag is set in
     ``session_state`` so the gate is skipped for the rest of the session.
     Calls :func:`streamlit.stop` while the gate is showing so nothing below
-    it in ``app.py`` renders. No-op outside a live ``streamlit run`` server
-    (bare ``import app`` under pytest, or an ``AppTest`` harness), so it never
-    halts test collection or the testing API.
+    it in ``app.py`` renders. No-op when disabled via ``WRINKLEFE_DISABLE_GATE``
+    (how the test suite drives the app) or for a bare ``import app`` outside a
+    Streamlit run, so it never halts test collection or the testing API.
     """
+    if _gate_disabled():
+        return
     if not _running_in_served_app():
         return
     if st.session_state.get("_wf_acknowledged"):

--- a/usage_tracking.py
+++ b/usage_tracking.py
@@ -1,0 +1,215 @@
+"""Soft-gate acknowledgment + optional usage logging for the WrinkleFE app.
+
+The hosted Streamlit app is public and runs on an *ephemeral* filesystem
+(see ``DEPLOYMENT_STREAMLIT.md``), so this module does two things:
+
+1. :func:`render_gate` shows a one-time acknowledgment screen (cite + star
+   the repo) before the rest of the app renders, capturing an optional
+   email so visitors can subscribe to release notes.
+2. :func:`log_event` appends ``signup`` / ``run`` rows to a Google Sheet so
+   the maintainer can see who is using the tool and what they analyse.
+
+Both are deliberately **fail-soft**: if ``gspread`` / ``google-auth`` are
+not installed, or no ``gcp_service_account`` secret is configured (e.g. a
+local ``streamlit run`` with no secrets), the gate still works and logging
+is silently skipped. The app never crashes because tracking is unavailable.
+
+Configure on Streamlit Community Cloud via *Manage app -> Settings ->
+Secrets* (see ``.streamlit/secrets.toml.example`` for the full template)::
+
+    [gcp_service_account]
+    type = "service_account"
+    project_id = "..."
+    private_key = "-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"
+    client_email = "wrinklefe-logger@...iam.gserviceaccount.com"
+    # ... rest of the downloaded service-account JSON ...
+
+    [usage_log]
+    sheet_key = "<google-sheet-id-from-its-url>"   # or: sheet_url = "https://..."
+
+Share the target Google Sheet with the service account's ``client_email``
+(give it *Editor*) so it can append rows.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import streamlit as st
+
+# Read-write scopes for Sheets + Drive (Drive is needed to open by URL/key).
+_SCOPES = (
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
+)
+
+REPO_URL = "https://github.com/elhajjar1/wrinklefe"
+
+
+def _running_in_streamlit() -> bool:
+    """True only inside a live ``streamlit run`` script execution.
+
+    Returns ``False`` during bare imports (pytest importing ``app.py``,
+    ``python app.py``), so :func:`render_gate` — and its unconditional
+    ``st.stop()`` — never fire at import time and can't break test collection.
+    """
+    try:
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+        if get_script_run_ctx(suppress_warning=True) is not None:
+            return True
+    except Exception:
+        pass
+    try:
+        from streamlit.runtime import exists
+
+        return bool(exists())
+    except Exception:
+        return False
+
+
+def _session_id() -> str:
+    """Return a stable, anonymous per-session id (not tied to any identity)."""
+    sid = st.session_state.get("_wf_session_id")
+    if not sid:
+        sid = uuid.uuid4().hex[:12]
+        st.session_state["_wf_session_id"] = sid
+    return str(sid)
+
+
+@st.cache_resource(show_spinner=False)
+def _worksheet() -> Any:
+    """Authorize against Google Sheets and return the target worksheet.
+
+    Cached for the lifetime of the server process so we authorise once, not
+    on every rerun. Returns ``None`` (and never raises) when the optional
+    dependencies or secrets are missing, which is the normal case for a
+    local run without configured secrets.
+    """
+    try:
+        import gspread
+        from google.oauth2.service_account import Credentials
+    except ImportError:
+        return None
+
+    try:
+        sa_info = dict(st.secrets["gcp_service_account"])
+        log_cfg = dict(st.secrets.get("usage_log", {}))
+    except Exception:
+        # No secrets file / section configured.
+        return None
+
+    sheet_key = log_cfg.get("sheet_key")
+    sheet_url = log_cfg.get("sheet_url")
+    if not (sheet_key or sheet_url):
+        return None
+
+    try:
+        creds = Credentials.from_service_account_info(sa_info, scopes=list(_SCOPES))
+        client = gspread.authorize(creds)
+        book = client.open_by_key(sheet_key) if sheet_key else client.open_by_url(sheet_url)
+        worksheet_name = log_cfg.get("worksheet")
+        ws = book.worksheet(worksheet_name) if worksheet_name else book.sheet1
+    except Exception:
+        # Bad credentials, sheet not shared with the service account, network
+        # hiccup, etc. Logging is best-effort; don't take the app down for it.
+        return None
+
+    # Best-effort header on a fresh sheet. Failure here is non-fatal.
+    try:
+        if not ws.row_values(1):
+            ws.append_row(
+                ["timestamp_utc", "event", "email", "session_id", "props"],
+                value_input_option="RAW",
+            )
+    except Exception:
+        pass
+    return ws
+
+
+def log_event(event: str, *, email: str = "", props: dict[str, Any] | None = None) -> None:
+    """Append one row to the usage sheet. Silent no-op if logging is unconfigured.
+
+    Parameters
+    ----------
+    event:
+        Short event kind, e.g. ``"signup"`` or ``"run"``.
+    email:
+        Optional email captured at the gate (blank for anonymous events).
+    props:
+        JSON-serialisable extra context (material, layup size, morphology…).
+    """
+    ws = _worksheet()
+    if ws is None:
+        return
+    try:
+        ws.append_row(
+            [
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                event,
+                email or "",
+                _session_id(),
+                json.dumps(props or {}, default=str),
+            ],
+            value_input_option="RAW",
+        )
+    except Exception:
+        # Never let a logging failure surface to the user mid-analysis.
+        pass
+
+
+def render_gate() -> None:
+    """Render the one-time acknowledgment gate; halt the app until accepted.
+
+    Once the visitor agrees, an ``_wf_acknowledged`` flag is set in
+    ``session_state`` so the gate is skipped for the rest of the session.
+    Calls :func:`streamlit.stop` while the gate is showing so nothing below
+    it in ``app.py`` renders. No-op outside a live ``streamlit run`` (e.g. a
+    bare ``import app`` under pytest), so it never halts test collection.
+    """
+    if not _running_in_streamlit():
+        return
+    if st.session_state.get("_wf_acknowledged"):
+        return
+
+    st.title("WrinkleFE")
+    st.subheader("Free academic software — a quick acknowledgment before you start")
+    st.markdown(
+        f"""
+**WrinkleFE** predicts strength and stiffness knockdown in composite
+laminates containing fiber-waviness defects. It is built and maintained by
+**Rani Elhajjar (University of Wisconsin–Milwaukee)** and released free
+under the MIT license.
+
+If WrinkleFE supports your published, academic, or commercial work, please:
+
+- **Cite it** — use the *Cite this repository* button on
+  [GitHub]({REPO_URL}) (driven by `CITATION.cff`).
+- **⭐ Star the repository** so other engineers can find it.
+"""
+    )
+
+    email = st.text_input(
+        "Email (optional)",
+        placeholder="you@university.edu",
+        help="Only used to send major release notes. Leave blank to skip.",
+    )
+    agree = st.checkbox(
+        "I'll acknowledge / cite WrinkleFE in any work that uses it."
+    )
+    st.caption(
+        "We keep an anonymous usage log (and your email, if you provide one) "
+        "to understand how the tool is used and improve it. Nothing else is "
+        "collected, and you can use the tool without entering an email."
+    )
+
+    if st.button("Enter the app →", type="primary", disabled=not agree):
+        st.session_state["_wf_acknowledged"] = True
+        log_event("signup", email=email.strip())
+        st.rerun()
+
+    # Block the rest of app.py until the visitor acknowledges.
+    st.stop()

--- a/usage_tracking.py
+++ b/usage_tracking.py
@@ -49,20 +49,16 @@ _SCOPES = (
 REPO_URL = "https://github.com/elhajjar1/wrinklefe"
 
 
-def _running_in_streamlit() -> bool:
-    """True only inside a live ``streamlit run`` script execution.
+def _running_in_served_app() -> bool:
+    """True only when a real Streamlit *server* Runtime is active.
 
-    Returns ``False`` during bare imports (pytest importing ``app.py``,
-    ``python app.py``), so :func:`render_gate` — and its unconditional
-    ``st.stop()`` — never fire at import time and can't break test collection.
+    Uses ``streamlit.runtime.exists()``, which is ``True`` under a live
+    ``streamlit run`` but ``False`` both for a bare ``import app`` (pytest
+    importing the module) and under ``streamlit.testing`` ``AppTest`` — the
+    latter runs the script with a ``ScriptRunContext`` but never starts a
+    server Runtime. That keeps the gate, and its ``st.stop()``, out of every
+    test context while still firing for end users.
     """
-    try:
-        from streamlit.runtime.scriptrunner import get_script_run_ctx
-
-        if get_script_run_ctx(suppress_warning=True) is not None:
-            return True
-    except Exception:
-        pass
     try:
         from streamlit.runtime import exists
 
@@ -167,10 +163,11 @@ def render_gate() -> None:
     Once the visitor agrees, an ``_wf_acknowledged`` flag is set in
     ``session_state`` so the gate is skipped for the rest of the session.
     Calls :func:`streamlit.stop` while the gate is showing so nothing below
-    it in ``app.py`` renders. No-op outside a live ``streamlit run`` (e.g. a
-    bare ``import app`` under pytest), so it never halts test collection.
+    it in ``app.py`` renders. No-op outside a live ``streamlit run`` server
+    (bare ``import app`` under pytest, or an ``AppTest`` harness), so it never
+    halts test collection or the testing API.
     """
-    if not _running_in_streamlit():
+    if not _running_in_served_app():
         return
     if st.session_state.get("_wf_acknowledged"):
         return


### PR DESCRIPTION
## What & why

You asked how to make visitors **acknowledge the repo / your effort** and let you **track usage** before they use the hosted Streamlit app (wrinklefe.streamlit.app). This adds a lightweight **soft gate** plus opt-in usage logging.

> **Reality check:** the app is public and MIT-licensed, so nothing can be *hard*-enforced (anyone can clone and run it locally, and MIT doesn't require citation). This is the realistic lever: a one-time screen that makes the citation request visible and captures interested users, plus a usage log you can actually read.

## Changes

- **`usage_tracking.py`** (new)
  - `render_gate()` — one-time screen asking visitors to cite / ⭐ the repo, with an **optional** email field. Remembered per session via `st.session_state`; halts the rest of the app with `st.stop()` until accepted. **No-ops outside a live `streamlit run`** (so bare `import app` under pytest is unaffected).
  - `log_event()` — appends `signup` / `run` rows to a Google Sheet via `gspread` + a service account in `st.secrets`.
  - **Fail-soft throughout:** missing deps, missing/invalid secrets, an unshared sheet, or a network blip are all swallowed — the app never crashes because logging is unavailable.
- **`app.py`** — render the gate right after `set_page_config`; log a `run` event when an analysis completes.
- **`requirements.txt`** — add `gspread` + `google-auth` (optional logging deps).
- **`pyproject.toml`** — `ignore_missing_imports` for `gspread` / `google.oauth2` under mypy (they ship no stubs and aren't in the lint job's `[dev]` install).
- **`.streamlit/secrets.toml.example`** + **`DEPLOYMENT_STREAMLIT.md` §10** — step-by-step setup; real `secrets.toml` is gitignored.
- **`CITATION.cff`** — point `repository-code` / `url` at `elhajjar1/wrinklefe` (was the stale `ranipdx-glitch` path) so GitHub's **Cite this repository** button is correct.

## Sheet schema

One row per event: `timestamp_utc, event, email, session_id, props`.

| event    | when                              | notes |
|----------|-----------------------------------|-------|
| `signup` | visitor clicks **Enter the app**  | `email` blank if skipped |
| `run`    | an analysis completes             | `props` → morphology, loading, analytical_only, n_plies, demo |

`session_id` is a random per-session token — no identity, no IP.

## Setup to activate logging (optional)

Without secrets, the gate still shows and the app still runs — only logging is skipped. To capture data: create a Google Cloud service account, enable the Sheets + Drive APIs, share a Sheet with the service-account email, and paste the JSON into Streamlit secrets. Full steps in `DEPLOYMENT_STREAMLIT.md` §10 / `.streamlit/secrets.toml.example`.

## Validation

- `ruff check .` ✓
- `mypy src/wrinklefe app.py streamlit_viz.py` ✓ for the changed code (remaining errors in this sandbox are pre-existing files lacking numpy/scipy/matplotlib stubs locally — resolved in CI where those deps install).
- `python -m py_compile` ✓

## Privacy note

You'd be storing emails + basic usage. The gate shows a short notice, keeps email optional, and collects nothing else — worth keeping that way given the university context.

https://claude.ai/code/session_01XmLgFecXCpnN7wwTQTLNg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmLgFecXCpnN7wwTQTLNg4)_