### PR TITLE
docs: document Dataset G, IM6G card, and stiffness/modulus validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,19 @@ version produced a given file.
 - `AC318_S6C10_vacbag` material card — the Li 2025 vacuum-bag
   realization of the AC318 / S6C10-800 S-glass/epoxy prepreg (measured
   Xc = 335.5 MPa, E1 = 50.8 GPa).
+- `IM6G_3501_6` material card — Hercules IM6G / 3501-6 carbon/epoxy
+  (Vf 0.66) from Hsiao & Daniel (1996), the material behind validation
+  **Dataset G** (UD carbon, measured stiffness *and* strength knockdown).
+  This brings the built-in `MaterialLibrary` to 12 cards (11
+  fibre-reinforced systems + the `EPOXY_S6C10` neat-epoxy card).
+- Stiffness-only validation driver (`validation/validate_modulus.py`):
+  compares WrinkleFE's axial Young's-modulus knockdown — the FE
+  `modulus_retention` and a closed-form CLT series-average estimate of
+  the off-axis lamina modulus over the wrinkle profile — against the
+  measured modulus knockdown in the UD datasets E (Li 2024), F (Li 2025),
+  and G (Hsiao & Daniel 1996). It is the first stiffness (as opposed to
+  strength) validation in the repository; analytical MAE 3.9 % (F) /
+  1.2 % (G), FE MAE 6.9 % (F) / 5.1 % (G).
 - Combined validation parity chart
   (`validation/plot_all_validation.py` →
   `validation/fig_all_validation_parity.png`): a predicted-vs-experimental
@@ -95,7 +108,7 @@ version produced a given file.
   missing), document `theta_eff = M_f·theta_max` and the optional
   Argon–Fleck quadratic term, and correct the graded through-thickness
   decay scale to `max(λ/2, A)`. The `MaterialLibrary` docstring (and its
-  doctest) now lists all 11 registered cards (10 fibre-reinforced systems
+  doctest) now lists all 12 registered cards (11 fibre-reinforced systems
   + the `EPOXY_S6C10` neat-epoxy card) instead of a stale list of nine.
 - `wrinklefe sweep` now validates its inputs: an unknown `--parameter`,
   `--min >= --max`, or `--steps < 2` print a one-line error and exit

--- a/README.md
+++ b/README.md
@@ -362,6 +362,21 @@ with each dataset predicted by the model that physically applies to it
 (Budiansky–Fleck / three-mechanism for the multidirectional cases A–D,
 the penetration gate for the UD cases E/F).
 
+### Stiffness (modulus) knockdown
+
+Besides strength, WrinkleFE reports a **stiffness** knockdown — the FE
+`modulus_retention` (wrinkled vs pristine axial Young's modulus from the
+linear static solve). The script
+[`validation/validate_modulus.py`](validation/validate_modulus.py) scores
+this against the UD datasets that report a *measured modulus* — **F**
+(Li 2025, S-glass), **G** (Hsiao & Daniel 1996, carbon — the
+`IM6G_3501_6` card), and the indicative **E** (Li 2024) — alongside a
+closed-form CLT series-average estimate. The analytical estimate lands at
+3.9 % MAE (F) / 1.2 % (G) and the FE at 6.9 % (F) / 5.1 % (G). The data
+and both models agree that stiffness is far more wrinkle-tolerant than
+strength: the modulus knockdown stays ≈0.81–0.98 for the S-glass cases
+and only reaches ≈0.52–0.57 for a carbon uniform wrinkle at θ = 15°.
+
 ## Supported morphologies
 
 WrinkleFE ships five wrinkle morphologies (defined in

--- a/docs/internal/ARCHITECTURE.md
+++ b/docs/internal/ARCHITECTURE.md
@@ -59,7 +59,7 @@ from wrinklefe.failure.evaluator import FailureEvaluator
 
 | Module | Description |
 |--------|-------------|
-| `core/material.py` | `OrthotropicMaterial` dataclass + `MaterialLibrary` (10 built-in fibre-reinforced systems + 1 isotropic neat-epoxy card) |
+| `core/material.py` | `OrthotropicMaterial` dataclass + `MaterialLibrary` (11 built-in fibre-reinforced systems + 1 isotropic neat-epoxy card) |
 | `core/laminate.py` | `Laminate`, `Ply`, `LoadState`; Classical Lamination Theory ABD matrices |
 | `core/wrinkle.py` | `GaussianSinusoidal` wrinkle profile: z(x) = A exp(-x^2/w^2) cos(2pi x/lam) |
 | `core/morphology.py` | `WrinkleConfiguration`, `MorphologyFactor`, `MORPHOLOGY_PHASES`; phase-to-Mf mapping |

--- a/docs/internal/VALIDATION.md
+++ b/docs/internal/VALIDATION.md
@@ -61,6 +61,45 @@ See the table in [README.md](../../README.md). Current sources:
   (incl. the near-surface position case S-A-2), **vacuum-bag**
   realization with a measured pristine of 335.5 MPa (material card
   `AC318_S6C10_vacbag`, measured Xc = 335.5, E1 = 50.8 GPa).
+- **Dataset G — Hsiao & Daniel (1996)**, *Composites Science and
+  Technology* 56(5):581–593 — UD **carbon**/epoxy (IM6G/3501-6, material
+  card `IM6G_3501_6`) periodic waviness under compression, with measured
+  defect-free baselines. Two specimens: a *uniform*-waviness coupon
+  (θ ≈ 15°, modulus knockdown 0.571) and a *graded*-waviness coupon
+  (θ ≈ 7.2°, modulus knockdown 0.941, strength knockdown 0.660). The
+  first carbon system and the first dataset carrying a measured
+  **stiffness** knockdown — see *Stiffness / modulus validation* below.
+
+### Stiffness / modulus validation
+
+Everything above scores **strength** knockdown. WrinkleFE also predicts a
+**stiffness** (axial Young's-modulus) knockdown, exercised by
+`validation/validate_modulus.py` against every UD dataset that reports a
+measured modulus:
+
+- **FE** — the linear static solve's `modulus_retention` (mean
+  fibre-direction stress / applied strain, wrinkled vs pristine).
+- **Analytical** — a closed-form CLT series-average of the off-axis
+  lamina modulus over the wrinkle profile. The shipped *analytical* path
+  has no stiffness model (it returns `modulus_retention = 1.0`), so the
+  driver computes this estimate from the package primitives; it is the
+  same off-axis-compliance integration as Hsiao & Daniel (1996).
+
+| Dataset | Material | analytical MAE | FE MAE |
+|---|---|---|---|
+| F — Li (2025) | S-glass/epoxy | 3.9 % | 6.9 % |
+| G — Hsiao & Daniel (1996) | carbon/epoxy | 1.2 % | 5.1 % |
+| E — Li (2024), indicative | S-glass/epoxy | 7.7 % | 10.3 % |
+
+Both predictors confirm the datasets' headline: stiffness is far more
+wrinkle-tolerant than strength — modulus knockdown stays 0.81–0.98 for
+the Li S-glass cases and drops only to ≈0.52–0.57 for the carbon
+uniform-waviness case at θ = 15° (whose *strength* would fall far
+further). The analytical CLT tracks the angle, amplitude/penetration and
+through-thickness-position axes; the homogenised-continuum FE is flatter
+on the amplitude/position axes, consistent with the strength findings.
+The modulus validation is **UD-only** — no multidirectional dataset in
+the ledger reports a measured modulus knockdown.
 
 ### UD predictor: the two-parameter (θ, D/T, z) penetration gate
 

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -356,6 +356,17 @@ load-stepped) system and evaluates ply failure.
   $D=\tfrac13\sum \bar{Q}_k(z_k^3-z_{k-1}^3)$, an FSDT transverse-shear
   $H$ matrix with shear-correction factor $5/6$, thermal resultants, and
   effective membrane moduli $E_x, E_y, G_{xy}, \nu_{xy}$ from $A^{-1}$.
+- **Stiffness (modulus) knockdown.** Besides the per-criterion strength
+  retention, the linear FE solve reports `modulus_retention` — the ratio
+  of the wrinkled to pristine mean fibre-direction stress at a fixed
+  applied strain, i.e. the axial Young's-modulus knockdown
+  $E_x/E_{x,0}$. The *analytical* path has no stiffness model (it returns
+  $1.0$); both the FE `modulus_retention` and a closed-form
+  CLT-series-average estimate are validated against the UD modulus
+  datasets (Li 2025, Hsiao & Daniel 1996) by
+  `validation/validate_modulus.py` — see the
+  [validation page](validation.md). Stiffness is consistently far more
+  wrinkle-tolerant than strength.
 
 ### 5.1 Cohesive-zone delamination (CZM)
 

--- a/tests/test_integration/test_multi_wrinkle_fe.py
+++ b/tests/test_integration/test_multi_wrinkle_fe.py
@@ -121,8 +121,13 @@ class TestMultiWrinkleFE:
         r_scalar = WrinkleAnalysis(scalar_cfg).run()
         r_multi = WrinkleAnalysis(multi_cfg).run()
 
+        # modulus_retention is an FP-reduced scalar (mean sigma_11 over the
+        # mesh); the scalar-graded and one-entry-wrinkles paths reduce in a
+        # different order, agreeing only to ~1e-8, so rel=1e-9 flakes across
+        # platforms (e.g. macOS arm64). 1e-6 is well within any physical
+        # meaning; the FI fields below stay strict.
         assert r_multi.modulus_retention == pytest.approx(
-            r_scalar.modulus_retention, rel=1e-9
+            r_scalar.modulus_retention, rel=1e-6
         )
         for crit, arr in r_scalar.failure_indices.items():
             np.testing.assert_allclose(
@@ -168,8 +173,13 @@ class TestMultiWrinkleFE:
             rtol=0, atol=1e-12,
             err_msg="coincident halves must produce the same angle field",
         )
+        # FP-reduced scalar (see test above): the full vs coincident-halves
+        # paths reduce sigma_11 in a different order and agree only to ~1e-8,
+        # even though the mesh nodes and angle field are bit-identical
+        # (asserted at 1e-12 above). rel=1e-9 flakes on macOS arm64; 1e-6 is
+        # far inside any physical tolerance.
         assert r_halves.modulus_retention == pytest.approx(
-            r_full.modulus_retention, rel=1e-9
+            r_full.modulus_retention, rel=1e-6
         )
         for crit, arr in r_full.failure_indices.items():
             np.testing.assert_allclose(


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #321, bringing the project docs in line with the additions merged there (the `IM6G_3501_6` card, the `validation/validate_modulus.py` stiffness driver, and Hsiao &amp; Daniel 1996 as validation **Dataset G**).

## Changes
- **`CHANGELOG.md`** — add the `IM6G_3501_6` material card and the `validate_modulus.py` stiffness-only validation driver under *Unreleased → Added*; correct the `MaterialLibrary` count to 12 cards (11 fibre-reinforced systems + `EPOXY_S6C10`).
- **`docs/internal/VALIDATION.md`** (ledger) — add **Dataset G** (Hsiao &amp; Daniel 1996, UD carbon, measured modulus + strength) and a new **Stiffness / modulus validation** section with the E/F/G modulus MAEs.
- **`README.md`** — add a *Stiffness (modulus) knockdown* subsection under Validation.
- **`docs/theory.md`** — note the FE `modulus_retention` stiffness-knockdown output.
- **`docs/internal/ARCHITECTURE.md`** — built-in fibre-system count 10 → 11.

## CI de-flake (one test, unrelated to the docs)
- **`tests/test_integration/test_multi_wrinkle_fe.py`** — loosen the two `modulus_retention` cross-path comparisons from `rel=1e-9` to `rel=1e-6`. That scalar is an FP-reduced mean of σ₁₁; the scalar-graded and multi-wrinkle assembly paths reduce in a different order and agree only to ~1e-8, which flaked on macOS arm64 (`0.99944116` vs `0.99944113`). The mesh-node / fibre-angle fields stay asserted bit-identical (`atol=1e-12`) and the FI fields stay at `rtol=1e-9`; only the downstream scalar is relaxed.

## Gates
- `sphinx-build -W docs docs/_build` ✅ (warnings-as-errors, clean)
- `ruff check` + the two affected tests ✅ locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfTLxhxvGFwYsEMnTKpg27