### PR TITLE
solver: add coordinate-aware max_*_location() to FieldResults (#297)

### DIFF
--- a/src/wrinklefe/solver/results.py
+++ b/src/wrinklefe/solver/results.py
@@ -388,6 +388,56 @@ class FieldResults:
         gp_idx = flat_idx % n_gp
         return float(comp_data[elem_idx, gp_idx]), elem_idx, gp_idx
 
+    def max_displacement_location(self) -> tuple[float, np.ndarray]:
+        """Maximum displacement magnitude and its physical location.
+
+        Coordinate-aware companion to :meth:`max_displacement`: resolves the
+        node index to its ``(x, y, z)`` coordinates via the mesh, so
+        reporting / visualisation need no manual index -> coordinate lookup.
+
+        Returns
+        -------
+        mag : float
+            Maximum displacement magnitude (mm).
+        location : np.ndarray
+            Shape ``(3,)`` node coordinates ``(x, y, z)`` (mm) where the
+            maximum occurs (undeformed reference coordinates).
+        """
+        mag, node_idx = self.max_displacement()
+        return mag, np.asarray(self.mesh.nodes[node_idx], dtype=float)
+
+    def max_stress_location(
+        self, component: int = 0, coord: str = 'local'
+    ) -> tuple[float, np.ndarray]:
+        """Maximum stress value and the physical location of its element.
+
+        Coordinate-aware companion to :meth:`max_stress`: resolves the
+        element index to its centroid ``(x, y, z)`` via the mesh.
+
+        Parameters
+        ----------
+        component : int, optional
+            Stress component in Voigt notation (0-5). Default is 0 (sigma_11).
+        coord : str, optional
+            ``'global'`` or ``'local'`` coordinate system. Default ``'local'``.
+
+        Returns
+        -------
+        value : float
+            Maximum stress value (MPa).
+        location : np.ndarray
+            Shape ``(3,)`` centroid coordinates ``(x, y, z)`` (mm) of the
+            element containing the maximum.
+        """
+        value, elem_idx, _gp_idx = self.max_stress(
+            component=component, coord=coord
+        )
+        if self.mesh.n_elements == 0:
+            return value, np.zeros(3, dtype=float)
+        return value, np.asarray(
+            self.mesh.element_center(elem_idx), dtype=float
+        )
+
     def reaction_forces(
         self,
         K_global: sparse.csc_matrix,

--- a/tests/test_solver/test_results_max_location.py
+++ b/tests/test_solver/test_results_max_location.py
@@ -1,0 +1,82 @@
+"""Coordinate-aware max-query methods on FieldResults (issue #297)."""
+
+import numpy as np
+
+from wrinklefe.core.mesh import MeshData
+from wrinklefe.solver.results import FieldResults
+
+
+def _two_element_mesh() -> MeshData:
+    """Two axis-aligned unit hexes side-by-side along x (12 nodes).
+
+    Element 0 spans x in [0, 1] (centroid (0.5, 0.5, 0.5)); element 1 spans
+    x in [1, 2] (centroid (1.5, 0.5, 0.5)).
+    """
+    nodes = np.array(
+        [
+            [0, 0, 0], [1, 0, 0], [2, 0, 0], [0, 1, 0], [1, 1, 0], [2, 1, 0],
+            [0, 0, 1], [1, 0, 1], [2, 0, 1], [0, 1, 1], [1, 1, 1], [2, 1, 1],
+        ],
+        dtype=float,
+    )
+    elements = np.array(
+        [[0, 1, 4, 3, 6, 7, 10, 9], [1, 2, 5, 4, 7, 8, 11, 10]], dtype=int
+    )
+    return MeshData(
+        nodes=nodes, elements=elements,
+        ply_ids=np.zeros(2, dtype=int), fiber_angles=np.zeros(12),
+        ply_angles=np.zeros(2), nx=2, ny=1, nz=1,
+    )
+
+
+def _field(mesh, displacement, stress_local):
+    n_elem, n_gp = stress_local.shape[:2]
+    z = np.zeros((n_elem, n_gp, 6))
+    return FieldResults(
+        displacement=displacement,
+        stress_global=z.copy(), stress_local=stress_local,
+        strain_global=z.copy(), strain_local=z.copy(),
+        mesh=mesh, laminate=None,
+    )
+
+
+def test_max_displacement_location_resolves_node_coords():
+    mesh = _two_element_mesh()
+    disp = np.zeros((12, 3))
+    disp[5] = [0.0, 0.0, 3.0]  # largest magnitude at node 5 = (2, 1, 0)
+    res = _field(mesh, disp, np.zeros((2, 8, 6)))
+
+    mag, loc = res.max_displacement_location()
+    assert mag == 3.0
+    np.testing.assert_allclose(loc, [2.0, 1.0, 0.0])
+    # Consistent with the index-returning method + the mesh lookup.
+    _, node_idx = res.max_displacement()
+    np.testing.assert_allclose(loc, mesh.nodes[node_idx])
+
+
+def test_max_stress_location_resolves_element_centroid():
+    mesh = _two_element_mesh()
+    stress = np.zeros((2, 8, 6))
+    stress[0, :, 0] = 10.0
+    stress[1, :, 0] = 50.0  # sigma_11 max in element 1
+    res = _field(mesh, np.zeros((12, 3)), stress)
+
+    value, loc = res.max_stress_location(component=0)
+    assert value == 50.0
+    np.testing.assert_allclose(loc, mesh.element_center(1))
+    np.testing.assert_allclose(loc, [1.5, 0.5, 0.5])
+
+
+def test_location_methods_do_not_change_index_methods():
+    """Additive (non-breaking): the index-returning methods are unchanged."""
+    mesh = _two_element_mesh()
+    disp = np.zeros((12, 3))
+    disp[5] = [0.0, 0.0, 3.0]
+    stress = np.zeros((2, 8, 6))
+    stress[1, :, 0] = 50.0
+    res = _field(mesh, disp, stress)
+
+    assert res.max_displacement() == (3.0, 5)
+    value, elem_idx, gp_idx = res.max_stress(component=0)
+    assert (value, elem_idx) == (50.0, 1)
+    assert 0 <= gp_idx < 8


### PR DESCRIPTION
## Summary

Fixes #297. `FieldResults.max_displacement()` and `max_stress()` return raw mesh indices, so every reporting/visualisation caller has to cross-reference the index back through the mesh (`mesh.nodes[idx]` / `mesh.element_center(idx)`) to get a plottable `(x, y, z)` — repetitive boilerplate and an easy place to confuse node vs. element indexing.

## The fix (issue's Option A — additive, non-breaking)

Two new coordinate-aware companions that delegate to the existing index-returning methods and resolve the index against the mesh:

- `max_displacement_location() -> (magnitude, xyz)` — node coordinates of the max displacement
- `max_stress_location(component=0, coord='local') -> (value, xyz)` — centroid of the element containing the max stress

The existing `max_displacement()` / `max_stress()` signatures are **untouched**, so current callers keep working.

## Acceptance criteria (all met)

- ✅ A user gets the physical location of the max displacement / max stress in **one call**, no manual index→coordinate lookup.
- ✅ Existing callers of `max_displacement` / `max_stress` continue to work (additive; verified by an explicit non-breaking test and the existing solver/failure suites).
- ✅ Returned coordinates unit-tested against a known field on a small two-element mesh (node coords for displacement, element centroid for stress).

## Quality

- `ruff check .` clean; whole-tree `mypy` (53 files) clean.
- New `tests/test_solver/test_results_max_location.py` (3 tests); 117 solver + failure tests pass. Purely additive — no behaviour change to existing methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_