### PR TITLE
feat: analytical stiffness (modulus) knockdown on the analytical path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Analytical stiffness (axial-modulus) knockdown on the analytical path:
+  `AnalysisResults.analytical_modulus_knockdown`, a closed-form CLT
+  series-average of the off-axis lamina modulus over the wrinkle profile
+  (`analysis._profile_modulus_knockdown`). Populated for unidirectional
+  layups (loading-independent, zero FE cost) — the closed-form companion
+  to the FE `modulus_retention`, which previously was the only stiffness
+  knockdown (the analytical path reported none). Surfaced in
+  `AnalysisResults.summary()`, the `analyze --output-json` payload,
+  `results_to_dict`, and the Streamlit app; validated by
+  `validation/validate_modulus.py` (analytical MAE 3.9 % / 1.2 % on the
+  Li 2025 / Hsiao & Daniel UD datasets).
 - Resin-pocket material zone (`wrinklefe.core.resin_pocket`:
   `ResinPocketSpec`, `compute_resin_mask`, `compute_resin_blend`):
   a graded neat-epoxy lens at the wrinkle crest, tagged into the FE mesh

--- a/README.md
+++ b/README.md
@@ -364,14 +364,15 @@ the penetration gate for the UD cases E/F).
 
 ### Stiffness (modulus) knockdown
 
-Besides strength, WrinkleFE reports a **stiffness** knockdown — the FE
-`modulus_retention` (wrinkled vs pristine axial Young's modulus from the
-linear static solve). The script
+Besides strength, WrinkleFE reports a **stiffness** knockdown of the axial
+Young's modulus two ways: the FE `modulus_retention` (wrinkled vs pristine
+from the linear static solve, any layup) and — for unidirectional layups —
+a closed-form `analytical_modulus_knockdown` (a CLT series-average of the
+off-axis lamina modulus over the wrinkle profile, no FE solve). The script
 [`validation/validate_modulus.py`](validation/validate_modulus.py) scores
-this against the UD datasets that report a *measured modulus* — **F**
+both against the UD datasets that report a *measured modulus* — **F**
 (Li 2025, S-glass), **G** (Hsiao & Daniel 1996, carbon — the
-`IM6G_3501_6` card), and the indicative **E** (Li 2024) — alongside a
-closed-form CLT series-average estimate. The analytical estimate lands at
+`IM6G_3501_6` card), and the indicative **E** (Li 2024). The analytical estimate lands at
 3.9 % MAE (F) / 1.2 % (G) and the FE at 6.9 % (F) / 5.1 % (G). The data
 and both models agree that stiffness is far more wrinkle-tolerant than
 strength: the modulus knockdown stays ≈0.81–0.98 for the S-glass cases

--- a/app.py
+++ b/app.py
@@ -1212,6 +1212,9 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         "morphology_factor": float(result.morphology_factor),
         "gamma_Y_eff": float(result.gamma_Y_eff),
         "analytical_knockdown": float(result.analytical_knockdown),
+        "analytical_modulus_knockdown": float(
+            result.analytical_modulus_knockdown
+        ),
         "analytical_strength_MPa": float(result.analytical_strength_MPa),
         "damage_index": float(result.damage_index),
         "tension_mechanisms": (
@@ -1736,6 +1739,15 @@ with tab_results:
                 "of load-carrying capacity. Above 0.5 is severe."
             ),
         )
+
+        _mod_kd = float(r.get("analytical_modulus_knockdown", 1.0))
+        if _mod_kd < 0.9999:
+            st.caption(
+                f"Analytical **stiffness** knockdown (axial modulus E₁): "
+                f"**{_mod_kd:.3f}** — closed-form CLT estimate for this "
+                "unidirectional wrinkle (no FE solve). Stiffness is far "
+                "more wrinkle-tolerant than strength."
+            )
 
         d1, d2, d3 = st.columns(3)
         d1.metric(

--- a/docs/internal/VALIDATION.md
+++ b/docs/internal/VALIDATION.md
@@ -79,11 +79,12 @@ measured modulus:
 
 - **FE** — the linear static solve's `modulus_retention` (mean
   fibre-direction stress / applied strain, wrinkled vs pristine).
-- **Analytical** — a closed-form CLT series-average of the off-axis
-  lamina modulus over the wrinkle profile. The shipped *analytical* path
-  has no stiffness model (it returns `modulus_retention = 1.0`), so the
-  driver computes this estimate from the package primitives; it is the
-  same off-axis-compliance integration as Hsiao & Daniel (1996).
+- **Analytical** — the analytical path's `analytical_modulus_knockdown`
+  (UD-scoped): a closed-form CLT series-average of the off-axis lamina
+  modulus over the wrinkle profile, the same off-axis-compliance
+  integration as Hsiao & Daniel (1996), at zero FE cost. (The driver
+  also recomputes this estimate standalone for datasets/configs outside
+  the single-`WrinkleAnalysis` path.)
 
 | Dataset | Material | analytical MAE | FE MAE |
 |---|---|---|---|

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -356,14 +356,20 @@ load-stepped) system and evaluates ply failure.
   $D=\tfrac13\sum \bar{Q}_k(z_k^3-z_{k-1}^3)$, an FSDT transverse-shear
   $H$ matrix with shear-correction factor $5/6$, thermal resultants, and
   effective membrane moduli $E_x, E_y, G_{xy}, \nu_{xy}$ from $A^{-1}$.
-- **Stiffness (modulus) knockdown.** Besides the per-criterion strength
-  retention, the linear FE solve reports `modulus_retention` — the ratio
-  of the wrinkled to pristine mean fibre-direction stress at a fixed
-  applied strain, i.e. the axial Young's-modulus knockdown
-  $E_x/E_{x,0}$. The *analytical* path has no stiffness model (it returns
-  $1.0$); both the FE `modulus_retention` and a closed-form
-  CLT-series-average estimate are validated against the UD modulus
-  datasets (Li 2025, Hsiao & Daniel 1996) by
+- **Stiffness (modulus) knockdown.** The analysis reports two estimates
+  of the axial Young's-modulus knockdown $E_x/E_{x,0}$. The FE
+  `modulus_retention` is the ratio of the wrinkled to pristine mean
+  fibre-direction stress at a fixed applied strain (any layup). For
+  **unidirectional** layups the analytical path additionally returns a
+  closed-form `analytical_modulus_knockdown`
+  (`analysis._profile_modulus_knockdown`): a Classical-Lamination-Theory
+  series-average of the off-axis lamina modulus
+  $1/E_x(\theta)=\cos^4\theta/E_1+(1/G_{12}-2\nu_{12}/E_1)\sin^2\theta\cos^2\theta+\sin^4\theta/E_2$
+  over the wrinkle profile (the same off-axis-compliance integration as
+  Hsiao & Daniel 1996), evaluated with no FE solve. It is loading-
+  independent and UD-scoped (it stays $1.0$ for multidirectional layups,
+  where `modulus_retention` is the predictor). Both are validated against
+  the UD modulus datasets (Li 2025, Hsiao & Daniel 1996) by
   `validation/validate_modulus.py` — see the
   [validation page](validation.md). Stiffness is consistently far more
   wrinkle-tolerant than strength.

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -378,6 +378,107 @@ def _profile_proportional_kd(
     return kd_sum / n_plies
 
 
+def _is_unidirectional(angles: Sequence[float], tol: float = 5.0) -> bool:
+    """True when every ply is a 0-degree (axial) ply within ``tol`` degrees.
+
+    0 and 180 degrees are equivalent fibre directions. The analytical
+    modulus knockdown (:func:`_profile_modulus_knockdown`) is only valid
+    for such unidirectional axial layups, so callers gate on this.
+    """
+    if not angles:
+        return False
+    for a in angles:
+        off = abs(float(a)) % 180.0
+        if min(off, 180.0 - off) > tol:
+            return False
+    return True
+
+
+def _profile_modulus_knockdown(
+    amplitude: float,
+    wavelength: float,
+    width: float,
+    domain_length: float,
+    ply_thickness: float,
+    n_plies: int,
+    E1: float,
+    E2: float,
+    G12: float,
+    nu12: float,
+    *,
+    morphology_factor: float = 1.0,
+    through_thickness_decay: bool = True,
+    z_position_fraction: float = 0.5,
+    decay_scale: float | None = None,
+    decay_floor: float = 0.0,
+) -> float:
+    r"""Axial Young's-modulus knockdown ``E_x / E_x0`` for a wavy UD laminate.
+
+    A Classical-Lamination-Theory series-average of the off-axis lamina
+    modulus over the wrinkle profile — the same off-axis-compliance
+    integration as Hsiao & Daniel (1996, Compos. Sci. Technol. 56:581).
+    At every ``(x, z_p)`` the local fibre tilt is the same field used by
+    :func:`_profile_proportional_kd`,
+    ``theta(x, z_p) = |dz_w/dx| * M_f * Phi(z_p)``, and the off-axis axial
+    modulus of a 0-degree ply tilted by ``theta`` is::
+
+        1/E_x(theta) = cos^4/E1 + (1/G12 - 2 nu12/E1) cos^2 sin^2 + sin^4/E2
+
+    The plies share the membrane strain, so the section modulus at a
+    station is the through-thickness mean
+    ``E_sec(x) = <E_x(theta(x, z_p))>_p``; along the load direction the
+    compliances add, so the effective modulus is the series (harmonic)
+    average ``E_eff = 1 / <1/E_sec(x)>_x``. The knockdown is
+    ``E_eff / E1`` (the pristine UD axial modulus is ``E1``).
+
+    Linear-elastic, hence loading-independent. **UD-scoped**: the off-axis
+    formula assumes a 0-degree base ply, so callers must restrict this to
+    unidirectional axial layups (see :func:`_is_unidirectional`).
+
+    Returns
+    -------
+    float
+        Axial-modulus knockdown in ``(0, 1]``.
+    """
+    T = n_plies * ply_thickness
+    z_center = z_position_fraction * T
+    L_s = domain_length
+    if decay_scale is None:
+        sigma = max(wavelength / 2.0, amplitude)
+    else:
+        sigma = float(decay_scale)
+    sigma_sq2 = 2.0 * sigma * sigma
+
+    # Same longitudinal angle field as the strength profile-average.
+    x = np.linspace(-L_s / 2.0, L_s / 2.0, _N_PROFILE_PTS)
+    gauss_env = np.exp(-(x ** 2) / (width ** 2))
+    cos_term = np.cos(2.0 * np.pi * x / wavelength)
+    sin_term = np.sin(2.0 * np.pi * x / wavelength)
+    dz_dx = amplitude * gauss_env * (
+        (-2.0 * x / (width ** 2)) * cos_term
+        - (2.0 * np.pi / wavelength) * sin_term
+    )
+    theta_x = np.abs(np.arctan(dz_dx)) * morphology_factor
+
+    shear_coupling = 1.0 / G12 - 2.0 * nu12 / E1
+    Ex_sum = np.zeros_like(x)
+    for p in range(n_plies):
+        z_p = (p + 0.5) * ply_thickness
+        if through_thickness_decay:
+            raw_p = np.exp(-((z_p - z_center) ** 2) / sigma_sq2)
+            phi_p = decay_floor + (1.0 - decay_floor) * raw_p
+        else:
+            phi_p = 1.0
+        theta = theta_x * phi_p
+        c2 = np.cos(theta) ** 2
+        s2 = np.sin(theta) ** 2
+        inv_Ex = c2 * c2 / E1 + shear_coupling * c2 * s2 + s2 * s2 / E2
+        Ex_sum += 1.0 / inv_Ex
+    E_sec = Ex_sum / n_plies              # through-thickness mean at each x
+    E_eff = 1.0 / np.mean(1.0 / E_sec)    # series-average along x
+    return float(E_eff / E1)
+
+
 def _check_multi_wrinkle_fe_support(cfg: AnalysisConfig) -> None:
     """Reject multi-wrinkle FE configs the pipeline cannot represent yet.
 
@@ -1429,6 +1530,13 @@ class AnalysisResults:
     mesh_max_angle_rad: float = 0.0  # max fiber angle from FE mesh (accounts for decay)
     damage_index: float = 0.0
     analytical_knockdown: float = 1.0
+    analytical_modulus_knockdown: float = 1.0
+    """Analytical axial Young's-modulus (stiffness) knockdown
+    ``E_x / E_x0`` — a closed-form CLT series-average of the off-axis
+    lamina modulus over the wrinkle profile (:func:`_profile_modulus_knockdown`).
+    UD-scoped: stays ``1.0`` for non-unidirectional layups and
+    multi-wrinkle configs. Loading-independent; the closed-form companion
+    to the FE :attr:`modulus_retention`."""
     analytical_onset_knockdown: float | None = None
     analytical_strength_MPa: float = 0.0
     gamma_Y_eff: float = 0.02  # layup-dependent effective yield strain
@@ -1551,6 +1659,7 @@ class AnalysisResults:
             f"({self.effective_angle_rad:.4f} rad)",
             f"    Damage index D:         {self.damage_index:.4f}",
             f"    Combined knockdown:     {self.analytical_knockdown:.4f}",
+            f"    Modulus knockdown:      {self.analytical_modulus_knockdown:.4f}",
             f"    Predicted strength:     {self.analytical_strength_MPa:.1f} MPa",
         ]
 
@@ -2436,6 +2545,45 @@ class WrinkleAnalysis:
             crack_length_per_interface=crack_len_per_iface,
         )
 
+    def _analytical_modulus_knockdown(
+        self, angles: list[float], morphology_factor: float
+    ) -> float:
+        """Closed-form axial-modulus knockdown for a wavy UD laminate.
+
+        Returns ``1.0`` (no analytical estimate) for multi-wrinkle configs,
+        non-unidirectional layups, or a degenerate wrinkle — the FE
+        :attr:`AnalysisResults.modulus_retention` covers those cases. See
+        :func:`_profile_modulus_knockdown`.
+        """
+        cfg = self.config
+        if cfg.wrinkles is not None:
+            return 1.0
+        if not _is_unidirectional(angles):
+            return 1.0
+        if cfg.wavelength <= 1e-12 or cfg.amplitude <= 0.0:
+            return 1.0
+        mat = cfg.material
+        assert mat is not None  # filled in __post_init__
+        graded = cfg.morphology.lower().strip() == "graded"
+        if cfg.through_thickness_decay_scale is not None:
+            decay_scale = float(cfg.through_thickness_decay_scale)
+        else:
+            decay_scale = max(cfg.wavelength / 2.0, cfg.amplitude)
+        return _profile_modulus_knockdown(
+            amplitude=cfg.amplitude,
+            wavelength=cfg.wavelength,
+            width=cfg.width,
+            domain_length=cfg.domain_length,
+            ply_thickness=cfg.ply_thickness,
+            n_plies=len(angles),
+            E1=mat.E1, E2=mat.E2, G12=mat.G12, nu12=mat.nu12,
+            morphology_factor=morphology_factor,
+            through_thickness_decay=graded,
+            z_position_fraction=float(cfg.wrinkle_z_position),
+            decay_scale=decay_scale,
+            decay_floor=float(cfg.decay_floor),
+        )
+
     def _compute_analytical(
         self,
         results: AnalysisResults,
@@ -2474,6 +2622,19 @@ class WrinkleAnalysis:
         else:
             theta_max = 0.0
         theta_eff = theta_max * mf
+
+        # Analytical stiffness (axial-modulus) knockdown — UD-scoped and
+        # loading-independent, set on both the gate and Budiansky-Fleck
+        # paths below. Resolve the layup the same way each path does.
+        if cfg.penetration_gate is not None:
+            _mod_angles = cfg.angles if cfg.angles else [0.0]
+        else:
+            _mod_angles = (
+                cfg.angles if cfg.angles else [0.0, 45.0, -45.0, 90.0] * 6
+            )
+        results.analytical_modulus_knockdown = (
+            self._analytical_modulus_knockdown(_mod_angles, mf)
+        )
 
         # Penetration-gate path (item D.3): when a calibrated gate is
         # configured, the analytical knockdown is the two-parameter

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -120,6 +120,9 @@ def analysis_results_to_dict(results: AnalysisResults) -> dict:
             "effective_angle_deg": float(np.degrees(results.effective_angle_rad)),
             "damage_index": float(results.damage_index),
             "analytical_knockdown": float(results.analytical_knockdown),
+            "analytical_modulus_knockdown": float(
+                results.analytical_modulus_knockdown
+            ),
             "analytical_strength_MPa": float(results.analytical_strength_MPa),
         },
     }

--- a/src/wrinklefe/io/results.py
+++ b/src/wrinklefe/io/results.py
@@ -235,6 +235,7 @@ def _knockdown_factors(results: AnalysisResults) -> dict:
     """Bundle the analytical + FE knockdown / retention factors."""
     out: dict = {
         "analytical": _f(results.analytical_knockdown),
+        "analytical_modulus": _f(results.analytical_modulus_knockdown),
     }
     # FE-derived strength retention factors are keyed by criterion in
     # results.retention_factors; we surface a single ``fe`` scalar as the
@@ -308,6 +309,9 @@ def results_to_dict(results: AnalysisResults) -> dict:
             "effective_angle_deg": _f(np.degrees(results.effective_angle_rad)),
             "damage_index": _f(results.damage_index),
             "analytical_knockdown": _f(results.analytical_knockdown),
+            "analytical_modulus_knockdown": _f(
+                results.analytical_modulus_knockdown
+            ),
             "analytical_strength_MPa": _f(results.analytical_strength_MPa),
             "gamma_Y_eff": _f(results.gamma_Y_eff),
         },

--- a/tests/test_analytical_modulus.py
+++ b/tests/test_analytical_modulus.py
@@ -1,0 +1,128 @@
+"""Analytical stiffness (axial-modulus) knockdown on the analytical path.
+
+Covers ``AnalysisResults.analytical_modulus_knockdown`` and the underlying
+``_profile_modulus_knockdown`` / ``_is_unidirectional`` helpers: the
+closed-form CLT series-average estimate populated for unidirectional
+laminates (the shipped analytical path otherwise reports no stiffness
+knockdown).
+"""
+from __future__ import annotations
+
+import pytest
+
+from wrinklefe.analysis import (
+    AnalysisConfig,
+    WrinkleAnalysis,
+    _is_unidirectional,
+    _profile_modulus_knockdown,
+)
+from wrinklefe.core.material import MaterialLibrary
+
+ML = MaterialLibrary()
+
+
+def _ud_config(amplitude=0.75, wavelength=12.9, loading="compression",
+               angles=None, morphology="graded"):
+    return AnalysisConfig(
+        amplitude=amplitude, wavelength=wavelength, width=wavelength / 2.0,
+        morphology=morphology, loading=loading,
+        material=ML.get("AC318_S6C10_vacbag"),
+        angles=angles if angles is not None else [0.0] * 14,
+        ply_thickness=0.44,
+        domain_length=max(3.0 * wavelength, 10.0), domain_width=10.0,
+    )
+
+
+def _kd(cfg):
+    return WrinkleAnalysis(cfg).run(analytical_only=True).analytical_modulus_knockdown
+
+
+# --------------------------------------------------------------------------
+# Helper unit tests
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("angles, expected", [
+    ([0.0] * 8, True),
+    ([0.0, 180.0, -180.0], True),
+    ([0.0, 2.0, -3.0], True),       # within 5-degree tolerance
+    ([0.0, 45.0, -45.0, 90.0], False),
+    ([90.0] * 4, False),
+    ([], False),
+])
+def test_is_unidirectional(angles, expected):
+    assert _is_unidirectional(angles) is expected
+
+
+def test_profile_modulus_unity_for_flat():
+    """Zero amplitude (no wrinkle) -> no stiffness loss."""
+    kd = _profile_modulus_knockdown(
+        amplitude=0.0, wavelength=12.9, width=6.45, domain_length=40.0,
+        ply_thickness=0.44, n_plies=14,
+        E1=50_800.0, E2=12_000.0, G12=5_500.0, nu12=0.28,
+    )
+    assert kd == pytest.approx(1.0, abs=1e-9)
+
+
+def test_profile_modulus_in_unit_interval():
+    kd = _profile_modulus_knockdown(
+        amplitude=0.75, wavelength=12.9, width=6.45, domain_length=40.0,
+        ply_thickness=0.44, n_plies=14,
+        E1=50_800.0, E2=12_000.0, G12=5_500.0, nu12=0.28,
+    )
+    assert 0.0 < kd < 1.0
+
+
+# --------------------------------------------------------------------------
+# Pipeline integration
+# --------------------------------------------------------------------------
+
+def test_ud_wrinkle_populates_modulus_knockdown():
+    """A UD graded wrinkle yields a sub-unity analytical modulus knockdown
+    (the shipped analytical path used to leave this at 1.0)."""
+    kd = _kd(_ud_config())
+    assert 0.80 < kd < 0.98
+
+
+def test_zero_amplitude_is_unity():
+    assert _kd(_ud_config(amplitude=0.0)) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_multidirectional_is_unity():
+    """UD-scoped: a multidirectional layup is left at 1.0 (use the FE
+    modulus_retention there)."""
+    kd = _kd(_ud_config(angles=[0.0, 45.0, -45.0, 90.0] * 2))
+    assert kd == pytest.approx(1.0, abs=1e-12)
+
+
+def test_loading_independent():
+    """Linear-elastic stiffness knockdown is the same in tension and
+    compression."""
+    kd_c = _kd(_ud_config(loading="compression"))
+    kd_t = _kd(_ud_config(loading="tension"))
+    assert kd_c == pytest.approx(kd_t, rel=1e-12)
+
+
+def test_decreases_with_amplitude():
+    kds = [_kd(_ud_config(amplitude=a)) for a in (0.25, 0.5, 0.75, 1.0)]
+    assert all(b < a for a, b in zip(kds, kds[1:])), kds
+    assert kds[0] < 1.0
+
+
+def test_exported_in_json_payloads():
+    from wrinklefe.io.export import analysis_results_to_dict
+    from wrinklefe.io.results import results_to_dict
+
+    result = WrinkleAnalysis(_ud_config()).run(analytical_only=True)
+    rd = results_to_dict(result)
+    assert "analytical_modulus_knockdown" in rd["analytical"]
+    assert rd["analytical"]["analytical_modulus_knockdown"] < 1.0
+    assert (rd["knockdown_factors"]["analytical_modulus"]
+            == rd["analytical"]["analytical_modulus_knockdown"])
+
+    ed = analysis_results_to_dict(result)
+    assert ed["analytical_predictions"]["analytical_modulus_knockdown"] < 1.0
+
+
+def test_summary_reports_modulus_knockdown():
+    result = WrinkleAnalysis(_ud_config()).run(analytical_only=True)
+    assert "Modulus knockdown" in result.summary()


### PR DESCRIPTION
## Summary

Gives WrinkleFE's **analytical** path a real stiffness output. Previously the analytical pipeline reported no modulus knockdown (`modulus_retention = 1.0` came only from the FE solve), even though the package predicts "strength *and* stiffness knockdown." This adds `AnalysisResults.analytical_modulus_knockdown` — a closed-form CLT series-average of the off-axis lamina axial modulus over the wrinkle profile, the same off-axis-compliance integration as Hsiao &amp; Daniel (1996), at zero FE cost.

It's the in-package version of the model validated in `validation/validate_modulus.py` (analytical MAE **3.9 %** on Li 2025 / **1.2 %** on Hsiao &amp; Daniel).

## What it computes

For each `(x, z_p)` the local fibre tilt is the same field the strength profile-average uses; the off-axis axial modulus is

```
1/E_x(θ) = cos⁴θ/E1 + (1/G12 − 2ν12/E1)·sin²θcos²θ + sin⁴θ/E2
```

Through-thickness mean → section modulus `E_sec(x)`; series-average along x → `E_eff`; knockdown = `E_eff/E1`. Linear-elastic, hence **loading-independent**, and **UD-scoped** (stays `1.0` for multidirectional layups and multi-wrinkle configs, where the FE `modulus_retention` is the predictor).

## Changes
- **`analysis.py`** — `_profile_modulus_knockdown` + `_is_unidirectional` helpers; `AnalysisResults.analytical_modulus_knockdown` field; computed in `_compute_analytical` (both the Budiansky–Fleck and penetration-gate paths); shown in `summary()`.
- **`io/results.py`, `io/export.py`** — field added to `results_to_dict`, `_knockdown_factors`, and the `analyze --output-json` payload.
- **`app.py`** — a stiffness-knockdown caption in the Analytical-predictions panel (shown only for UD wrinkles, where it's meaningful).
- **`tests/test_analytical_modulus.py`** (new, 15 tests) — UD value vs the validated number, zero-amplitude → 1.0, multidirectional → 1.0, loading-independence, monotonic-in-amplitude, JSON/summary exposure.
- **Docs** — theory page, README, validation ledger, and CHANGELOG updated (they previously stated the analytical path had no stiffness model).

## Gates (local)
- `ruff check .` ✅
- `mypy src/wrinklefe app.py streamlit_viz.py` ✅
- `sphinx-build -W docs docs/_build` ✅
- new tests + io / sweep / changelog / multi-wrinkle regressions ✅

Purely additive — no existing prediction (`analytical_knockdown`, `modulus_retention`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfTLxhxvGFwYsEMnTKpg27

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfTLxhxvGFwYsEMnTKpg27)_