### PR TITLE
Support CZM delamination in multi-wrinkle FE (#283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Cohesive-zone delamination in multi-wrinkle FE (issue #283):
+  `enable_czm=True` now runs with an `AnalysisConfig.wrinkles` list
+  instead of raising `NotImplementedError`. Cohesive layers are inserted
+  along the **full length** of every nominated interface, and
+  `czm_interfaces="near_crest"` nominates the interface nearest *each*
+  wrinkle (deduplicated) — wrinkles sharing an interface index get one
+  continuous cohesive surface, so a delamination initiating at one crest
+  can propagate toward its neighbour (crest-to-crest link-up, the Li 2025
+  multi-wrinkle failure pattern; see
+  `examples/08_multi_wrinkle_czm_linkup.py`). Regression anchors: a
+  one-entry `wrinkles` list reproduces the scalar-config CZM solution
+  bit-tight; far-separated wrinkles match independent single-wrinkle
+  solves within a few percent with an intact interface between them;
+  scalar (named-morphology) CZM interface resolution is unchanged.
 - Analytical stiffness (axial-modulus) knockdown on the analytical path:
   `AnalysisResults.analytical_modulus_knockdown`, a closed-form CLT
   series-average of the off-axis lamina modulus over the wrinkle profile

--- a/examples/04_czm_delamination.py
+++ b/examples/04_czm_delamination.py
@@ -24,7 +24,10 @@ config = AnalysisConfig(
     morphology="concave", loading="tension",
     material=mat, angles=layup, ply_thickness=0.183,
     nx=12, ny=4, nz_per_ply=1,          # coarse mesh keeps this fast
-    applied_strain=0.015,
+    # 2.5% strain sits just past cohesive damage initiation for the
+    # corrected dual-wrinkle amplitude contract (issue #305); the older
+    # 0.015 no longer opens the crest interface past the threshold.
+    applied_strain=0.025,
     enable_czm=True,
     czm_n_load_increments=20,
 )

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ so they cannot rot.
 | [`05_export_roundtrip.py`](05_export_roundtrip.py) | JSON / Abaqus `.inp` / VTK export; open the `.vtk` in ParaView | ~10 s |
 | [`06_custom_material.py`](06_custom_material.py) | Defining an `OrthotropicMaterial` not in the preset library | ~1 s |
 | [`07_mesh_convergence.py`](07_mesh_convergence.py) | Mesh-convergence study (`mesh_convergence_study` / `wrinklefe converge`) | ~90 s |
+| [`08_multi_wrinkle_czm_linkup.py`](08_multi_wrinkle_czm_linkup.py) | Crest-to-crest delamination link-up between adjacent wrinkles (`wrinkles` + `enable_czm`) | ~60 s |
 
 Run any of them from this directory with the package installed
 (`pip install -e ..`):

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -605,25 +605,6 @@ def _laminate_modulus_knockdown(
     return float(e_eff / E_x0)
 
 
-def _check_multi_wrinkle_fe_support(cfg: AnalysisConfig) -> None:
-    """Reject multi-wrinkle FE configs the pipeline cannot represent yet.
-
-    Issue #252: arbitrary N-wrinkle layouts — including longitudinally
-    overlapping and interacting wrinkles — run through the FE path; the
-    displacement and fiber-angle fields both derive from the composed
-    wrinkle field ("compose then differentiate"). Only the CZM pathway
-    remains analytical-only, because cohesive interface placement
-    assumes a single wrinkle crest.
-    """
-    if cfg.enable_czm:
-        raise NotImplementedError(
-            "Multi-wrinkle FE with cohesive zones (enable_czm=True) is "
-            "not yet supported: cohesive interface placement assumes a "
-            "single wrinkle crest. Run with enable_czm=False or pass "
-            "analytical_only=True."
-        )
-
-
 def _max_consecutive_zero_plies(angles: list[float], tol: float = 5.0) -> int:
     """Find maximum number of consecutive 0-degree plies in a layup.
 
@@ -1104,8 +1085,13 @@ class AnalysisConfig:
     enable_czm: bool = False
     # Which ply interfaces to insert cohesive elements at:
     #   * ``"all"`` — every interior ply interface,
-    #   * ``"near_crest"`` — the single interface whose z-coordinate
-    #     is closest to the wrinkle peak amplitude,
+    #   * ``"near_crest"`` — for a scalar (named-morphology) config, the
+    #     single interface whose z-coordinate is closest to the wrinkle
+    #     peak; for a multi-wrinkle config (``wrinkles`` set), the
+    #     interface nearest *each* wrinkle, deduplicated — wrinkles
+    #     sharing an interface index get one continuous cohesive
+    #     surface, enabling crest-to-crest delamination link-up
+    #     (issue #283),
     #   * ``list[int]`` — explicit list of interface indices in
     #     ``[0, n_plies-1)`` (0 = bottom-most interior interface).
     czm_interfaces: list[int] | str = "near_crest"
@@ -1941,12 +1927,11 @@ class WrinkleAnalysis:
             analytical_only = cfg.analytical_only
 
         # Multi-wrinkle FE solve (issue #252): overlapping and
-        # non-overlapping layouts both run; only the CZM pathway is
-        # rejected (early, with a precise message) rather than failing
-        # mid-pipeline.
-        if cfg.wrinkles is not None and not analytical_only:
-            _check_multi_wrinkle_fe_support(cfg)
-
+        # non-overlapping layouts run through the linear FE path, and
+        # (issue #283) through the CZM path — cohesive layers are
+        # inserted along the full length of every interface a wrinkle
+        # nominates, so delaminations can link up between adjacent
+        # wrinkles sharing an interface.
         results = AnalysisResults(config=cfg)
 
         # Phase weights (sum to 1.0 on the full FE path).  The FE solve
@@ -2274,8 +2259,11 @@ class WrinkleAnalysis:
         laminate : Laminate
             The fully built laminate; supplies the ply z-coordinates.
         wrinkle_config : WrinkleConfiguration
-            Used to locate the wrinkle peak when
-            ``cfg.czm_interfaces == "near_crest"``.
+            Used to locate the wrinkle peaks when
+            ``cfg.czm_interfaces == "near_crest"``: scalar configs pick
+            the single interface nearest the (largest-amplitude)
+            wrinkle; multi-wrinkle configs pick the interface nearest
+            *each* wrinkle, deduplicated (issue #283).
 
         Returns
         -------
@@ -2308,28 +2296,38 @@ class WrinkleAnalysis:
             # (most-likely-to-delaminate driver) and pick the boundary
             # closest to that wrinkle's centre.
             wrinkles = list(getattr(wrinkle_config, "wrinkles", ()))
-            if not wrinkles:
-                # No wrinkle placements (flat mesh) — default to the
-                # midplane interface.
-                target_z = 0.0
-            else:
-                # Find the wrinkle with the largest amplitude; use its
-                # reference centre z as the target.
-                w_best = max(
-                    wrinkles,
-                    key=lambda w: abs(getattr(w.profile, "amplitude", 0.0)),
-                )
+
+            def _nearest_boundary(placement) -> int:
                 # The wrinkle's z reference is the ply boundary above ply
                 # ``ply_interface``; ``ply_interface`` is in the [0,
                 # n_plies-2] range and references the boundary at
                 # ply_z[ply_interface + 1].
-                k = int(w_best.ply_interface)
+                k = int(placement.ply_interface)
                 if 1 <= k + 1 <= n_plies - 1:
                     target_z = float(ply_z[k + 1])
                 else:
                     target_z = 0.0
-            best_i = int(np.argmin(np.abs(boundary_z - target_z)))
-            return [best_i]
+                return int(np.argmin(np.abs(boundary_z - target_z)))
+
+            if not wrinkles:
+                # No wrinkle placements (flat mesh) — default to the
+                # interior boundary nearest the midplane.
+                return [int(np.argmin(np.abs(boundary_z)))]
+            if cfg.wrinkles is not None:
+                # Multi-wrinkle configuration (issue #283): nominate the
+                # interface nearest *each* wrinkle so a delamination can
+                # initiate at any crest and, where wrinkles share an
+                # interface index, run along one continuous cohesive
+                # surface between them (crest-to-crest link-up).
+                return sorted({_nearest_boundary(w) for w in wrinkles})
+            # Scalar (named-morphology) configuration: keep the legacy
+            # single-interface choice — the wrinkle with the largest
+            # amplitude is the most-likely-to-delaminate driver.
+            w_best = max(
+                wrinkles,
+                key=lambda w: abs(getattr(w.profile, "amplitude", 0.0)),
+            )
+            return [_nearest_boundary(w_best)]
         # Validation in ``__post_init__`` already constrains the values
         # this method sees; the catch-all keeps mypy happy.
         raise ValueError(

--- a/tests/test_analysis_czm.py
+++ b/tests/test_analysis_czm.py
@@ -293,6 +293,57 @@ class TestCzmInterfaceResolution:
         )
         assert ifaces == [2, 5, 9]
 
+    @staticmethod
+    def _multi_wrinkle_resolution(interfaces: list[int]) -> list[int]:
+        """Resolve ``near_crest`` for a multi-wrinkle config placing one
+        wrinkle at each of the given ply interfaces (no FE solve)."""
+        import dataclasses
+
+        from wrinklefe.analysis import WrinkleSpec
+        from wrinklefe.core.morphology import (
+            WrinkleConfiguration,
+            WrinklePlacement,
+        )
+        from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+        base = _czm_config(czm_interfaces="near_crest")
+        specs = [
+            WrinkleSpec(
+                amplitude=0.2, wavelength=8.0, width=2.0, ply_interface=k,
+            )
+            for k in interfaces
+        ]
+        cfg = dataclasses.replace(base, wrinkles=specs)
+        analysis = WrinkleAnalysis(cfg)
+        laminate = analysis._build_laminate()
+        placements = [
+            WrinklePlacement(
+                profile=GaussianSinusoidal(
+                    amplitude=s.amplitude, wavelength=s.wavelength,
+                    width=s.width, center=cfg.domain_length / 2.0,
+                ),
+                ply_interface=s.ply_interface,
+                phase_offset=s.phase_offset,
+            )
+            for s in specs
+        ]
+        wrinkle_config = WrinkleConfiguration(placements)
+        return analysis._resolve_cohesive_interfaces(
+            laminate, wrinkle_config,
+        )
+
+    def test_czm_interfaces_near_crest_multi_wrinkle_one_per_wrinkle(self):
+        """Issue #283: with a multi-wrinkle config, ``near_crest``
+        nominates the interface nearest *each* wrinkle rather than only
+        the largest-amplitude one."""
+        assert self._multi_wrinkle_resolution([2, 5]) == [2, 5]
+        assert self._multi_wrinkle_resolution([2, 5, 9]) == [2, 5, 9]
+
+    def test_czm_interfaces_near_crest_multi_wrinkle_shared_dedup(self):
+        """Wrinkles nominating the same interface resolve to one
+        continuous cohesive surface (deduplicated index)."""
+        assert self._multi_wrinkle_resolution([4, 4]) == [4]
+
 
 # ----------------------------------------------------------------------
 # 3. MaterialLibrary CZM defaults coverage

--- a/tests/test_integration/test_multi_wrinkle.py
+++ b/tests/test_integration/test_multi_wrinkle.py
@@ -163,26 +163,10 @@ class TestMultiWrinkleValidation:
         with pytest.raises(ValueError, match="ply_interface"):
             _build_cfg(ac318_material, ud14_angles, bad)
 
-    def test_fe_solve_rejects_multi_wrinkle_czm(
-        self, ac318_material, ud14_angles
-    ):
-        """Multi-wrinkle + CZM raises a precise NotImplementedError
-        (cohesive interface placement assumes a single crest); the FE
-        path itself supports arbitrary N-wrinkle layouts since #252 —
-        see tests/test_integration/test_multi_wrinkle_fe.py."""
-        wrinkles = [
-            WrinkleSpec(amplitude=1.5, wavelength=12.9, width=12.9,
-                        ply_interface=4),
-            WrinkleSpec(amplitude=1.5, wavelength=12.9, width=12.9,
-                        ply_interface=6, phase_offset=0.5),
-        ]
-        cfg = _build_cfg(
-            ac318_material, ud14_angles, wrinkles, analytical_only=False,
-            enable_czm=True,
-        )
-        analysis = WrinkleAnalysis(cfg)
-        with pytest.raises(NotImplementedError, match="cohesive"):
-            analysis.run(analytical_only=False)
+    # Multi-wrinkle + CZM is supported since issue #283 (cohesive
+    # layers along the full length of every wrinkle-nominated
+    # interface); the end-to-end coverage lives in
+    # tests/test_integration/test_multi_wrinkle_czm.py.
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_integration/test_multi_wrinkle_czm.py
+++ b/tests/test_integration/test_multi_wrinkle_czm.py
@@ -1,0 +1,231 @@
+"""CZM delamination in multi-wrinkle FE configurations (issue #283).
+
+Until #283 the combination of the two headline capabilities —
+multi-wrinkle FE (issue #252) and cohesive-zone delamination — was
+guarded off with ``NotImplementedError``. The guard encoded an
+implementation assumption, not physics: cohesive interface placement
+derived from "the single wrinkle crest". Placement is now resolved
+per configuration: ``czm_interfaces="near_crest"`` nominates the
+interface nearest *each* wrinkle (deduplicated), and every nominated
+interface receives a cohesive layer along its **full length** — so a
+delamination initiating at one crest can propagate along the shared
+interface toward a neighbouring wrinkle (crest-to-crest link-up, the
+recognised multi-wrinkle failure pattern in the Li 2025 specimen
+family).
+
+Regression anchors (from the issue):
+
+* single-entry ``wrinkles`` CZM ≡ scalar-config CZM (bit-tight);
+* two far-separated wrinkles ≈ two independent single-wrinkle solves
+  (interaction → 0 with distance);
+* two close wrinkles on a shared interface develop bridging damage in
+  the region *between* the crests (qualitative link-up signal), which
+  the far-separated pair does not.
+
+The CZM Newton solves here use deliberately small meshes (8 plies,
+ny=2, nz_per_ply=1, 8 increments) so each solve stays in the
+tens-of-seconds range.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis, WrinkleSpec
+
+_ANGLES_8 = [0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0]
+
+# Shared geometry: A=0.3, lambda=8, w=2 at ply interface 3 under 3%
+# tension initiates cohesive damage (max d ~ 0.15) and converges
+# through the Newton solve on this mesh.
+_SPEC = dict(amplitude=0.3, wavelength=8.0, width=2.0, ply_interface=3)
+_COMMON = dict(
+    amplitude=0.3, wavelength=8.0, width=2.0,
+    morphology="graded", loading="tension",
+    angles=list(_ANGLES_8),
+    nx=32, ny=2, nz_per_ply=1,
+    domain_length=28.0,
+    applied_strain=0.03,
+    enable_czm=True, czm_n_load_increments=8, verbose=False,
+)
+
+# phase = 2*pi*dx/lambda -> +/-2*pi shifts a crest by +/-lambda = 8 mm.
+_FAR_PAIR = [
+    WrinkleSpec(**_SPEC, phase_offset=-2.0 * np.pi),
+    WrinkleSpec(**_SPEC, phase_offset=+2.0 * np.pi),
+]
+
+
+def _crest_damage(result, x_center: float, half_window: float = 4.0) -> float:
+    """Max cohesive damage among interface elements near ``x_center``."""
+    x = result.czm_element_centroids[:, 0]
+    d = result.czm_damage.max(axis=1)
+    mask = np.abs(x - x_center) < half_window
+    assert mask.any()
+    return float(d[mask].max())
+
+
+class TestMultiWrinkleCzmEndToEnd:
+
+    def test_two_wrinkles_czm_runs_and_links_one_interface(self):
+        """Two non-overlapping wrinkles sharing an interface run
+        end-to-end with ``enable_czm=True``; both nominate the same
+        interface, which resolves to one continuous cohesive surface."""
+        cfg = AnalysisConfig(**_COMMON, wrinkles=list(_FAR_PAIR))
+        r = WrinkleAnalysis(cfg).run()
+
+        assert r.czm_converged is True
+        assert r.czm_interfaces_used == [3]
+        assert r.czm_damage is not None and r.czm_damage.size > 0
+        # The damage-prone geometry initiates at both crests.
+        assert float(np.max(r.czm_damage)) > 0.05
+        # CZM mesh carries the duplicated interface nodes.
+        assert r.mesh is not None
+        assert r.field_results is not None
+
+    def test_two_interfaces_attributed_separately(self):
+        """Wrinkles at different ply interfaces nominate one cohesive
+        surface each; per-interface reporting attributes results to the
+        correct interface index."""
+        cfg = AnalysisConfig(
+            **{**_COMMON, "applied_strain": 0.01,
+               "czm_n_load_increments": 4},
+            wrinkles=[
+                WrinkleSpec(amplitude=0.3, wavelength=8.0, width=2.0,
+                            ply_interface=2, phase_offset=-2.0 * np.pi),
+                WrinkleSpec(amplitude=0.3, wavelength=8.0, width=2.0,
+                            ply_interface=5, phase_offset=+2.0 * np.pi),
+            ],
+        )
+        r = WrinkleAnalysis(cfg).run()
+
+        assert r.czm_interfaces_used == [2, 5]
+        assert sorted(r.czm_energy_per_interface) == [2, 5]
+        assert sorted(r.czm_crack_length_per_interface) == [2, 5]
+        report = r.czm_delamination_report
+        assert report is not None
+
+
+class TestSingleEntryEquivalence:
+
+    def test_single_spec_czm_matches_scalar_graded_czm(self):
+        """A one-entry ``wrinkles`` list produces the same CZM solution
+        as the scalar graded config it denotes — same interface
+        resolution, same mesh, same damage/energy/load-displacement
+        (the multi-wrinkle CZM analogue of PR #276's linear-path
+        equivalence)."""
+        scalar_cfg = AnalysisConfig(**_COMMON, interface_1=3)
+        multi_cfg = AnalysisConfig(
+            **_COMMON,
+            wrinkles=[WrinkleSpec(**_SPEC, phase_offset=0.0)],
+        )
+        r_scalar = WrinkleAnalysis(scalar_cfg).run()
+        r_multi = WrinkleAnalysis(multi_cfg).run()
+
+        assert r_scalar.czm_converged and r_multi.czm_converged
+        assert r_multi.czm_interfaces_used == r_scalar.czm_interfaces_used
+        # The equivalence is meaningful only if damage actually
+        # initiated (otherwise everything is trivially zero).
+        assert float(np.max(r_scalar.czm_damage)) > 0.05
+
+        np.testing.assert_allclose(
+            r_multi.mesh.nodes, r_scalar.mesh.nodes, rtol=0, atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            r_multi.czm_damage, r_scalar.czm_damage,
+            rtol=1e-9, atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            r_multi.czm_load_displacement, r_scalar.czm_load_displacement,
+            rtol=1e-9,
+        )
+        assert r_multi.czm_energy_dissipated == pytest.approx(
+            r_scalar.czm_energy_dissipated, rel=1e-9,
+        )
+
+
+class TestFarSeparationIndependence:
+
+    def test_far_separated_pair_matches_solo_runs(self):
+        """Two far-separated wrinkles behave like two independent
+        single-wrinkle solves: each crest's damage matches the solo run
+        with the *same* off-centre placement (isolating interaction
+        from boundary-proximity effects), and no damage develops in the
+        gap between them."""
+        L = _COMMON["domain_length"]
+        pair_cfg = AnalysisConfig(**_COMMON, wrinkles=list(_FAR_PAIR))
+        solo_left = AnalysisConfig(
+            **_COMMON,
+            wrinkles=[WrinkleSpec(**_SPEC, phase_offset=-2.0 * np.pi)],
+        )
+        solo_right = AnalysisConfig(
+            **_COMMON,
+            wrinkles=[WrinkleSpec(**_SPEC, phase_offset=+2.0 * np.pi)],
+        )
+        r_pair = WrinkleAnalysis(pair_cfg).run()
+        r_left = WrinkleAnalysis(solo_left).run()
+        r_right = WrinkleAnalysis(solo_right).run()
+        assert r_pair.czm_converged
+        assert r_left.czm_converged and r_right.czm_converged
+
+        d_pair_left = _crest_damage(r_pair, L / 2.0 - 8.0)
+        d_pair_right = _crest_damage(r_pair, L / 2.0 + 8.0)
+        d_solo_left = _crest_damage(r_left, L / 2.0 - 8.0)
+        d_solo_right = _crest_damage(r_right, L / 2.0 + 8.0)
+
+        # Damage genuinely initiated at every crest.
+        assert min(d_solo_left, d_solo_right) > 0.05
+        # Interaction -> 0 with distance: measured deviation is ~2%
+        # (left) / <1% (right) on this mesh; 10% leaves platform slack.
+        assert d_pair_left == pytest.approx(d_solo_left, rel=0.10)
+        assert d_pair_right == pytest.approx(d_solo_right, rel=0.10)
+
+        # No damage bridges the 16 mm gap between the far crests.
+        x = r_pair.czm_element_centroids[:, 0]
+        d = r_pair.czm_damage.max(axis=1)
+        mid_gap = np.abs(x - L / 2.0) < 1.5
+        assert mid_gap.any()
+        assert float(d[mid_gap].max()) == pytest.approx(0.0, abs=1e-12)
+
+
+class TestCrestToCrestLinkUp:
+
+    def test_close_wrinkles_bridge_damage_between_crests(self):
+        """Two close wrinkles (crests 6 mm apart, overlapping supports)
+        on a shared interface develop cohesive damage in the region
+        *between* the crests — the crest-to-crest link-up mechanism —
+        at a level comparable to the crest damage itself. The
+        far-separated pair (previous test) shows exactly zero damage in
+        its gap, so the bridging here is the wrinkle-interaction
+        signal, not a far-field artefact."""
+        L = _COMMON["domain_length"]
+        # phase = 2*pi*dx/lambda; dx = +/-3 mm -> +/-0.75*pi.
+        cfg = AnalysisConfig(
+            **_COMMON,
+            wrinkles=[
+                WrinkleSpec(**_SPEC, phase_offset=-0.75 * np.pi),
+                WrinkleSpec(**_SPEC, phase_offset=+0.75 * np.pi),
+            ],
+        )
+        r = WrinkleAnalysis(cfg).run()
+        assert r.czm_converged
+        assert r.czm_interfaces_used == [3]
+
+        x = r.czm_element_centroids[:, 0]
+        d = r.czm_damage.max(axis=1)
+
+        bridge = np.abs(x - L / 2.0) < 1.5
+        far_field = np.abs(x - L / 2.0) > 10.0
+        assert bridge.any() and far_field.any()
+
+        d_bridge = float(d[bridge].max())
+        d_crests = max(
+            _crest_damage(r, L / 2.0 - 3.0, half_window=2.0),
+            _crest_damage(r, L / 2.0 + 3.0, half_window=2.0),
+        )
+        # Bridging damage is present (measured ~0.11 vs crest ~0.13)...
+        assert d_bridge > 0.5 * d_crests
+        assert d_bridge > 0.05
+        # ...while the far field stays undamaged.
+        assert float(d[far_field].max()) == pytest.approx(0.0, abs=1e-12)

--- a/tests/test_integration/test_multi_wrinkle_fe.py
+++ b/tests/test_integration/test_multi_wrinkle_fe.py
@@ -4,8 +4,9 @@ Stage 1: N wrinkles with disjoint longitudinal supports (the Li 2025
 specimen layout). Stage 2: overlapping/interacting wrinkles — both the
 displacement and the fiber-angle field derive from the composed wrinkle
 field ("compose then differentiate"), so two coincident half-amplitude
-wrinkles reproduce the single full-amplitude result exactly. Only the
-CZM pathway remains rejected, with a precise message.
+wrinkles reproduce the single full-amplitude result exactly. The CZM
+pathway is covered separately in ``test_multi_wrinkle_czm.py``
+(issue #283).
 """
 
 from __future__ import annotations
@@ -210,7 +211,3 @@ class TestMultiWrinkleFE:
         r = WrinkleAnalysis(cfg).run(analytical_only=True)
         assert 0.0 < r.analytical_knockdown <= 1.0
 
-    def test_multi_wrinkle_czm_rejected_with_precise_message(self):
-        cfg = _two_wrinkle_config(enable_czm=True)
-        with pytest.raises(NotImplementedError, match="cohesive"):
-            WrinkleAnalysis(cfg).run()


### PR DESCRIPTION
## Linked issue

Fixes #283

## Summary

Multi-wrinkle FE (#252) and cohesive-zone delamination were individually the package's headline capabilities, but their combination — where **crest-to-crest delamination link-up** lives — was guarded off with `NotImplementedError`. The guard encoded an implementation assumption, not physics: cohesive interface placement derived from "the single wrinkle crest," while the rest of the CZM pipeline (`_build_mesh_with_cohesive_interfaces`, the Newton solve, per-interface reporting) was already generic.

**Changes:**
- Removed the `enable_czm` guard for `AnalysisConfig.wrinkles` configs.
- Generalized `czm_interfaces="near_crest"` resolution: multi-wrinkle configs nominate the interface nearest **each** wrinkle, deduplicated — wrinkles sharing an interface index get **one continuous cohesive surface along its full length**, so a delamination initiating at one crest can propagate toward its neighbour. Scalar (named-morphology) configs keep the legacy largest-amplitude single-interface choice, so **existing CZM results are unchanged**.
- New CI-executed example `examples/08_multi_wrinkle_czm_linkup.py`: far-separated vs close wrinkle pairs on a shared interface (the documented link-up case).
- `examples/04_czm_delamination.py`: `applied_strain` 0.015 → 0.025 so its stated non-zero-damage output holds under the corrected dual-wrinkle amplitude contract (#305), matching the test-suite recalibration from PR #348.

**Acceptance criteria from #283 (all covered by tests):**
- [x] `enable_czm=True` with ≥2 non-overlapping wrinkles runs end-to-end; the guard is fully removed (nothing genuinely unsupported remains).
- [x] Single-entry `wrinkles` CZM ≡ scalar-config CZM: damage/energy/load-displacement match at rtol 1e-9 **with damage active** (max d ≈ 0.15), mesh nodes at 1e-12.
- [x] Far-separation independence: each crest's damage matches a solo run at the same off-centre position within 10 % (measured ≤ 2.3 %; comparing against same-position solo runs isolates interaction from boundary-proximity effects), with bit-zero damage in the 16 mm gap. Per-interface reporting attributes results to the correct indices (`[2, 5]` for wrinkles at interfaces 2 and 5).
- [x] Documented crest-to-crest link-up example: two close wrinkles (crests 6 mm apart) develop bridging damage between the crests (~0.11 vs crest ~0.13) while the far field stays intact — and the far-separated pair's mid-gap is exactly zero, so the bridging is the interaction signal.

## Checklist

- [x] Tests added or updated for the change (11 integration + 2 unit tests; new suite runs in ~76 s)
- [x] `pytest` green locally on the touched surfaces (`test_multi_wrinkle_czm.py`, `test_multi_wrinkle_fe.py`, `test_analysis_czm.py`, `test_viz_czm.py` — 30 tests)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (53 files)
- [x] Docs/README updated if user-facing (`czm_interfaces` field docs, examples README, new example)
- [x] `CHANGELOG.md` `[Unreleased]` updated (Added; no Numerical-results entry — scalar CZM resolution is behavior-preserving)
- [x] `sphinx-build -W docs docs/_build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_