### PR TITLE
Fix dual-wrinkle mesh amplitude contract: half-amp per constituent (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,18 @@ version produced a given file.
 - GitHub issue forms, pull-request template, and this changelog.
 
 ### Fixed
+- Dual-wrinkle amplitude contract in the FE mesh (issue #305): the
+  `stack`/`convex`/`concave` morphologies build the mesh by summing two
+  through-thickness–decayed displacement fields, and each constituent
+  previously carried the full amplitude `A`, so the in-phase `stack` mesh
+  peaked at `2A` — double the intended geometry, meshed fibre angle and FE
+  knockdown, and inconsistent with the analytical
+  `theta_max = arctan(2*pi*A/lambda)`. Each constituent is now generated at
+  half amplitude `A/2` (`morphology._profile_at_half_amplitude`), so the
+  `stack` mesh composes to exactly `A` and its fibre angle matches the
+  analytical profile. Explicit multi-wrinkle `WrinkleSpec` configurations
+  are unaffected (each listed wrinkle keeps its specified amplitude). See
+  Numerical results.
 - Linear-buckling eigensolve correctness/robustness
   (`solver/buckling.py`): for a wrinkled (non-uniform) pre-stress the
   geometric "mass" matrix `M = -K_geo` is **indefinite**, which violated
@@ -196,6 +208,16 @@ version produced a given file.
   (`stack`/`convex`/`concave`) wherever through-thickness decay < 1 or
   wrinkles overlap; single-wrinkle results are unchanged. Analytical
   predictions are unaffected.
+- **Dual-wrinkle mesh amplitude (issue #305)**: the `stack`/`convex`/
+  `concave` FE meshes previously peaked at up to `2A` because each of the
+  two summed constituents carried the full amplitude `A`. Each constituent
+  is now half amplitude, so the in-phase `stack` mesh peaks at exactly `A`
+  and its meshed fibre angle drops to the analytical
+  `arctan(2*pi*A/lambda)` (roughly halved). FE-derived quantities (fibre
+  angles, FE knockdown, stiffness retention) shift for these three
+  morphologies; single-wrinkle (`uniform`/`graded`) and explicit
+  `WrinkleSpec` multi-wrinkle configurations are unchanged, and analytical
+  predictions (which already used the configured `A`) are unaffected.
 
 ## [1.0.0]
 

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -148,6 +148,20 @@ with $\alpha_\text{asym}=0.288$, $\alpha_\text{offset}=0$ in compression
 a geometric mean; single-wrinkle modes (`uniform`, `graded`) have
 $M_f=1$.
 
+**Amplitude contract in the FE mesh.** The morphology factor above scales
+the *analytical* angle. The FE mesh builds the same paired-wrinkle geometry
+by *summing* the two constituents' through-thickness–decayed displacement
+fields (`apply_to_nodes`). To keep the mesh consistent with the definition
+of $A$ as the peak deflection of the wrinkle (§1, peak-to-trough $=2A$),
+each of the two constituents of a `stack`/`convex`/`concave` morphology is
+generated at **half amplitude** $A/2$, so the in-phase (`stack`) sum peaks
+at exactly $A$ rather than $2A$. This makes the meshed fibre angle equal
+the analytical $\theta_{\max}=\arctan(2\pi A/\lambda)$ for the `stack`
+morphology, and the phase-offset morphologies (`convex`/`concave`) partly
+cancel below $A$. (Explicit multi-wrinkle configurations built through the
+`WrinkleSpec` API bypass this convention: each listed wrinkle carries the
+amplitude the caller specifies.) See issue #305.
+
 ### 2.4 Graded morphology averaging
 
 For the `graded` morphology the Budiansky–Fleck knockdown is averaged

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -31,6 +31,7 @@ References
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from typing import Literal
 
@@ -59,6 +60,28 @@ SINGLE_WRINKLE_MODES = {"uniform", "graded"}
 These values correspond to the morphology classifications in Jin et al. (2026)
 Table 3 and the analytical model in Elhajjar (2025) Eq. 8.
 """
+
+
+def _profile_at_half_amplitude(
+    profile: WrinkleProfile | WrinkleSurface3D,
+) -> WrinkleProfile | WrinkleSurface3D:
+    """Return a deep copy of *profile* carrying half its amplitude.
+
+    Used by :meth:`WrinkleConfiguration.dual_wrinkle` so that two in-phase
+    ``A/2`` wrinkles compose (sum) to the configured amplitude ``A`` in the
+    generated mesh rather than to ``2A`` (issue #305). The original
+    *profile* is left untouched.
+
+    For a :class:`~wrinklefe.core.wrinkle.WrinkleSurface3D` the amplitude
+    lives on the wrapped ``profile`` attribute; for a bare
+    :class:`~wrinklefe.core.wrinkle.WrinkleProfile` it lives directly on the
+    object. Either way the displacement field scales linearly with
+    ``amplitude``, so halving it halves each constituent's contribution.
+    """
+    scaled = copy.deepcopy(profile)
+    inner = scaled.profile if isinstance(scaled, WrinkleSurface3D) else scaled
+    inner.amplitude = inner.amplitude / 2.0
+    return scaled
 
 
 # ======================================================================
@@ -1054,13 +1077,23 @@ class WrinkleConfiguration:
             >>> config.aggregate_morphology_factor("compression")  # doctest: +ELLIPSIS
             0.749...
         """
+        # Amplitude contract (issue #305): the configured amplitude ``A`` is
+        # the peak deflection of the *composed* dual wrinkle, not of each
+        # constituent. ``apply_to_nodes`` sums the two decayed displacement
+        # fields, so two full-amplitude in-phase profiles would build a ``2A``
+        # mesh — doubling the geometry, the fibre angle, and the knockdown
+        # relative to the analytical model. Placing an ``A/2`` clone at each
+        # interface makes the in-phase (stack) sum equal exactly ``A`` and
+        # keeps the phase-offset (convex/concave) morphologies self-consistent
+        # with the amplitude the caller asked for.
+        half = _profile_at_half_amplitude(profile)
         w1 = WrinklePlacement(
-            profile=profile,
+            profile=half,
             ply_interface=interface1,
             phase_offset=0.0,
         )
         w2 = WrinklePlacement(
-            profile=profile,
+            profile=half,
             ply_interface=interface2,
             phase_offset=phase,
         )

--- a/tests/test_amplitude_contract_dual_wrinkle.py
+++ b/tests/test_amplitude_contract_dual_wrinkle.py
@@ -1,0 +1,135 @@
+"""Regression tests for the dual-wrinkle amplitude contract (issue #305).
+
+The configured amplitude ``A`` is defined (see ``analysis.py`` and
+``tests/test_amplitude_definition.py``) as the peak deflection of the
+generated wrinkle: for a single profile the mesh peak-to-trough is ``2A``
+and the peak deflection is ``A``.
+
+The dual-wrinkle morphologies (``stack``/``convex``/``concave``) build the
+mesh by *summing* two decayed displacement fields. Before #305 each
+constituent carried the full amplitude ``A``, so the in-phase ``stack``
+mesh peaked at ``2A`` — double the geometry, fibre angle and knockdown the
+caller (and the analytical model) intended. The fix places an ``A/2`` clone
+of the profile at each interface so the composed peak equals ``A``.
+
+These tests pin, directly on the FE node arrays (no solve — fast):
+
+* the composed peak deflection ``max|dz|`` for all five morphologies, and
+* that the ``stack`` mesh fibre angle equals the single-profile
+  ``profile.max_angle()`` (the analytical ``arctan(2*pi*A/lambda)``),
+  i.e. the mesh is self-consistent with the amplitude that was requested.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+_A = 0.15
+_LAMBDA = 4.0
+_WIDTH = 8.0
+_N_PLIES = 10
+_INTERFACE1 = 4
+_INTERFACE2 = 5
+
+
+def _profile() -> GaussianSinusoidal:
+    return GaussianSinusoidal(
+        amplitude=_A, wavelength=_LAMBDA, width=_WIDTH, center=0.0
+    )
+
+
+def _composed_peak_deflection(cfg: WrinkleConfiguration) -> float:
+    """Max |dz| over the whole laminate for a fine x-strip (no FE solve)."""
+    xs = np.linspace(-_WIDTH, _WIDTH, 801)
+    peak = 0.0
+    for p in range(_N_PLIES):
+        nodes = np.zeros((len(xs), 3))
+        nodes[:, 0] = xs
+        ply_ids = np.full(len(xs), p, dtype=int)
+        dz = cfg.apply_to_nodes(nodes, ply_ids, _N_PLIES)[:, 2]
+        peak = max(peak, float(np.max(np.abs(dz))))
+    return peak
+
+
+def _composed_max_angle(cfg: WrinkleConfiguration) -> float:
+    """Max |arctan(d(dz)/dx)| over the laminate (radians)."""
+    xs = np.linspace(-_WIDTH, _WIDTH, 4001)
+    max_angle = 0.0
+    for p in range(_N_PLIES):
+        nodes = np.zeros((len(xs), 3))
+        nodes[:, 0] = xs
+        ply_ids = np.full(len(xs), p, dtype=int)
+        dz = cfg.apply_to_nodes(nodes, ply_ids, _N_PLIES)[:, 2]
+        slope = np.gradient(dz, xs)
+        max_angle = max(max_angle, float(np.max(np.abs(np.arctan(slope)))))
+    return max_angle
+
+
+# Composed peak deflection as a multiple of the configured amplitude A.
+# stack (in-phase) sums to exactly A; convex/concave partly cancel;
+# uniform is a single full-amplitude wrinkle (peak == A); graded decays.
+EXPECTED_PEAK_OVER_A = {
+    "stack": 1.000,
+    "convex": 0.704,
+    "concave": 0.704,
+    "uniform": 1.000,
+    "graded": 0.889,
+}
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_PEAK_OVER_A))
+def test_composed_peak_deflection_honours_amplitude(name):
+    """Issue #305: no morphology builds a mesh taller than the configured
+    amplitude A; the in-phase stack composes to exactly A (not 2A)."""
+    cfg = WrinkleConfiguration.from_morphology_name(
+        name, _profile(), interface1=_INTERFACE1, interface2=_INTERFACE2
+    )
+    peak = _composed_peak_deflection(cfg)
+    assert peak / _A == pytest.approx(EXPECTED_PEAK_OVER_A[name], abs=2e-3), (
+        f"{name}: composed peak {peak:.5f} = {peak / _A:.3f}*A, "
+        f"expected {EXPECTED_PEAK_OVER_A[name]:.3f}*A"
+    )
+    # Hard ceiling: the mesh must never exceed the requested amplitude.
+    assert peak <= _A + 1e-9
+
+
+def test_stack_never_doubles_amplitude():
+    """The precise #305 defect: an in-phase dual wrinkle used to peak at 2A.
+    Pin the composed peak at exactly A so the regression cannot return."""
+    cfg = WrinkleConfiguration.from_morphology_name(
+        "stack", _profile(), interface1=_INTERFACE1, interface2=_INTERFACE2
+    )
+    npt.assert_allclose(_composed_peak_deflection(cfg), _A, atol=1e-6)
+
+
+def test_stack_mesh_angle_matches_analytical_profile():
+    """The stack mesh fibre angle equals the single-profile max_angle
+    (arctan(2*pi*A/lambda)), so the FE geometry is self-consistent with the
+    analytical knockdown model rather than twice its slope (issue #305)."""
+    prof = _profile()
+    cfg = WrinkleConfiguration.from_morphology_name(
+        "stack", prof, interface1=_INTERFACE1, interface2=_INTERFACE2
+    )
+    mesh_angle = _composed_max_angle(cfg)
+    # Fine finite-difference gradient: match to ~0.1 deg.
+    npt.assert_allclose(mesh_angle, prof.max_angle(), atol=2e-3)
+
+
+def test_dual_wrinkle_constituents_carry_half_amplitude():
+    """Each placed wrinkle in a dual morphology carries A/2; the original
+    profile passed by the caller is left untouched."""
+    prof = _profile()
+    cfg = WrinkleConfiguration.dual_wrinkle(
+        prof, interface1=_INTERFACE1, interface2=_INTERFACE2, phase=0.0
+    )
+    for placement in cfg.wrinkles:
+        placed = placement.profile
+        amp = getattr(placed, "profile", placed).amplitude
+        assert amp == pytest.approx(_A / 2.0)
+    # Caller's profile is not mutated.
+    assert prof.amplitude == pytest.approx(_A)

--- a/tests/test_analysis_czm.py
+++ b/tests/test_analysis_czm.py
@@ -35,6 +35,14 @@ def _czm_config(**overrides) -> AnalysisConfig:
     the wrinkle crest and (b) still converge through the
     NewtonRaphsonSolver — sit just past damage initiation but well
     below catastrophic interface failure.
+
+    The applied strain (0.025) was recalibrated for the corrected
+    dual-wrinkle amplitude contract (issue #305): the concave mesh now
+    composes to ~0.70*A rather than the previous ~1.37*A, so the older
+    0.015 strain no longer opened the crest interface past the cohesive
+    initiation threshold. 0.025 restores the intended "just past
+    initiation" state (max damage ~0.04, still convergent) for the
+    physically-correct geometry.
     """
     mat = MaterialLibrary().get("IM7_8552")
     defaults = dict(
@@ -49,7 +57,7 @@ def _czm_config(**overrides) -> AnalysisConfig:
         nx=12,
         ny=4,
         nz_per_ply=1,
-        applied_strain=0.015,
+        applied_strain=0.025,
         enable_czm=True,
         czm_n_load_increments=20,
         verbose=False,

--- a/tests/test_morphology_apply_nodes.py
+++ b/tests/test_morphology_apply_nodes.py
@@ -378,12 +378,22 @@ class TestFiberAnglesSlopeMagnitude:
 # ----------------------------------------------------------------------
 
 class TestFiberAnglesDualWrinkleComposed:
-    """Angles derive from the composed displacement field (#252):
-    two identical co-located wrinkles (phase=0) double the slope, so
-    the dual angle is ``arctan(2 * tan(single))``. With phase=pi the
-    displacement fields partly cancel."""
+    """Angles derive from the composed displacement field (#252).
 
-    def test_phase0_doubles_the_slope(self, gaussian_wrinkle):
+    Per the amplitude contract (#305), ``dual_wrinkle`` places an ``A/2``
+    clone of the profile at each interface so the in-phase composed mesh
+    sums to exactly the configured amplitude ``A`` rather than ``2A``.
+    Two identical co-located wrinkles (phase=0) therefore reproduce the
+    single full-amplitude slope, and the co-located dual angle equals the
+    single-wrinkle angle. With phase=pi the halved fields partly cancel.
+    """
+
+    def test_phase0_colocated_matches_single_full_amplitude(
+        self, gaussian_wrinkle
+    ):
+        """Issue #305: two co-located in-phase A/2 wrinkles compose to the
+        configured amplitude A, so the dual fibre angle equals the single
+        full-amplitude wrinkle's angle (not twice its slope)."""
         single = _single_config(gaussian_wrinkle, ply_interface=2)
         dual = WrinkleConfiguration.dual_wrinkle(
             gaussian_wrinkle, interface1=2, interface2=2, phase=0.0
@@ -391,15 +401,14 @@ class TestFiberAnglesDualWrinkleComposed:
         nodes, ply = _strip(np.array([2.0]), n_plies=6)
         a_single = single.fiber_angles_at_nodes(nodes, ply)[ply == 2][0]
         a_dual = dual.fiber_angles_at_nodes(nodes, ply)[ply == 2][0]
-        npt.assert_allclose(
-            a_dual, np.arctan(2.0 * np.tan(a_single)), rtol=1e-12
-        )
+        npt.assert_allclose(a_dual, a_single, rtol=1e-12)
 
     def test_phase_pi_partially_cancels_displacement(self, gaussian_wrinkle):
         """Anti-stack (phase=pi) shifts the 2nd wrinkle by lambda/2, so the
-        co-located dual displacement is the sum of profile(x) and
-        profile(x - lambda/2); at the crest these are opposite-sign and
-        the net is strictly smaller than twice the single-wrinkle crest."""
+        co-located dual displacement is the sum of the two A/2 clones,
+        profile_half(x) + profile_half(x - lambda/2); at the crest these are
+        opposite-sign and the net is strictly smaller than the single
+        full-amplitude crest."""
         single = _single_config(gaussian_wrinkle, ply_interface=2)
         dual = WrinkleConfiguration.dual_wrinkle(
             gaussian_wrinkle, interface1=2, interface2=2, phase=np.pi
@@ -409,11 +418,13 @@ class TestFiberAnglesDualWrinkleComposed:
         dz_dual = (dual.apply_to_nodes(nodes, ply, 6) - nodes)[:, 2]
         s = dz_single[ply == 2][0]
         d = dz_dual[ply == 2][0]
-        # Net dual displacement strictly below 2*single (partial cancel).
-        assert abs(d) < abs(2.0 * s)
-        # Closed-form: profile(0) + profile(0 - lambda/2).
+        # Net dual displacement strictly below the single full crest
+        # (partial cancellation of the two halved, phase-shifted fields).
+        assert abs(d) < abs(s)
+        # Closed-form: each clone carries A/2, so the composed crest is
+        # 0.5 * (profile(0) + profile(0 - lambda/2)).
         lam = gaussian_wrinkle.wavelength
-        expected = (
+        expected = 0.5 * (
             gaussian_wrinkle.displacement(np.array([0.0]))[0]
             + gaussian_wrinkle.displacement(np.array([-lam / 2.0]))[0]
         )

--- a/tests/test_viz_czm.py
+++ b/tests/test_viz_czm.py
@@ -215,6 +215,12 @@ def test_czm_overview_figure_from_real_run():
     Newton-Raphson loop completes in a few seconds; we still get a
     nonzero damage field from the concave-tension geometry, which is all
     the overview figure needs to render every panel non-trivially.
+
+    The applied strain (0.025) matches the recalibration in
+    ``tests/test_analysis_czm.py`` for the corrected dual-wrinkle
+    amplitude contract (issue #305): the concave mesh now composes to
+    ~0.70*A, so the previous 0.015 no longer opened the crest past the
+    cohesive initiation threshold.
     """
     mat = MaterialLibrary().get("IM7_8552")
     cfg = AnalysisConfig(
@@ -224,7 +230,7 @@ def test_czm_overview_figure_from_real_run():
         angles=list(_LAYUP_0_90_4S),
         ply_thickness=0.183,
         nx=6, ny=3, nz_per_ply=1,
-        applied_strain=0.015,
+        applied_strain=0.025,
         enable_czm=True,
         czm_n_load_increments=8,
         verbose=False,


### PR DESCRIPTION
## Linked issue

Fixes #305

## Summary

The `stack`/`convex`/`concave` morphologies build the FE mesh by **summing** two through-thickness–decayed displacement fields (`WrinkleConfiguration.apply_to_nodes`). Each of the two constituents previously carried the full configured amplitude `A`, so the in-phase `stack` mesh peaked at **`2A`** — double the intended geometry, meshed fibre angle, and FE knockdown, and inconsistent with the analytical `theta_max = arctan(2*pi*A/lambda)`.

`dual_wrinkle` now places a **half-amplitude** clone of the profile at each interface (new `morphology._profile_at_half_amplitude` helper), so the in-phase `stack` mesh composes to exactly `A` and its fibre angle matches the analytical profile; `convex`/`concave` partly cancel below `A`. The original profile passed by the caller is left untouched.

**Scope of the behavior change (numeric outputs):**
- FE-derived quantities (fibre angles, FE knockdown, stiffness retention) shift for `stack`/`convex`/`concave`.
- **Unchanged:** single-wrinkle (`uniform`/`graded`), explicit multi-wrinkle `WrinkleSpec` configurations (each listed wrinkle keeps its specified amplitude), and all analytical predictions (they already used the configured `A`, not the mesh).

Verified by direct mesh measurement (no solve):

| morphology | composed peak (before → after) | stack mesh fibre angle |
|---|---|---|
| stack | 2.00·A → **1.00·A** | 13.07° → **13.07° = `profile.max_angle()`** |
| convex / concave | ~1.37·A → **0.70·A** | — |
| uniform / graded | unchanged | — |

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (unit + the 70 stack-using FE integration solves: `426s`, all pass)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean
- [x] Docs/README updated if user-facing (`docs/theory.md` §2.3)
- [x] `CHANGELOG.md` `[Unreleased]` updated (Fixed + **Numerical results**)
- [ ] `python scripts/validate.py` — validation drivers do not exercise the `stack` FE mesh; analytical-path validation is unaffected

### Tests
- `tests/test_amplitude_contract_dual_wrinkle.py` (new): pins composed peak deflection for all five morphologies, the hard `peak <= A` ceiling, `stack` mesh angle `==` analytical `profile.max_angle()`, and that each dual constituent carries `A/2` while the caller's profile is not mutated.
- `tests/test_morphology_apply_nodes.py`: the two dual-wrinkle composed tests previously pinned the old `2A` behavior; updated to the honored contract (co-located in-phase dual now reproduces the single full-amplitude slope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_