### PR TITLE
core: baseline the mesh aspect-ratio warning off the mesh median (#303)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -77,6 +77,18 @@ class MeshValidationError(ValueError):
 MESH_DECAY_WARN_RATIO: float = 2.5
 MESH_DECAY_INVERT_RATIO: float = 5.0
 
+# Aspect-ratio quality warning (issue #303). Ply-by-ply solid meshes are
+# intentionally thin through-thickness (one ply per element), so a large
+# overall max/min bounding-box ratio is the inherent "pancake" shape of the
+# discretization, not a defect — a fixed threshold flags ~every element of
+# ~every run. Instead, baseline off the mesh's own *median* element aspect
+# ratio and flag only elements ``ASPECT_RATIO_REL_FACTOR`` x worse than that
+# (wrinkle-induced distortion / in-plane slivers), never below
+# ``ASPECT_RATIO_ABS_FLOOR``:1 so genuinely cubic meshes still catch true
+# slivers.
+ASPECT_RATIO_REL_FACTOR: float = 3.0
+ASPECT_RATIO_ABS_FLOOR: float = 10.0
+
 
 @dataclass(frozen=True)
 class MeshShearDiagnostics:
@@ -618,7 +630,9 @@ class MeshData:
 
         * No NaN or Inf values in node coordinates.
         * Element connectivity indices are within ``[0, n_nodes)``.
-        * Element aspect ratios (bounding-box based) do not exceed 10:1.
+        * Element aspect ratios (bounding-box based) are not anomalous
+          relative to the mesh's own median — flags wrinkle-induced
+          distortion, not the inherent ply-pancake shape (issue #303).
         * No degenerate elements (all 8 nodes collapsed to a single point).
         * Element Jacobian determinant ``det(J)`` at the centroid is
           strictly positive for every hex8 element.  This is the upstream
@@ -656,27 +670,41 @@ class MeshData:
                 )
                 connectivity_ok = False
 
-        # 3. Aspect ratio check (bounding-box based, sampled for large meshes)
+        # 3. Aspect ratio check (bounding-box based, sampled for large
+        #    meshes). Ply-by-ply solid meshes are inherently pancake-shaped
+        #    (each element is one ply thick), so a fixed max/min threshold
+        #    flags every element of every run (issue #303). Baseline off the
+        #    mesh's own median element aspect ratio and flag only outliers
+        #    materially worse than that — wrinkle-induced distortion rather
+        #    than the inherent through-thickness pancake.
         if self.elements.size > 0 and connectivity_ok:
             n_check = min(self.n_elements, 500)
             rng = np.random.default_rng(42)
             sample_ids = rng.choice(self.n_elements, size=n_check, replace=False)
-            bad_aspect = 0
+            ratios: list[float] = []
             for eid in sample_ids:
                 coords = self.nodes[self.elements[eid]]  # (8, 3)
                 extents = coords.max(axis=0) - coords.min(axis=0)
                 # Replace zeros to avoid division issues
                 nonzero = extents[extents > 0]
                 if nonzero.size >= 2:
-                    ratio = nonzero.max() / nonzero.min()
-                    if ratio > 10.0:
-                        bad_aspect += 1
-            if bad_aspect > 0:
-                pct = 100.0 * bad_aspect / n_check
-                warnings.append(
-                    f"{bad_aspect}/{n_check} sampled elements have aspect "
-                    f"ratio > 10:1 ({pct:.1f}%)"
+                    ratios.append(float(nonzero.max() / nonzero.min()))
+            if ratios:
+                ratios_arr = np.asarray(ratios)
+                baseline = float(np.median(ratios_arr))
+                threshold = max(
+                    ASPECT_RATIO_ABS_FLOOR,
+                    ASPECT_RATIO_REL_FACTOR * baseline,
                 )
+                bad_aspect = int(np.count_nonzero(ratios_arr > threshold))
+                if bad_aspect > 0:
+                    pct = 100.0 * bad_aspect / len(ratios)
+                    warnings.append(
+                        f"{bad_aspect}/{len(ratios)} sampled elements have "
+                        f"aspect ratio > {threshold:.0f}:1 ({pct:.1f}%), well "
+                        f"above the mesh's typical {baseline:.0f}:1 — possible "
+                        f"distortion"
+                    )
 
         # 4. Degenerate element check (all 8 nodes at same point)
         if self.elements.size > 0 and connectivity_ok:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -504,3 +504,65 @@ class TestValidateJacobianSign:
         )
         with pytest.raises(MeshValidationError, match=r"inverted hex8"):
             bad.validate()
+
+
+# --------------------------------------------------------------------------- #
+# Aspect-ratio warning calibration (issue #303)
+# --------------------------------------------------------------------------- #
+
+
+def _box_mesh(boxes):
+    """Build a MeshData of independent axis-aligned hex8 boxes.
+
+    Each box is ``(x0, x1, y0, y1, z0, z1)`` and gets its own 8 nodes in the
+    standard hex8 ordering (positive Jacobian), so the degenerate and
+    inversion checks pass and only the aspect-ratio logic is exercised.
+    """
+    nodes: list[tuple[float, float, float]] = []
+    elements: list[list[int]] = []
+    for i, (x0, x1, y0, y1, z0, z1) in enumerate(boxes):
+        base = 8 * i
+        nodes += [
+            (x0, y0, z0), (x1, y0, z0), (x1, y1, z0), (x0, y1, z0),
+            (x0, y0, z1), (x1, y0, z1), (x1, y1, z1), (x0, y1, z1),
+        ]
+        elements.append(list(range(base, base + 8)))
+    n = len(boxes)
+    return MeshData(
+        nodes=np.asarray(nodes, dtype=float),
+        elements=np.asarray(elements, dtype=int),
+        ply_ids=np.zeros(n, dtype=int),
+        fiber_angles=np.zeros(n, dtype=float),
+        ply_angles=np.array([0.0]),
+        nx=n, ny=1, nz=1,
+    )
+
+
+class TestAspectRatioWarning:
+    """Issue #303: the AR warning must baseline off the mesh's own median
+    so the inherent ply-pancake shape does not trip it on every run."""
+
+    def test_default_pancake_mesh_emits_no_aspect_warning(self, small_laminate):
+        # Package-default in-plane discretization: dx=4, dy=2, dz=0.183 ->
+        # ~22:1 by construction. The old fixed 10:1 flagged 100% of these.
+        mesh = WrinkleMesh(
+            laminate=small_laminate, wrinkle_config=None,
+            Lx=48.0, Ly=12.0, nx=12, ny=6, nz_per_ply=1,
+        ).generate()
+        warns = mesh.validate()
+        assert not any("aspect ratio" in w for w in warns), warns
+
+    def test_uniformly_thin_mesh_is_silent(self):
+        # Every element a 50:1 pancake -> uniform, no outlier -> silent;
+        # standard practice for thin laminates is not a defect.
+        boxes = [(0, 5, j, j + 5, 0, 0.1) for j in range(6)]
+        warns = _box_mesh(boxes).validate()
+        assert not any("aspect ratio" in w for w in warns), warns
+
+    def test_anomalous_in_plane_sliver_warns(self):
+        # Five well-shaped cubes plus one in-plane sliver (AR 200): far above
+        # the mesh's ~1:1 median, so it must still be flagged.
+        boxes = [(0, 1, j, j + 1, 0, 1) for j in range(5)]
+        boxes.append((0.0, 10.0, 0.0, 0.05, 0.0, 1.0))
+        warns = _box_mesh(boxes).validate()
+        assert any("aspect ratio" in w for w in warns), warns


### PR DESCRIPTION
## Summary

Fixes #303. `MeshData.validate()` flagged any element whose bounding-box aspect ratio exceeded a fixed **10:1**. Ply-by-ply solid meshes are inherently pancake-shaped (each element is one ~0.18 mm ply thick vs mm-scale in-plane), so with stock defaults elements are ~22:1 **by construction** — the warning fired on **71–100% of elements on every run** (both the wrinkled and flat-reference meshes). That alarm fatigue buried the warnings that matter (Jacobian-sign inversion, decay-ratio guidance).

## The fix

Replace the fixed threshold with an **outlier test relative to the mesh's own median** element aspect ratio:

```
threshold = max(ASPECT_RATIO_ABS_FLOOR (10:1), ASPECT_RATIO_REL_FACTOR (3×) · median_AR)
```

This flags only elements materially worse-shaped than the inherent pancake — i.e. wrinkle-induced distortion / in-plane slivers — while correctly treating the inherent (and uniformly-thin) pancake shape as the non-defect it is (the issue's option 1, the "config-aware baseline", realised self-contained from the mesh itself so `validate()` needs no config access). The degenerate-element and Jacobian-sign (which *raises*) checks are unchanged.

## Acceptance criteria (all met)

- ✅ **Stock run is silent** — `WrinkleAnalysis(AnalysisConfig()).run()` now emits **zero** mesh-quality warnings (verified end-to-end: 0 aspect warnings vs the previous 71%/100%).
- ✅ **Genuine distortion still warns** — an anomalous in-plane sliver (AR 200) among well-shaped elements is flagged.
- ✅ **Default-config silence is pinned** by a test; all existing mesh tests pass.

New `TestAspectRatioWarning` covers the default pancake mesh (silent), a uniformly-thin mesh (silent — standard practice for thin laminates is not a defect), and an anomalous sliver (warns).

## Quality

- `ruff check .` clean; whole-tree `mypy` (53 files) clean.
- `tests/test_mesh.py` — 51 passed. No test depended on the old `> 10:1` behavior (the change is warning-logic only and cannot affect FE numerical results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_