### PR TITLE
core: warn when the FE mesh under-samples the wrinkle wavelength (#306)

### DIFF
--- a/src/wrinklefe/core/mesh.py
+++ b/src/wrinklefe/core/mesh.py
@@ -77,6 +77,15 @@ class MeshValidationError(ValueError):
 MESH_DECAY_WARN_RATIO: float = 2.5
 MESH_DECAY_INVERT_RATIO: float = 5.0
 
+# Minimum in-plane elements per wrinkle wavelength (issue #306). A trilinear
+# hex mesh needs several elements per wavelength to represent the sinusoid;
+# below this the FE "wrinkle" is aliasing noise even though the solve
+# completes. Stock defaults give exactly 4 elements/wavelength and validated
+# configs used ~8, so warning below 4 keeps default runs silent while
+# flagging the clearly-inadequate 1-3/wavelength regime. Analogous to the
+# analytical path's own Nyquist guard in ``core/wrinkle.py``.
+MESH_RESOLUTION_WARN_RATIO: float = 4.0
+
 # Aspect-ratio quality warning (issue #303). Ply-by-ply solid meshes are
 # intentionally thin through-thickness (one ply per element), so a large
 # overall max/min bounding-box ratio is the inherent "pancake" shape of the
@@ -869,7 +878,50 @@ class WrinkleMesh:
         for w in mesh_warnings:
             logger.warning(w)
 
+        resolution_warning = self._wrinkle_resolution_warning()
+        if resolution_warning is not None:
+            logger.warning(resolution_warning)
+
         return mesh_data
+
+    def _wrinkle_resolution_warning(self) -> str | None:
+        """Warn when the in-plane mesh under-samples the wrinkle wave.
+
+        The trilinear hex mesh needs several elements per wavelength to
+        represent the sinusoid; below :data:`MESH_RESOLUTION_WARN_RATIO`
+        the FE "wrinkle" is aliasing noise even though the solve completes
+        and returns failure indices with full confidence (issue #306). The
+        element x-size and each wrinkle's wavelength are both known here, so
+        the adequacy ratio ``lambda / dx`` is one division; multi-wrinkle
+        configs are governed by the shortest wavelength (fewest elements per
+        wavelength). Returns ``None`` when adequately resolved or flat.
+        """
+        cfg = self.wrinkle_config
+        if cfg is None or self.nx <= 0 or self.Lx <= 0.0:
+            return None
+        wavelengths = []
+        for w in getattr(cfg, "wrinkles", ()) or ():
+            inner = getattr(w.profile, "profile", w.profile)
+            lam = float(getattr(inner, "wavelength", 0.0))
+            if lam > 0.0:
+                wavelengths.append(lam)
+        if not wavelengths:
+            return None
+        dx = self.Lx / self.nx
+        lam_min = min(wavelengths)  # shortest wavelength -> worst sampling
+        elems_per_wave = lam_min / dx
+        if elems_per_wave >= MESH_RESOLUTION_WARN_RATIO:
+            return None
+        nx_needed = int(math.ceil(MESH_RESOLUTION_WARN_RATIO * self.Lx / lam_min))
+        return (
+            f"Wrinkle wavelength {lam_min:.3g} mm is sampled by only "
+            f"{elems_per_wave:.1f} elements/wavelength (element dx="
+            f"{dx:.3g} mm), below the recommended "
+            f"{MESH_RESOLUTION_WARN_RATIO:.0f}: the hex mesh cannot represent "
+            f"the wrinkle and the result may be aliasing noise. Increase nx "
+            f"to >= {nx_needed} (or shorten domain_length), or run a "
+            f"convergence study (`wrinklefe converge`)."
+        )
 
     def _augment_inversion_error(
         self, err: MeshValidationError

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -7,7 +7,7 @@ import pytest
 from wrinklefe.core.laminate import Laminate
 from wrinklefe.core.material import OrthotropicMaterial
 from wrinklefe.core.mesh import MeshData, MeshValidationError, WrinkleMesh
-from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.morphology import WrinkleConfiguration, WrinklePlacement
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 
 
@@ -566,3 +566,66 @@ class TestAspectRatioWarning:
         boxes.append((0.0, 10.0, 0.0, 0.05, 0.0, 1.0))
         warns = _box_mesh(boxes).validate()
         assert any("aspect ratio" in w for w in warns), warns
+
+
+# --------------------------------------------------------------------------- #
+# Wrinkle-wavelength resolution guard (issue #306)
+# --------------------------------------------------------------------------- #
+
+
+class TestWrinkleResolutionWarning:
+    """Issue #306: warn when the in-plane mesh under-samples the wrinkle
+    wave (too few elements per wavelength to represent the sinusoid)."""
+
+    def _mesh(self, laminate, config, Lx, nx):
+        return WrinkleMesh(
+            laminate=laminate, wrinkle_config=config,
+            Lx=Lx, Ly=5.0, nx=nx, ny=3, nz_per_ply=1,
+        )
+
+    def test_under_resolved_wrinkle_warns(self, small_laminate):
+        # Repro from #306: 2 mm wavelength on a 6 mm domain with nx=4 ->
+        # dx=1.5 mm -> 1.3 elements/wavelength.
+        prof = GaussianSinusoidal(
+            amplitude=0.05, wavelength=2.0, width=1.5, center=3.0
+        )
+        cfg = WrinkleConfiguration.dual_wrinkle(
+            prof, interface1=1, interface2=2, phase=0.0
+        )
+        msg = self._mesh(small_laminate, cfg, Lx=6.0, nx=4)._wrinkle_resolution_warning()
+        assert msg is not None
+        assert "1.3" in msg      # elements per wavelength named
+        assert ">= 12" in msg    # nx needed to reach 4/wavelength named
+
+    def test_adequately_resolved_is_silent(self, small_laminate):
+        # 16 mm wavelength, 48 mm domain, nx=12 -> dx=4 -> exactly 4/wave.
+        prof = GaussianSinusoidal(
+            amplitude=0.1, wavelength=16.0, width=12.0, center=24.0
+        )
+        cfg = WrinkleConfiguration.dual_wrinkle(
+            prof, interface1=1, interface2=2, phase=0.0
+        )
+        mesh = self._mesh(small_laminate, cfg, Lx=48.0, nx=12)
+        assert mesh._wrinkle_resolution_warning() is None
+
+    def test_flat_mesh_is_silent(self, small_laminate):
+        mesh = self._mesh(small_laminate, None, Lx=48.0, nx=12)
+        assert mesh._wrinkle_resolution_warning() is None
+
+    def test_multi_wrinkle_uses_shortest_wavelength(self, small_laminate):
+        # A well-resolved 16 mm wrinkle plus an under-resolved 4 mm wrinkle
+        # at nx=12 over 48 mm (dx=4): the 4 mm (1 element/wavelength) governs.
+        long_p = GaussianSinusoidal(
+            amplitude=0.1, wavelength=16.0, width=12.0, center=24.0
+        )
+        short_p = GaussianSinusoidal(
+            amplitude=0.05, wavelength=4.0, width=3.0, center=24.0
+        )
+        cfg = WrinkleConfiguration([
+            WrinklePlacement(profile=long_p, ply_interface=1, phase_offset=0.0),
+            WrinklePlacement(profile=short_p, ply_interface=2, phase_offset=0.0),
+        ])
+        msg = self._mesh(small_laminate, cfg, Lx=48.0, nx=12)._wrinkle_resolution_warning()
+        assert msg is not None
+        assert "1.0 elements" in msg   # shortest (4 mm) wavelength governs
+        assert ">= 48" in msg


### PR DESCRIPTION
## Summary

Fixes #306. The FE mesher validated NaN/connectivity, aspect ratio, degeneracy, Jacobian sign, and the through-thickness decay ratio — but nothing checked the **in-plane sampling of the wrinkle wave**. So a mesh with ~1.3 elements per wavelength solved to completion and returned failure indices with full confidence, even though the trilinear hexes geometrically cannot contain the sinusoid (the "wrinkle" the solver sees is aliasing noise). The *analytical* path already guards its own Nyquist sampling (`core/wrinkle.py`); this brings the FE side up to the same standard.

## The fix

`WrinkleMesh.generate()` now computes `elements_per_wavelength = wavelength / (Lx / nx)` and warns below **`MESH_RESOLUTION_WARN_RATIO = 4.0`** (documented right next to `MESH_DECAY_WARN_RATIO`). Multi-wrinkle configs are governed by the **shortest** wavelength (fewest elements/wavelength). The message is actionable — it names the current ratio, the `nx` needed to reach the threshold, and points at `wrinklefe converge`:

```
Wrinkle wavelength 2 mm is sampled by only 1.3 elements/wavelength (element dx=1.5 mm),
below the recommended 4: the hex mesh cannot represent the wrinkle and the result may be
aliasing noise. Increase nx to >= 12 (or shorten domain_length), or run a convergence
study (`wrinklefe converge`).
```

Stock defaults give **exactly 4** elements/wavelength, so default runs stay silent — keeping the warning channel credible (cf. #303).

## Acceptance criteria (all met, verified end-to-end)

- ✅ The #306 repro (`amplitude=0.1, wavelength=2.0, nx=4` → 6 mm domain → 1.3/λ) emits a warning naming the ratio **and** the `nx` (≥12) that fixes it.
- ✅ Default `AnalysisConfig()` emits **no** new warning (0 resolution warnings).
- ✅ Multi-wrinkle configs use the worst (shortest-wavelength) ratio.
- ✅ Threshold documented next to the existing decay-ratio constant.

## Quality

- `ruff check .` clean; whole-tree `mypy` (53 files) clean.
- `tests/test_mesh.py` — 55 passed (new `TestWrinkleResolutionWarning`: under-resolved / adequately-resolved / flat / multi-wrinkle). Warning-only change — no impact on FE numerical results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ee9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_