### PR TITLE
viz: add plot_failure_mode_breakdown (#269, part 1)

### DIFF
--- a/src/wrinklefe/viz/plots_2d.py
+++ b/src/wrinklefe/viz/plots_2d.py
@@ -29,7 +29,7 @@ Budiansky, B. & Fleck, N.A. (1993). J. Mech. Phys. Solids, 41(1), 183-211.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -41,6 +41,7 @@ from wrinklefe.viz.style import (
     ACCENT_GRAY,
     FIGSIZE_DOUBLE_COLUMN,
     FIGSIZE_SINGLE_TALL,
+    MODE_COLORS,
     MORPHOLOGY_COLORS,
     MORPHOLOGY_LABELS,
     colorbar_setup,
@@ -1203,3 +1204,123 @@ def czm_overview_figure(results: AnalysisResults) -> Figure:
     fig.suptitle("Cohesive Zone Modeling — Overview", fontsize=12)
 
     return fig
+
+
+def failure_mode_family(mode: str) -> str:
+    """Map a failure-mode string to a colour family in :data:`MODE_COLORS`.
+
+    ``fiber_*`` / ``*kink*`` -> ``"fiber"``; ``matrix_*`` -> ``"matrix"``;
+    ``shear`` -> ``"shear"``; ``delam*`` -> ``"delamination"``; anything
+    else (including an empty / unspecified mode) -> ``"other"``.
+    """
+    m = (mode or "").lower()
+    if m.startswith("fiber") or "kink" in m:
+        return "fiber"
+    if m.startswith("matrix"):
+        return "matrix"
+    if m.startswith("shear"):
+        return "shear"
+    if m.startswith("delam"):
+        return "delamination"
+    return "other"
+
+
+def _governing_mode_shares(
+    results: Any, weight: str
+) -> tuple[dict[str, float], str, float]:
+    """Aggregate the governing failure mode over the FE field.
+
+    At every (element, Gauss-point) the governing criterion is the one with
+    the largest failure index; its mode string is the governing mode there.
+    Returns ``(shares, top_mode, max_fi)`` where ``shares`` maps each mode
+    string to its share (fractions summing to 1) under the requested weight
+    (``"count"`` = element/GP share, ``"fi"`` = failure-index-weighted).
+    """
+    fi = results.failure_indices
+    modes = results.failure_modes
+    if not fi or not modes:
+        raise ValueError(
+            "results carries no FE failure field (failure_indices / "
+            "failure_modes are empty) — run an FE analysis first."
+        )
+    crits = [c for c in fi if c in modes]
+    if not crits:
+        raise ValueError("No criterion has both a FI and a mode field.")
+    fi_stack = np.stack([np.asarray(fi[c], dtype=float) for c in crits])
+    mode_stack = np.stack([np.asarray(modes[c], dtype=object) for c in crits])
+    gov = np.argmax(fi_stack, axis=0)
+    ii, jj = np.indices(gov.shape)
+    gov_fi = fi_stack[gov, ii, jj].ravel()
+    gov_mode = mode_stack[gov, ii, jj].ravel().astype(str)
+    max_fi = float(gov_fi.max()) if gov_fi.size else 0.0
+
+    labels = np.where(gov_mode == "", "unspecified", gov_mode)
+    totals: dict[str, float] = {}
+    for m in np.unique(labels):
+        mask = labels == m
+        totals[str(m)] = (
+            float(np.count_nonzero(mask)) if weight == "count"
+            else float(gov_fi[mask].sum())
+        )
+    grand = sum(totals.values())
+    shares = (
+        {m: v / grand for m, v in totals.items()} if grand > 0
+        else dict.fromkeys(totals, 0.0)
+    )
+    top_mode = max(shares, key=lambda m: shares[m]) if shares else "unspecified"
+    return shares, top_mode, max_fi
+
+
+def plot_failure_mode_breakdown(
+    results: Any, *, weight: str = "count", ax: Axes | None = None
+) -> Axes:
+    """Bar chart of the governing failure-mode share over an FE run.
+
+    After "how big is the knockdown?" the next engineering question is
+    "which mechanism drives it — fibre kinking, matrix cracking, or shear?"
+    The answer changes the mitigation and the model conservatism. That mode
+    field is computed on every FE run (``AnalysisResults.failure_modes``)
+    but was not surfaced by the viz layer (issue #269).
+
+    Parameters
+    ----------
+    results : AnalysisResults
+        A finished FE analysis carrying ``failure_indices`` and
+        ``failure_modes``.
+    weight : {"count", "fi"}, optional
+        ``"count"`` (default) shows the element/Gauss-point share of each
+        governing mode; ``"fi"`` weights by failure index, emphasising
+        near-critical regions.
+    ax : Axes, optional
+        Target axes. A new figure is created when ``None``.
+
+    Returns
+    -------
+    Axes
+        The axes with the mode-breakdown bar chart.
+    """
+    if weight not in ("count", "fi"):
+        raise ValueError(f"weight must be 'count' or 'fi', got {weight!r}")
+    shares, top_mode, max_fi = _governing_mode_shares(results, weight)
+
+    set_publication_style()
+    ax = ensure_axes(ax, figsize=FIGSIZE_DOUBLE_COLUMN)
+
+    order = sorted(shares, key=lambda m: shares[m], reverse=True)
+    values = [100.0 * shares[m] for m in order]
+    colors = [MODE_COLORS[failure_mode_family(m)] for m in order]
+    ax.bar(
+        range(len(order)), values, color=colors, edgecolor="k", linewidth=0.5
+    )
+    ax.set_xticks(range(len(order)))
+    ax.set_xticklabels(order, rotation=30, ha="right", fontsize=8)
+    ax.set_ylabel(
+        "Element share (%)" if weight == "count" else "FI-weighted share (%)"
+    )
+    ax.set_title(
+        f"Governing failure mode — {top_mode} dominates "
+        f"({shares.get(top_mode, 0.0) * 100:.0f}%), max FI = {max_fi:.3g}"
+    )
+    ax.set_ylim(0, max(values) * 1.15 if values else 1.0)
+    ax.grid(axis="y", alpha=0.3)
+    return ax

--- a/src/wrinklefe/viz/style.py
+++ b/src/wrinklefe/viz/style.py
@@ -55,6 +55,19 @@ MORPHOLOGY_MARKERS: dict[str, str] = {
 }
 """Scatter plot markers for morphology types."""
 
+MODE_COLORS: dict[str, str] = {
+    "fiber": "#d62728",        # red   — fibre-dominated (kinking/tension/comp)
+    "matrix": "#1f77b4",       # blue  — matrix-dominated (all matrix_* modes)
+    "shear": "#ff7f0e",        # orange
+    "delamination": "#9467bd", # purple
+    "other": "#7f7f7f",        # gray fallback
+}
+"""Fixed colours per failure-mode *family*, so the legend of a
+failure-mode breakdown is stable across runs (issue #269). Individual
+mode strings (e.g. ``fiber_kinking``, ``matrix_transverse_compression``)
+map to a family via :func:`wrinklefe.viz.plots_2d.failure_mode_family`.
+"""
+
 MORPHOLOGY_LINESTYLES: dict[str, str] = {
     "stack": "-",       # solid
     "convex": "--",     # dashed

--- a/tests/test_viz/test_failure_mode_breakdown.py
+++ b/tests/test_viz/test_failure_mode_breakdown.py
@@ -1,0 +1,86 @@
+"""Failure-mode breakdown plot (issue #269)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from types import SimpleNamespace  # noqa: E402
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from matplotlib.axes import Axes  # noqa: E402
+
+from wrinklefe.viz.plots_2d import (  # noqa: E402
+    _governing_mode_shares,
+    failure_mode_family,
+    plot_failure_mode_breakdown,
+)
+
+
+def _synthetic_results():
+    """Four elements, two criteria; governing = per-element max-FI criterion.
+
+    elem0 larc05 0.9 (fiber_kinking), elem1 max_stress 0.7 (matrix_compression),
+    elem2 larc05 0.8 (fiber_kinking), elem3 max_stress 0.6 (matrix_tension).
+    """
+    fi = {
+        "larc05": np.array([[0.9], [0.2], [0.8], [0.1]]),
+        "max_stress": np.array([[0.3], [0.7], [0.5], [0.6]]),
+    }
+    modes = {
+        "larc05": np.array(
+            [["fiber_kinking"], ["matrix_tension"], ["fiber_kinking"], ["shear"]]
+        ),
+        "max_stress": np.array(
+            [["matrix_compression"], ["matrix_compression"], ["shear"],
+             ["matrix_tension"]]
+        ),
+    }
+    return SimpleNamespace(failure_indices=fi, failure_modes=modes)
+
+
+def test_family_mapping():
+    assert failure_mode_family("fiber_kinking") == "fiber"
+    assert failure_mode_family("kink_band") == "fiber"
+    assert failure_mode_family("matrix_transverse_compression") == "matrix"
+    assert failure_mode_family("shear") == "shear"
+    assert failure_mode_family("delamination") == "delamination"
+    assert failure_mode_family("") == "other"
+
+
+def test_governing_shares_count():
+    shares, top, max_fi = _governing_mode_shares(_synthetic_results(), "count")
+    assert top == "fiber_kinking"
+    assert max_fi == pytest.approx(0.9)
+    assert shares["fiber_kinking"] == pytest.approx(0.5)
+    assert shares["matrix_compression"] == pytest.approx(0.25)
+    assert shares["matrix_tension"] == pytest.approx(0.25)
+    assert sum(shares.values()) == pytest.approx(1.0)
+
+
+def test_governing_shares_fi_weighted():
+    shares, top, _ = _governing_mode_shares(_synthetic_results(), "fi")
+    assert top == "fiber_kinking"
+    assert shares["fiber_kinking"] == pytest.approx(1.7 / 3.0)
+    assert shares["matrix_compression"] == pytest.approx(0.7 / 3.0)
+    assert shares["matrix_tension"] == pytest.approx(0.6 / 3.0)
+
+
+@pytest.mark.parametrize("weight", ["count", "fi"])
+def test_plot_renders_one_bar_per_mode(weight):
+    ax = plot_failure_mode_breakdown(_synthetic_results(), weight=weight)
+    assert isinstance(ax, Axes)
+    assert len(ax.patches) == 3  # three distinct governing modes
+    plt.close(ax.figure)
+
+
+def test_invalid_weight_raises():
+    with pytest.raises(ValueError, match="weight"):
+        plot_failure_mode_breakdown(_synthetic_results(), weight="bogus")
+
+
+def test_empty_field_raises():
+    empty = SimpleNamespace(failure_indices=None, failure_modes=None)
+    with pytest.raises(ValueError, match="FE failure field"):
+        plot_failure_mode_breakdown(empty, weight="count")


### PR DESCRIPTION
## Summary

Addresses **#269** (part 1 — the core plot). The governing failure mode per element is computed on every FE run (`AnalysisResults.failure_modes`) but the viz layer never surfaced it, so a user could see the knockdown magnitude but not *which mechanism drives it* — fibre kinking vs. matrix cracking vs. shear, the first question after "how big is the knockdown?" (and the answer changes the mitigation and the model conservatism).

## What's here

`plot_failure_mode_breakdown(results, *, weight='count'|'fi', ax=None) -> Axes` in `viz/plots_2d.py`:
- Bar chart of the **governing-mode share** over the FE field. The governing criterion at each (element, Gauss point) is the max-FI one; its mode string is the governing mode there.
- `weight='count'` (default): element/GP share. `weight='fi'`: failure-index-weighted, emphasising near-critical regions.
- Bars coloured by mode **family** via a new stable `MODE_COLORS` palette (fiber / matrix / shear / delamination / other) alongside `MORPHOLOGY_COLORS`, so the legend is consistent across runs.
- Title annotates the dominant mode and max FI.

Self-contained and **additive** — no change to existing code paths.

## Acceptance criteria

- ✅ **#1** `plot_failure_mode_breakdown` renders from a standard FE run with both weightings; unit tests assert the count- and FI-weighted bar values against a known synthetic `mode_fields`/`fi_fields`.
- ⏳ #2 through-thickness mode variant, #3 Streamlit results-tab surfacing, #4 governing-mode share in the NCR/JSON summary — **deferred as follow-ups** on #269 (the issue explicitly allows the through-thickness variant as a follow-up; the Streamlit part isn't CI-verifiable, so it's better landed attended). This PR intentionally does **not** auto-close #269.

## Quality

- `ruff check .` clean; whole-tree `mypy` (53 files) clean.
- New `tests/test_viz/test_failure_mode_breakdown.py` (7 tests: family mapping, count/FI shares, bar rendering per weighting, invalid-weight and empty-field guards); full viz suite (26) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_