### PR TITLE
docs: correct LaRC05 and buckling API-reference docstrings (physics audit follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,15 @@ version produced a given file.
   decay scale to `max(λ/2, A)`. The `MaterialLibrary` docstring (and its
   doctest) now lists all 11 registered cards (10 fibre-reinforced systems
   + the `EPOXY_S6C10` neat-epoxy card) instead of a stale list of nine.
+- API-reference docstrings (physics audit, follow-up): the LaRC05 module
+  docstring described "iterative φ_c computation" and a Ramberg-Osgood
+  nonlinear-shear amplification that the code does not apply — corrected
+  to the linear closed-form load-induced φ_c that is actually used (the
+  `max_phi_c_iter` / `phi_c_tol` parameters are documented as reserved /
+  unused). The linear-buckling module docstring now carries the item-D.4
+  negative-finding note (the eigenvalue over-predicts the UD wrinkle
+  knockdown; use the penetration gate instead), matching the README and
+  the new theory page.
 - `wrinklefe sweep` now validates its inputs: an unknown `--parameter`,
   `--min >= --max`, or `--steps < 2` print a one-line error and exit
   non-zero (code 2) before any solve, instead of a raw traceback or a

--- a/src/wrinklefe/failure/larc05.py
+++ b/src/wrinklefe/failure/larc05.py
@@ -4,7 +4,7 @@ Implements the NASA Langley Research Center failure criteria (Dávila,
 Camanho, Pinho 2005) with:
 
 - **Fibre kinking** under compression via misalignment-frame rotation
-  with iterative φ_c computation and Ramberg-Osgood nonlinear shear
+  with a closed-form load-induced φ_c rotation
 - **Fibre tension** with fibre-matrix shear interaction
 - **Matrix failure** via fracture-plane search (Mohr-Coulomb)
 - **In-situ strength** corrections (fracture-toughness-based when GIc/GIIc
@@ -21,23 +21,20 @@ Derived from the fracture plane angle α₀ (typically 53° for CFRP)::
     μ_L = -S_L · cos(2α₀) / (Y_c · cos²(α₀))
     μ_T = -1 / tan(2α₀)
 
-Nonlinear Shear (Ramberg-Osgood)
----------------------------------
-Effective shear strain in the misalignment frame::
-
-    γ_12 = τ_12 / G_12 + β · τ_12³
-
-The nonlinear contribution amplifies the effective shear stress seen by
-the kink band, which is critical for accurate kink-band initiation
-predictions with fibre waviness.
-
-Iterative φ_c Computation
+Load-induced φ_c rotation
 -------------------------
-The additional fibre rotation under load is found by iterating::
+Under compression the misaligned fibres rotate further before kinking.
+The additional rotation is taken from the Dávila & Camanho linear
+closed form (NOT an iterative scheme)::
 
-    φ_c = (|σ_1| - σ_2) · φ_0 / (G_12 + |σ_1| - σ_2)  (linear approx.)
+    φ_c = (|σ₁| - σ₂) · φ₀ / (G₁₂ + |σ₁| - σ₂)      (clamped to [0, φ₀])
 
-Then the full nonlinear shear response refines φ_c until convergence.
+For wrinkle problems φ₀ is the dominant angle read from the geometry, so
+this small load-induced correction is evaluated once, with no iteration
+instability. A Ramberg-Osgood nonlinear-shear refinement
+(``γ_12 = τ_12 / G_12 + β · τ_12³``) is provided as a helper but is **not**
+applied to the kinking failure index in the current implementation, which
+uses the linear closed-form φ_c above.
 
 References
 ----------
@@ -71,9 +68,12 @@ class LaRC05Criterion(FailureCriterion):
     n_theta : int
         Number of fracture-plane angles to search (default 181).
     max_phi_c_iter : int
-        Maximum iterations for φ_c convergence (default 20).
+        Reserved for API compatibility (default 20). The current φ_c is a
+        single linear closed-form evaluation, so this iteration cap is not
+        used.
     phi_c_tol : float
-        Convergence tolerance for φ_c iteration (radians, default 1e-6).
+        Reserved for API compatibility (radians, default 1e-6). Unused
+        while φ_c is computed in closed form (see ``_compute_phi_c``).
     """
 
     name = "larc05"

--- a/src/wrinklefe/solver/buckling.py
+++ b/src/wrinklefe/solver/buckling.py
@@ -25,6 +25,22 @@ so the **microbuckling knockdown** is
 Unlike the progressive-damage path this is a single eigenvalue solve (no
 load stepping, no arc-length), and it captures the rotation-amplification
 the linear stress analysis misses.
+
+.. note::
+
+   **Negative finding (item D.4): this is not the production UD wrinkle
+   predictor.** Calibrated against the Li (2025) grids, the linear
+   eigenvalue *over-predicts* the knockdown badly (e.g. F
+   0.30 / 0.06 / 0.38 vs measured 0.89 / 0.63 / 0.47) for two physical
+   reasons: (1) the wrinkled structure is imperfection-sensitive (Koiter
+   — the bifurcation load sits far below the limit load), and (2)
+   buckling of the homogenised ply-mesh is local *structural* buckling of
+   the soft wrinkle region, not the sub-ply *fibre kinking* that actually
+   governs. ``K_geo`` is correct, tested infrastructure for genuine
+   structural-buckling analyses and is retained as such, but the
+   unidirectional wrinkle knockdown should be taken from the
+   :mod:`~wrinklefe.core.penetration_gate` instead. See the wrinkle
+   modelling findings (item D.4).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Follow-up to the physics/mechanics documentation audit (#320), correcting two **source docstrings that feed the Sphinx API reference** but overstated the implemented mechanics. Verified against the source so the docs match the code.

## What changed

### LaRC05 (`failure/larc05.py`)
The module docstring advertised "**iterative φ_c computation**" and a "**Ramberg-Osgood nonlinear shear**" amplification of the kink-band stresses. In the code:
- `_compute_phi_c` is a **single linear closed form** (Dávila & Camanho) — no iteration loop, and `beta` is passed but unused.
- The `_nonlinear_shear_strain` / `_effective_shear_stress` helpers are **defined but never called** — the kinking failure index uses only the linear closed-form φ_c.
- `max_phi_c_iter` / `phi_c_tol` are stored but never consumed.

Reworded the module docstring to describe the closed-form load-induced φ_c actually used (noting the Ramberg-Osgood refinement is provided as a helper but not applied), and documented `max_phi_c_iter` / `phi_c_tol` as reserved/unused.

### Linear buckling (`solver/buckling.py`)
The module docstring read as a working capability ("captures the rotation-amplification the linear stress analysis misses"). Added the **item-D.4 negative-finding note**: the linearized eigenvalue *over-predicts* the UD wrinkle knockdown (Koiter imperfection sensitivity; homogenised structural buckling vs sub-ply fibre kinking), so `K_geo` is retained as structural-buckling infrastructure but the UD knockdown should come from the penetration gate. This brings the API reference in line with the README and the new theory page from #320.

## Verification
- `ruff check` and `mypy` on both changed modules — pass.
- `sphinx-build -W docs docs/_build` — passes (warnings-as-errors; the `:mod:` cross-ref resolves, no private-method xref).
- `pytest tests/test_failure/test_larc05.py tests/test_buckling.py` — 29 passed.

Docstring-only; **no runtime behaviour changes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcSYDWf524or46iNFgQzZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcSYDWf524or46iNFgQzZX)_