### PR TITLE
core: validate ply angles and accept ASCII +-/-+ in parse_layup (#308)

### DIFF
--- a/src/wrinklefe/core/layup.py
+++ b/src/wrinklefe/core/layup.py
@@ -9,11 +9,16 @@ front-ends can never drift apart.
 Two notations are accepted:
 
 * **Contracted** -- ``[0/45/-45/90]_3s`` (sublaminate in brackets,
-  optional repeat count, trailing ``s`` for symmetry). ``+/-`` (written
-  ``±``) and ``_n`` ply-level modifiers are also supported, e.g.
-  ``[0/±45/90_2]s``.
+  optional repeat count, trailing ``s`` for symmetry). ``±`` (ASCII
+  ``+-``; ``-+`` gives the reversed ``∓`` order) and ``_n`` ply-level
+  modifiers are also supported, e.g. ``[0/±45/90_2]s``.
 * **Explicit list** -- comma-, semicolon-, or newline-separated angles,
   e.g. ``0, 45, -45, 90, ...``.
+
+Ply angles must be canonical (``|angle| <= 90``). Common ASCII typos for
+the ``_n`` repeat syntax -- a leading-zero token like ``02`` or an
+out-of-range token like ``902`` -- are rejected with a hint toward the
+intended ``0_2`` / ``90_2`` spelling rather than silently parsed.
 """
 
 from __future__ import annotations
@@ -24,9 +29,12 @@ from collections.abc import Sequence
 __all__ = ["parse_layup", "to_contracted_layup"]
 
 
+_MAX_PLY_ANGLE = 90.0
+
+
 _PLY_TOKEN_RE = re.compile(
     r"""\s*
-        (?P<sign>±)?\s*
+        (?P<sign>±|\+-|-\+)?\s*
         (?P<angle>[+-]?\d+(?:\.\d+)?)\s*
         (?:_(?P<rep>\d+))?\s*
     """,
@@ -34,18 +42,81 @@ _PLY_TOKEN_RE = re.compile(
 )
 
 
+def _subscript_hint(angle_str: str) -> str | None:
+    """Spelling a bare-digit-subscript typo most likely meant.
+
+    For an out-of-range *integer* angle that reads as a canonical angle
+    followed by a bare repeat count (``902`` -> ``90_2``, ``452`` ->
+    ``45_2``), return the ``_n`` spelling; otherwise ``None``. A trailing
+    ``_1`` is a no-op repeat, so a split is only offered for counts >= 2.
+    """
+    sign = ""
+    mag = angle_str
+    if mag[:1] in "+-":
+        sign, mag = mag[0], mag[1:]
+    if not mag.isdigit():  # decimals are never subscript typos
+        return None
+    for k in range(len(mag) - 1, 0, -1):
+        head, tail = mag[:k], mag[k:]
+        if 0 <= int(head) <= _MAX_PLY_ANGLE and int(tail) >= 2:
+            return f"{sign}{head}_{tail}"
+    return None
+
+
 def _expand_ply_token(token: str) -> list[float]:
-    """Expand a single ply entry like ``0``, ``45_2``, ``±45``, or ``±30_2``."""
+    """Expand a single ply entry like ``0``, ``45_2``, ``±45``, ``+-45``,
+    ``-+30``, or ``±30_2``.
+
+    ``±45`` and the ASCII aliases ``+-45`` expand to ``[45, -45]``;
+    ``-+45`` (the reversed order, the ASCII spelling of ``∓``) expands to
+    ``[-45, 45]``. Angles must be canonical (``|angle| <= 90``); leading
+    zeros (``02``) and out-of-range angles (``902``) are rejected with a
+    hint toward the ``_n`` repeat syntax they were likely meant to be.
+    """
     token = token.strip()
     if not token:
         return []
     m = _PLY_TOKEN_RE.fullmatch(token)
     if not m:
         raise ValueError(f"Could not parse ply token: {token!r}")
-    angle = float(m.group("angle"))
+    angle_str = m.group("angle")
     rep = int(m.group("rep")) if m.group("rep") else 1
-    if m.group("sign") == "±":
+
+    # Leading-zero integer tokens (02, 045) are never an angle — almost
+    # always a bare-digit repeat the user meant to write as `0_n`.
+    has_sign = angle_str[:1] in "+-"
+    mag = angle_str[1:] if has_sign else angle_str
+    if "." not in mag and len(mag) > 1 and mag[0] == "0":
+        sign_str = angle_str[0] if has_sign else ""
+        rest = mag.lstrip("0") or "0"
+        lead_hint = (
+            f" Did you mean {sign_str}0_{rest} (use _n for a repeated ply)?"
+            if int(rest) >= 2
+            else ""
+        )
+        raise ValueError(
+            f"Invalid ply angle {angle_str!r}: leading zeros are not "
+            f"allowed.{lead_hint}"
+        )
+
+    angle = float(angle_str)
+    if abs(angle) > _MAX_PLY_ANGLE:
+        hint = _subscript_hint(angle_str)
+        suggestion = (
+            f" Did you mean {hint} (use _n for a repeated ply)?"
+            if hint
+            else ""
+        )
+        raise ValueError(
+            f"Ply angle {angle:g}° is outside the canonical fibre-angle "
+            f"range [-90, 90].{suggestion}"
+        )
+
+    sign = m.group("sign")
+    if sign in ("±", "+-"):
         return [angle, -angle] * rep
+    if sign == "-+":
+        return [-angle, angle] * rep
     return [angle] * rep
 
 

--- a/tests/test_layup.py
+++ b/tests/test_layup.py
@@ -75,6 +75,72 @@ def test_malformed_layup_raises_value_error(bad):
 
 
 # --------------------------------------------------------------------------- #
+# Angle-range validation (issue #308)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", ["[900]", "[452]", "[0/91/90]", "900", "-452"])
+def test_out_of_range_angle_raises(bad):
+    with pytest.raises(ValueError, match="canonical"):
+        parse_layup(bad)
+
+
+def test_canonical_bounds_are_accepted():
+    # ±90 are the same fibre direction and must stay valid.
+    assert parse_layup("[90/-90/0]") == [90.0, -90.0, 0.0]
+    assert parse_layup("0, 90, -90, 45.5, -45.5") == [
+        0.0, 90.0, -90.0, 45.5, -45.5
+    ]
+
+
+def test_subscript_typo_suggests_underscore_syntax():
+    with pytest.raises(ValueError, match=r"90_2"):
+        parse_layup("[902]")
+    with pytest.raises(ValueError, match=r"45_2"):
+        parse_layup("452")
+
+
+# --------------------------------------------------------------------------- #
+# Leading-zero token rejection (issue #308)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", ["[02/902]s", "02", "045", "[0/030/90]"])
+def test_leading_zero_token_raises(bad):
+    with pytest.raises(ValueError, match="leading zero"):
+        parse_layup(bad)
+
+
+def test_leading_zero_suggests_repeat_syntax():
+    # The headline #308 case: [02/902]s must fail loudly toward [0_2/90_2]s.
+    with pytest.raises(ValueError, match=r"0_2"):
+        parse_layup("[02/902]s")
+
+
+# --------------------------------------------------------------------------- #
+# ASCII sign aliases +-, -+ for the Unicode ± / ∓ (issue #308)
+# --------------------------------------------------------------------------- #
+
+
+def test_ascii_plus_minus_matches_unicode():
+    assert parse_layup("[0/+-45/90]s") == parse_layup("[0/±45/90]s")
+    assert parse_layup("0, +-45, 90") == [0.0, 45.0, -45.0, 90.0]
+
+
+def test_ascii_minus_plus_is_reversed_order():
+    assert parse_layup("[0/-+45/90]s") == [
+        0.0, -45.0, 45.0, 90.0, 90.0, 45.0, -45.0, 0.0
+    ]
+    # -+ is the ASCII spelling of the reversed pair, opposite of +-.
+    assert parse_layup("-+30") == [-30.0, 30.0]
+    assert parse_layup("+-30") == [30.0, -30.0]
+
+
+def test_ascii_sign_alias_respects_repeat():
+    assert parse_layup("+-45_2") == [45.0, -45.0, 45.0, -45.0]
+
+
+# --------------------------------------------------------------------------- #
 # Contracted rendering (to_contracted_layup)
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Summary

Fixes #308. `parse_layup` (the shared layup parser behind the CLI and Streamlit app) silently accepted physically-impossible layups and rejected the ASCII sign spellings users actually type. This hardens the token parser in `core/layup.py` to **fail loudly with a hint toward the documented `_n` syntax**, while leaving the documented grammar untouched.

## The three fixes

1. **Angle-range validation** — reject `|angle| > 90` (the canonical fibre-angle range). `452` → error suggesting `45_2`; `900` → error naming the out-of-range angle. This also stops a bogus 900° "ply" from being miscounted as a 90° ply by the downstream tension-mechanism heuristic (`analysis.py:2305`, `abs(a) > 85`).
2. **Leading-zero rejection** — `02`, `045` (the common ASCII mis-spelling of a subscript repeat) now error with a `0_2` suggestion. The headline case `[02/902]s` (the user meant `[0_2/90_2]s`) errored instead of silently parsing to a `2°/902°` laminate.
3. **ASCII sign aliases** — `+-45` is now an alias for `±45` → `[45, -45]`, and `-+45` gives the reversed order `[-45, 45]` (the ASCII spelling of `∓`), in both contracted and explicit notations. CLI/script users no longer need to type `±`.

## Acceptance criteria (all met, verified at runtime)

```
'[02/902]s' → Invalid ply angle '02': leading zeros are not allowed. Did you mean 0_2 (use _n for a repeated ply)?
'[900]'     → Ply angle 900° is outside the canonical fibre-angle range [-90, 90].
'452'       → Ply angle 452° is outside the canonical fibre-angle range [-90, 90]. Did you mean 45_2 (use _n for a repeated ply)?
parse_layup('[0/+-45/90]s') == parse_layup('[0/±45/90]s')   # True
parse_layup('-+45') == [-45, 45]   #  vs  parse_layup('+-45') == [45, -45]
parse_layup('[90/-90/0]') == [90, -90, 0]   # ±90 still valid
```

## Scope / non-goals

Validation is at the **string-parse boundary** (`parse_layup`) only, exactly as the issue scopes it — directly assigning `AnalysisConfig.angles=[900]` is unchanged (a broader concern). The documented grammar (`±`, `_n`, `_ns`, explicit lists, decimals, negative and ±90 angles) is preserved.

## Tests / quality

- New tests in `tests/test_layup.py` for each rejection message (range, leading-zero, subscript hint) and the ASCII-alias equivalence/ordering.
- `ruff check .` clean; whole-tree `mypy` (53 files) clean.
- All parser-consuming suites pass unchanged: `test_layup` (47), `test_cli`, `test_blocked_layup_confinement`, `test_through_thickness_decay` (108 combined), `test_io/test_export` (54). A repo-wide scan confirmed no existing layup literal trips the new validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_