### PR TITLE
materials: add GIc/GIIc to S2 glass and Kevlar presets for CZM (#268)

### DIFF
--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -798,6 +798,11 @@ class MaterialLibrary:
         #    laminate tables) and Daniel & Ishai (2006) "Engineering
         #    Mechanics of Composite Materials", 2nd ed., Table A.4.
         #    Representative cured-ply values at Vf ≈ 0.60.
+        #    Interlaminar fracture toughness: glass/epoxy is markedly tougher
+        #    than carbon/epoxy (published GIc ≈ 0.4–1.0 N/mm, GIIc ≈ 2–4×
+        #    GIc); GIc = 0.8, GIIc = 2.0 N/mm are representative values in
+        #    that range (CMH-17 Vol 2 / Daniel & Ishai 2006), consistent
+        #    with the ~2.5× GIIc/GIc ratio of the carbon presets above.
         self.add(OrthotropicMaterial(
             name="S2_GLASS_EPOXY",
             E1=52_000.0, E2=19_000.0, E3=19_000.0,
@@ -810,7 +815,7 @@ class MaterialLibrary:
             alpha1=6.6e-6, alpha2=19.7e-6, alpha3=19.7e-6,
             beta1=0.0, beta2=0.3, beta3=0.3,
             gamma_Y=0.02,
-            GIc=None, GIIc=None, alpha_0=53.0,
+            GIc=0.80, GIIc=2.00, alpha_0=53.0,
             sigma_max=70.0, tau_max=90.0,
         ))
 
@@ -820,6 +825,11 @@ class MaterialLibrary:
         #    Table 2.2.  Representative cured-ply values at Vf ≈ 0.60.
         #    Note: longitudinal compressive strength of aramid prepregs
         #    is markedly lower than tensile because of fibre kinking.
+        #    Interlaminar fracture toughness: aramid/epoxy GIc ≈ 0.3–0.6
+        #    N/mm (moderate matrix-dominated Mode I, raised by fibre
+        #    bridging); GIc = 0.4, GIIc = 1.0 N/mm are representative values
+        #    in that range (Daniel & Ishai 2006), at the ~2.5× GIIc/GIc
+        #    ratio of the other presets.
         self.add(OrthotropicMaterial(
             name="KEVLAR49_EPOXY",
             E1=76_000.0, E2=5_500.0, E3=5_500.0,
@@ -832,7 +842,7 @@ class MaterialLibrary:
             alpha1=-4.0e-6, alpha2=79.0e-6, alpha3=79.0e-6,
             beta1=0.0, beta2=0.6, beta3=0.6,
             gamma_Y=0.02,
-            GIc=None, GIIc=None, alpha_0=53.0,
+            GIc=0.40, GIIc=1.00, alpha_0=53.0,
             sigma_max=40.0, tau_max=70.0,
         ))
 

--- a/tests/test_material_library_completeness.py
+++ b/tests/test_material_library_completeness.py
@@ -110,3 +110,38 @@ def test_issue_88_material_allowables(name):
         assert got == pytest.approx(want, rel=REL_TOL), (
             f"{name}.{attr}: got {got}, expected {want} (±{REL_TOL:.0%})"
         )
+
+
+# --------------------------------------------------------------------------- #
+# CZM (cohesive-zone) capability matrix (issue #268)
+# --------------------------------------------------------------------------- #
+
+
+def test_all_presets_are_czm_capable():
+    """Every built-in preset ships interlaminar toughness (GIc, GIIc) so
+    cohesive-zone delamination runs without user-supplied overrides
+    (issue #268). If a new preset is added without them, populate the
+    values or justify the None with a comment and update this test."""
+    lib = MaterialLibrary()
+    missing = [
+        name for name in lib.list_names()
+        if lib.get(name).GIc is None or lib.get(name).GIIc is None
+    ]
+    assert not missing, (
+        f"presets missing CZM toughness (GIc/GIIc): {sorted(missing)} — "
+        "populate them or document the None explicitly."
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "gic", "giic"),
+    [("S2_GLASS_EPOXY", 0.80, 2.00), ("KEVLAR49_EPOXY", 0.40, 1.00)],
+)
+def test_glass_and_aramid_toughness_pinned(name, gic, giic):
+    """Issue #268: the two previously-None presets now carry representative
+    interlaminar toughness in the published glass/aramid ranges."""
+    mat = MaterialLibrary().get(name)
+    assert mat.GIc == pytest.approx(gic)
+    assert mat.GIIc == pytest.approx(giic)
+    # Physically sane: positive, and Mode II tougher than Mode I.
+    assert mat.GIIc > mat.GIc > 0


### PR DESCRIPTION
## Summary

Fixes #268. `S2_GLASS_EPOXY` and `KEVLAR49_EPOXY` shipped `GIc=None`/`GIIc=None` while carrying the rest of the CZM block (`sigma_max`/`tau_max`), so cohesive-zone delamination was silently unavailable for **2 of the advertised presets** — picking them and toggling CZM raised *"Cohesive zone modelling requires GIc, GIIc, …"* with no path forward.

## The fix

Populate representative interlaminar fracture toughness in the published material-class ranges, citing the references already on each card, framed (like the existing card comments) as representative preset defaults:

| Preset | GIc (N/mm) | GIIc (N/mm) | Basis |
|---|---|---|---|
| `S2_GLASS_EPOXY` | 0.80 | 2.00 | glass/epoxy is markedly tougher than carbon/epoxy (published GIc ≈ 0.4–1.0); CMH-17 Vol 2 / Daniel & Ishai 2006 |
| `KEVLAR49_EPOXY` | 0.40 | 1.00 | aramid/epoxy GIc ≈ 0.3–0.6; Daniel & Ishai 2006 |

Both sit at the ~2.5× GIIc/GIc ratio of the existing carbon presets. They're representative starting values (users override `czm_*` for a specific material) — the same framing as the "representative cured-ply values" already in these cards.

## Acceptance criteria (all met)

- ✅ CZM runs for both presets without user-supplied overrides — **verified end-to-end**: a CZM analysis with `S2_GLASS_EPOXY` now completes instead of being rejected by the toughness guard.
- ✅ New values carry literature citations in the code comment, consistent with the existing preset style.
- ✅ Library test asserts the CZM-capability matrix explicitly: `test_all_presets_are_czm_capable` flags any future preset shipped without GIc/GIIc; the two fixed presets have their values pinned (and Mode II > Mode I > 0 checked). **All 12 built-in presets are now CZM-capable.**

## Quality

- `ruff check .` clean; whole-tree `mypy` (53 files) clean.
- 55 material tests pass. The change is additive material data + tests; existing behaviour is unchanged for presets that already had toughness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_