### PR TITLE
Pin the penetration-gate UD strength path in the validation harness (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Penetration-gate validation harness (issue #161): the calibrated UD
+  gate — the only strength path sensitive to wrinkle amplitude and
+  through-thickness position independently of the peak angle — is now
+  pinned in the reproducible ledger. `scripts/validate.py` scores a
+  per-case gate column (with drift detection and `--update` re-pinning)
+  for any dataset naming a `penetration_gate` preset; the Li 2025
+  dataset carries `expected_gate_kd` baselines and a per-case `z_frac`
+  through-thickness position (S-A-2 rides the gate's `P(z)` factor to
+  its measured near-surface KD). The issue's acceptance criteria are
+  permanent regression tests: the S-M-2/4/5 amplitude trio (identical
+  20° angle, measured KD 0.629/0.943/1.000) lands at +2.2 %/−0.6 %/
+  −0.3 % (±15 % band), orderings asserted monotonic, all six cases
+  within the ±20 % parity band. README and VALIDATION.md updated to
+  document the in-repo reproducible UD validation.
 - Cohesive-zone delamination in multi-wrinkle FE (issue #283):
   `enable_czm=True` now runs with an `AnalysisConfig.wrinkles` list
   instead of raising `NotImplementedError`. Cohesive layers are inserted

--- a/README.md
+++ b/README.md
@@ -333,11 +333,37 @@ strengths:
   tension knockdown is no more severe than compression for the same
   defect.
 
-These act as regression guards on the analytical model. They are not a
-quantitative validation against experimental data: this repository does
-not currently ship the Elhajjar (2025), Mukhopadhyay (2015), or Li et
-al. (2026) experimental data points, nor a script that regenerates
-case-by-case error statistics. (Tracking issue: #22.)
+These act as regression guards on the analytical model. For the
+multidirectional datasets (Elhajjar 2025, Mukhopadhyay 2015, Li et al.
+2026) the repository does not ship the experimental data points, so
+case-level error statistics for them are not reproducible in-repo.
+(Tracking issue: #22.)
+
+For the **unidirectional** datasets the situation is different: the
+committed validation ledger
+([`tests/test_validation/ledger.json`](tests/test_validation/ledger.json))
+carries the digitized measured knockdowns for **Li et al. (2025)**
+(Dataset F, 6 single-wrinkle S-glass compression cases) and **Hsiao &
+Daniel (1996)** (Dataset G, carbon), and one command regenerates the
+full per-case predicted-vs-measured table with drift detection against
+pinned baselines:
+
+```bash
+python scripts/validate.py
+```
+
+For Li (2025) the ledger scores three predictors per case: the plain
+Budiansky–Fleck angle floor, the closed-form **modulus** knockdown, and
+the calibrated **penetration gate** — the UD strength path (issue #161)
+that is sensitive to amplitude and through-thickness position
+independently of the peak angle. On the S-M-2/4/5 trio (identical 20°
+peak angle, amplitude 1.5/1.0/0.5 mm, measured KD 0.63/0.94/1.00 — a
+~60 % strength spread invisible to any angle-only model) the gate lands
+within **2.2 % / 0.6 % / 0.3 %**; over all six cases (including the
+near-surface S-A-2 via the position factor) the mean absolute KD error
+is **0.035**, with every case inside the ±20 % parity band. These
+acceptance criteria are pinned as permanent regression tests in
+[`tests/test_validation/test_ledger.py`](tests/test_validation/test_ledger.py).
 
 ### Quantitative validation against experiment
 
@@ -350,9 +376,9 @@ data is documented in the accompanying paper:
 
 Additional datasets referenced by the model calibration (Mukhopadhyay
 et al., 2015; Li et al., 2026) are cited in [References](#references)
-below. Reproducing case-level pass/fail tables from this repository
-alone is not currently possible — the raw data and regeneration script
-are not included.
+below. Reproducing case-level pass/fail tables for those
+multidirectional datasets from this repository alone is not currently
+possible — their raw data are not included.
 
 For a consolidated predicted-vs-experimental view, the script
 [`validation/plot_all_validation.py`](validation/plot_all_validation.py)

--- a/docs/internal/VALIDATION.md
+++ b/docs/internal/VALIDATION.md
@@ -223,7 +223,7 @@ wrinkle defects.* AIP Advances 15, 065118. DOI 10.1063/5.0276297.
   would yield only a figure-derived, non-pristine apparent KD biased to the
   initial-damage region — below the database data-quality bar.
 
-## Evaluated — deferred (pending model capability)
+## Evaluated — initially deferred, since included (issue #161 closed)
 
 ### Li, Li, Ge & Liang (2025)
 
@@ -245,8 +245,22 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   > MAE 5.0 %, 6/6. The gate is a *separate fitted predictor*, not the
   > analytical/FE pipeline; the analysis below explains why that BF /
   > FE-strength pipeline could not capture the amplitude-at-constant-angle
-  > effect (issue #161 remains open for that pipeline and for the
-  > multi-wrinkle D-/T- cases).
+  > effect.
+  >
+  > **Update (issue #161 closed)**: the gate path is now wired into the
+  > reproducible harness — `scripts/validate.py` scores it per case
+  > against `expected_gate_kd` baselines pinned in
+  > `tests/test_validation/ledger.json` (the S-A-2 through-thickness
+  > position rides the new per-case `z_frac` field through the gate's
+  > `P(z)` factor), and the #161 acceptance criteria are permanent
+  > regression tests in `tests/test_validation/test_ledger.py`: the
+  > S-M-2/4/5 trio lands at **+2.2 % / −0.6 % / −0.3 %** (band ±15 %),
+  > the amplitude and angle orderings are asserted monotonic, and all
+  > six cases sit inside the ±20 % parity band. The gate is the issue's
+  > candidate direction 3 (a zone-based knockdown layered on the BF
+  > core). The multi-wrinkle D-/T- cases remain out of the ledger (the
+  > gate is calibrated on single wrinkles; gate × multi-wrinkle wiring
+  > is issue #342).
 - **Dataset** (pristine plate 335.52 MPa; A = peak-to-peak amplitude;
   θ_max = arctan(2π·(A/2)/λ)):
 
@@ -274,10 +288,19 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   strength response is in fact flatter than the analytical one (S-M-2 FE
   strength error ≈ 59%). (Underlying FE LaRC05 max-FI at ε = −0.01:
   0.767 / 0.765 / 0.777, ≤1.5% spread; modulus retention 0.945 for all
-  three — both confirm the same flat behaviour.) Capturing the effect
-  needs geometrically nonlinear progressive-damage FE (issue #161). S-A-2
-  additionally exposes a missing through-thickness wrinkle-position
-  parameter (out of scope; excluded on future inclusion).
+  three — both confirm the same flat behaviour.) In the *analytical*
+  family the effect is now captured by the penetration gate (see the
+  closure note above). On the *FE* side, the crack-band
+  progressive-damage solver (`ProgressiveDamageSolver`,
+  `crack_band=True`) does develop a genuine amplitude trend at constant
+  angle — at Gf = 3.0, nx = 16 the trio predicts 0.805 / 0.912 / 0.957
+  (measured 0.629 / 0.943 / 1.000): S-M-4/5 within ~4 %, S-M-2 still
+  +28 % (see `validation/validate_li_progressive.py` and the
+  `li_progressive_*.csv` runs) — the FE remains an open research
+  direction, no longer tracked by a blocking issue. S-A-2's
+  through-thickness position is no longer out of scope: the
+  `wrinkle_z_position` parameter and the gate's `P(z)` factor reproduce
+  it (pinned via `z_frac` in the ledger).
 - **Related (resolved)**: the `graded` compression through-thickness
   decay had a separate real bug, tracked and closed by issue #254:
   `decay_floor` was inert in compression (honored in tension), and the
@@ -291,7 +314,7 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   results bit-for-bit — confirmed by zero drift across this dataset's
   pinned baselines in `tests/test_validation/ledger.json`. Neither
   change addresses the amplitude-at-constant-angle gap above, which
-  remains issue #161.
+  was closed separately by the penetration-gate path (issue #161).
 
 ## Identified — pending evaluation
 

--- a/docs/internal/VALIDATION.md
+++ b/docs/internal/VALIDATION.md
@@ -296,7 +296,16 @@ Li et al. (2026), *Compos. A* 205:109719 already in the database
   angle — at Gf = 3.0, nx = 16 the trio predicts 0.805 / 0.912 / 0.957
   (measured 0.629 / 0.943 / 1.000): S-M-4/5 within ~4 %, S-M-2 still
   +28 % (see `validation/validate_li_progressive.py` and the
-  `li_progressive_*.csv` runs) — the FE remains an open research
+  `li_progressive_*.csv` runs). **Caveat (measured 2026-07-04)**: the
+  crack band does *not* make the predicted strength mesh-objective in
+  this setting. Refining to a wavelength-proportional 12 elements per
+  wavelength (nx = 36) at the same Gf = 3.0 collapses every S-M case to
+  0.32–0.57 (errors −33 % to −62 %, MAE 46 % vs 14 % at nx = 16): the
+  finer mesh resolves a steeper local misalignment, so FI-driven
+  initiation fires earlier and the h-scaled softening slope does not
+  compensate. The Gf calibration is therefore only valid at the mesh
+  density it was fitted at (nx = 16, nz_per_ply = 2) — do not "improve"
+  the mesh without recalibrating. The FE remains an open research
   direction, no longer tracked by a blocking issue. S-A-2's
   through-thickness position is no longer out of scope: the
   `wrinkle_z_position` parameter and the gate's `P(z)` factor reproduce

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -34,13 +34,20 @@ LEDGER = REPO / "tests" / "test_validation" / "ledger.json"
 sys.path.insert(0, str(REPO / "src"))
 
 
-def case_config(dataset: dict, case: dict):
+def case_config(dataset: dict, case: dict, *, with_gate: bool = False):
     """Build the AnalysisConfig for one ledger case (the reference recipe).
 
     Recipe fields default to the dataset level, but a case may override
     ``morphology``, ``layup``, ``ply_thickness_mm``, ``material`` or
     ``loading`` (used by Dataset G, whose uniform and graded specimens
     differ in morphology, layup and ply thickness).
+
+    With ``with_gate=True`` (and the dataset naming a ``penetration_gate``
+    preset), the config also carries the calibrated penetration gate and
+    the case's through-thickness position ``z_frac`` (default 0.5,
+    mid-plane) — the recipe for the UD gate path (issues #161 / D.3),
+    whose ``analytical_knockdown`` is the gate value instead of plain
+    Budiansky-Fleck.
     """
     from wrinklefe.analysis import AnalysisConfig
     from wrinklefe.core.layup import parse_layup
@@ -48,6 +55,14 @@ def case_config(dataset: dict, case: dict):
 
     def field(key):
         return case[key] if key in case else dataset[key]
+
+    kwargs = {}
+    if with_gate:
+        import wrinklefe.core.penetration_gate as pg
+
+        preset_name = dataset["penetration_gate"]
+        kwargs["penetration_gate"] = getattr(pg, preset_name)
+        kwargs["wrinkle_z_position"] = float(case.get("z_frac", 0.5))
 
     return AnalysisConfig(
         amplitude=case["amplitude_p2p_mm"] / 2.0,
@@ -58,6 +73,7 @@ def case_config(dataset: dict, case: dict):
         material=MaterialLibrary().get(field("material")),
         angles=parse_layup(field("layup")),
         ply_thickness=field("ply_thickness_mm"),
+        **kwargs,
     )
 
 
@@ -88,6 +104,22 @@ def run_case_both(dataset: dict, case: dict) -> tuple[float, float]:
     )
 
 
+def run_case_gate(dataset: dict, case: dict) -> float:
+    """Recompute one case's penetration-gate strength knockdown.
+
+    Requires the dataset to name a ``penetration_gate`` preset. The gate
+    (issue #161 / item D.3) is the UD strength path that is sensitive to
+    amplitude and through-thickness position independently of the peak
+    angle — the axis plain Budiansky-Fleck cannot see.
+    """
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    cfg = case_config(dataset, case, with_gate=True)
+    return float(
+        WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
+    )
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -101,14 +133,21 @@ def main(argv=None) -> int:
     failures = 0
 
     for dataset in ledger["datasets"]:
+        has_gate = "penetration_gate" in dataset
         print(f"\n=== {dataset['name']}  ({dataset['reference']})")
+        gate_hdr = (
+            f"   {'KD gate':>8} {'gate pin':>9} {'drift%':>8} {'err%':>7}"
+            if has_gate else ""
+        )
         print(
             f"{'case':<10} {'KD meas':>8} {'KD pred':>9} {'pinned':>9} "
             f"{'drift%':>8} {'meas err%':>10}   "
             f"{'Em meas':>8} {'Em pred':>9} {'Em pin':>9} {'drift%':>8}"
+            f"{gate_hdr}"
         )
         str_errors = []
         mod_errors = []
+        gate_errors = []
         for case in dataset["cases"]:
             predicted, predicted_mod = run_case_both(dataset, case)
 
@@ -156,10 +195,42 @@ def main(argv=None) -> int:
             else:
                 mod_cols = ""
 
+            # --- penetration-gate knockdown (UD datasets, issue #161) ---
+            gate_cols = ""
+            if has_gate:
+                predicted_gate = run_case_gate(dataset, case)
+                pinned_gate = case.get("expected_gate_kd")
+                if pinned_gate is not None:
+                    drift_gate = (
+                        abs(predicted_gate - float(pinned_gate))
+                        / max(abs(float(pinned_gate)), 1e-30)
+                    )
+                    if drift_gate > tol:
+                        flag += "  <-- GATE DRIFT"
+                        failures += 1
+                    drift_gate_s = f"{100 * drift_gate:>8.3f}"
+                    pin_gate_s = f"{float(pinned_gate):>9.4f}"
+                else:
+                    drift_gate_s = f"{'--':>8}"
+                    pin_gate_s = f"{'--':>9}"
+                if meas is not None:
+                    gate_errors.append(abs(predicted_gate - meas))
+                    gate_err_s = (
+                        f"{100 * (predicted_gate - meas) / meas:>+7.1f}"
+                    )
+                else:
+                    gate_err_s = f"{'--':>7}"
+                gate_cols = (
+                    f"   {predicted_gate:>8.4f} {pin_gate_s} "
+                    f"{drift_gate_s} {gate_err_s}"
+                )
+                if args.update:
+                    case["expected_gate_kd"] = round(predicted_gate, 6)
+
             print(
                 f"{case['case']:<10} {meas_s} "
                 f"{predicted:>9.4f} {pinned:>9.4f} {100 * drift:>8.3f} "
-                f"{meas_err_s}{mod_cols}{flag}"
+                f"{meas_err_s}{mod_cols}{gate_cols}{flag}"
             )
             if args.update:
                 case["expected_analytical_kd"] = round(predicted, 6)
@@ -174,6 +245,12 @@ def main(argv=None) -> int:
             print(
                 f"MAE modulus  vs measured KD: {mae_m:.4f}  "
                 f"({len(mod_errors)} cases)"
+            )
+        if gate_errors:
+            mae_g = sum(gate_errors) / len(gate_errors)
+            print(
+                f"MAE gate     vs measured KD: {mae_g:.4f}  "
+                f"({len(gate_errors)} cases)"
             )
 
     if args.update:

--- a/tests/test_validation/ledger.json
+++ b/tests/test_validation/ledger.json
@@ -27,7 +27,7 @@
     {
       "name": "li_2025_multi_wrinkle_compression",
       "reference": "Li, Li, Ge & Liang (2025), Polymer Composites 46(16):15176-15187, DOI 10.1002/pc.30121",
-      "status": "deferred \u2014 pending issue #161 (amplitude effect at constant peak angle); see VALIDATION.md",
+      "status": "included \u2014 strength via the calibrated penetration gate (GATE_LI2025_VACBAG, issue #161 resolved; the plain Budiansky-Fleck column is retained as the angle-only floor for drift detection). See VALIDATION.md.",
       "material": "AC318_S6C10",
       "layup": "[0]_14",
       "ply_thickness_mm": 0.44,
@@ -46,7 +46,8 @@
           "measured_kd": 0.891,
           "expected_analytical_kd": 0.428859,
           "measured_kd_modulus": 0.931,
-          "expected_analytical_modulus_kd": 0.949288
+          "expected_analytical_modulus_kd": 0.949288,
+          "expected_gate_kd": 0.778045
         },
         {
           "case": "S-M-2",
@@ -57,7 +58,8 @@
           "measured_kd": 0.629,
           "expected_analytical_kd": 0.308699,
           "measured_kd_modulus": 0.864,
-          "expected_analytical_modulus_kd": 0.839641
+          "expected_analytical_modulus_kd": 0.839641,
+          "expected_gate_kd": 0.642705
         },
         {
           "case": "S-M-3",
@@ -68,7 +70,8 @@
           "measured_kd": 0.472,
           "expected_analytical_kd": 0.247616,
           "measured_kd_modulus": 0.811,
-          "expected_analytical_modulus_kd": 0.722632
+          "expected_analytical_modulus_kd": 0.722632,
+          "expected_gate_kd": 0.545168
         },
         {
           "case": "S-M-4",
@@ -79,7 +82,8 @@
           "measured_kd": 0.943,
           "expected_analytical_kd": 0.316646,
           "measured_kd_modulus": 0.967,
-          "expected_analytical_modulus_kd": 0.850933
+          "expected_analytical_modulus_kd": 0.850933,
+          "expected_gate_kd": 0.937759
         },
         {
           "case": "S-M-5",
@@ -90,7 +94,8 @@
           "measured_kd": 1.0,
           "expected_analytical_kd": 0.36273,
           "measured_kd_modulus": 0.975,
-          "expected_analytical_modulus_kd": 0.895154
+          "expected_analytical_modulus_kd": 0.895154,
+          "expected_gate_kd": 0.996862
         },
         {
           "case": "S-A-2",
@@ -102,9 +107,12 @@
           "expected_analytical_kd": 0.308699,
           "measured_kd_modulus": 0.923,
           "expected_analytical_modulus_kd": 0.839641,
-          "note": "S-M-2 geometry at a near-surface interface; the ledger recipe carries no through-thickness wrinkle-position parameter, so the harness runs the mid-plane configuration. Both the strength and the modulus predictions are identical to S-M-2 by construction (the measured near-surface KDs are stored for reference only)."
+          "note": "S-M-2 geometry at a near-surface interface (z = 10/14 through the thickness, carried as z_frac). The plain-BF strength and modulus predictions are identical to S-M-2 by construction; the penetration gate applies its through-thickness position factor P(z) (item D.5, calibrated to this single case), so expected_gate_kd reproduces the measured near-surface mildness.",
+          "z_frac": 0.7142857142857143,
+          "expected_gate_kd": 0.981179
         }
-      ]
+      ],
+      "penetration_gate": "GATE_LI2025_VACBAG"
     },
     {
       "name": "hsiao_daniel_1996_ud_carbon",

--- a/tests/test_validation/test_ledger.py
+++ b/tests/test_validation/test_ledger.py
@@ -160,3 +160,94 @@ def test_replace_preserves_ledger_predictions():
         analytical_only=True
     ).analytical_knockdown
     assert kd1 == pytest.approx(kd2, rel=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Issue #161 — penetration-gate strength path (UD amplitude effect)
+# --------------------------------------------------------------------------- #
+
+
+def _gate_cases():
+    for dataset in _LEDGER["datasets"]:
+        if "penetration_gate" not in dataset:
+            continue
+        for case in dataset["cases"]:
+            yield pytest.param(
+                dataset, case, id=f"{dataset['name']}-{case['case']}"
+            )
+
+
+@pytest.mark.parametrize(("dataset", "case"), list(_gate_cases()))
+def test_gate_matches_pinned_baseline(dataset, case):
+    """Pin the calibrated penetration-gate knockdown (issue #161).
+
+    The gate is the package's best UD strength predictor — the only
+    analytical path sensitive to amplitude and through-thickness
+    position independently of the peak angle. Before this guard it was
+    entirely unpinned: a drift in the gate formula, the preset
+    constants, or the position factor was invisible to CI.
+    """
+    predicted = validate.run_case_gate(dataset, case)
+    pinned = case["expected_gate_kd"]
+    tol = _LEDGER["rel_tolerance"]
+    assert predicted == pytest.approx(pinned, rel=tol), (
+        f"{case['case']} penetration-gate KD drifted from the pinned "
+        f"baseline ({predicted} vs {pinned}). If intentional, re-pin via "
+        f"'python scripts/validate.py --update' and explain the move."
+    )
+
+
+def _gate_kd_by_case() -> dict:
+    dataset = next(
+        d for d in _LEDGER["datasets"] if "penetration_gate" in d
+    )
+    return {
+        c["case"]: (validate.run_case_gate(dataset, c), c["measured_kd"])
+        for c in dataset["cases"]
+    }
+
+
+def test_issue_161_amplitude_trend_at_constant_angle():
+    """The #161 acceptance criterion, as a permanent regression guard.
+
+    S-M-2 / S-M-4 / S-M-5 share the same 20-degree peak angle but span
+    amplitude 1.5 / 1.0 / 0.5 mm (measured KD 0.629 / 0.943 / 1.000 —
+    a ~60% strength spread invisible to any angle-only model). The
+    penetration gate must reproduce each within +/-15% relative KD and
+    preserve the monotonic amplitude ordering.
+    """
+    kd = _gate_kd_by_case()
+    trio = ["S-M-2", "S-M-4", "S-M-5"]
+    for name in trio:
+        pred, meas = kd[name]
+        assert abs(pred - meas) / meas <= 0.15, (
+            f"{name}: gate KD {pred:.3f} vs measured {meas:.3f} exceeds "
+            f"the +/-15% acceptance band of issue #161"
+        )
+    # Larger amplitude at the same angle => lower strength.
+    assert kd["S-M-2"][0] < kd["S-M-4"][0] < kd["S-M-5"][0]
+
+
+def test_issue_161_angle_trend_not_degraded():
+    """Companion guard: the angle series S-M-1/2/3 (10/20/30 degrees at
+    fixed amplitude 1.5 mm) stays monotonic under the gate, and every
+    Li 2025 case stays within the +/-20% parity band the README claims
+    for the UD datasets."""
+    kd = _gate_kd_by_case()
+    assert kd["S-M-1"][0] > kd["S-M-2"][0] > kd["S-M-3"][0]
+    for name, (pred, meas) in kd.items():
+        assert abs(pred - meas) / meas <= 0.20, (
+            f"{name}: gate KD {pred:.3f} vs measured {meas:.3f} outside "
+            f"the +/-20% parity band"
+        )
+
+
+def test_gate_position_factor_reproduces_near_surface_case():
+    """S-A-2 is S-M-2's geometry at z = 10/14: the ledger's z_frac plus
+    the gate's position factor P(z) must reproduce the measured
+    near-surface mildness (KD 0.981 vs mid-plane 0.629)."""
+    kd = _gate_kd_by_case()
+    pred_mid, _ = kd["S-M-2"]
+    pred_surf, meas_surf = kd["S-A-2"]
+    assert pred_surf > pred_mid + 0.2
+    assert pred_surf == pytest.approx(meas_surf, abs=0.02)


### PR DESCRIPTION
## Linked issue

Fixes #161

## Summary

Issue #161's diagnostic — the Li 2025 **S-M-2/4/5 trio** (identical 20° peak angle, amplitude 1.5/1.0/0.5 mm, measured KD 0.629/0.943/1.000, a ~60 % strength spread invisible to any angle-only model) — is captured by the calibrated **penetration gate** (`GATE_LI2025_VACBAG`), which is the issue's candidate direction 3 (a zone-based knockdown layered on the Budiansky–Fleck core). Gate errors on the trio: **+2.2 % / −0.6 % / −0.3 %**, well inside the ±15 % acceptance band; the angle series stays monotonic; the near-surface S-A-2 is reproduced through the `P(z)` position factor (+0.0 %).

The gap this PR closes: the gate was **entirely unpinned**. The reproducible harness (`scripts/validate.py` + `tests/test_validation/ledger.json`) scored only the plain BF floor (−47…−68 % on this dataset), so the package's best UD predictor could drift silently, and none of the #161 acceptance criteria were enforced in CI.

**Changes:**
- `scripts/validate.py`: `case_config(with_gate=True)` resolves the dataset's `penetration_gate` preset + per-case `z_frac`; new `run_case_gate`; the report gains a gate column (prediction, pinned baseline, drift, measured error, per-dataset MAE) with `--update` re-pinning.
- `ledger.json`: Li 2025 names `GATE_LI2025_VACBAG`, carries `expected_gate_kd` pins for all six cases and `z_frac = 10/14` for S-A-2. Existing BF/modulus baselines: **zero drift**.
- `test_ledger.py`: per-case gate baseline guard + the #161 acceptance criteria as permanent regression tests (trio within ±15 %, amplitude/angle orderings monotonic, all six cases within the ±20 % parity band, S-A-2 position factor). 31 tests, all pass in ~7 s.
- `README.md`: documents that UD validation (Li 2025 + Hsiao & Daniel) is now reproducible in-repo with one command, with the gate results.
- `docs/internal/VALIDATION.md`: Li 2025 section moved from "deferred pending #161" to closed; the FE crack-band progressive solver is documented as capturing the amplitude trend qualitatively (trio 0.805/0.912/0.957 at Gf = 3; S-M-2 still +28 %) and left as a non-blocking research direction.

**No prediction paths changed** — this PR pins and guards existing behavior (the only numeric artifacts are new `expected_gate_kd` ledger entries).

### #161 acceptance criteria
- [x] S-M-2/4/5 amplitude trend at fixed 20° within ±15 % relative KD, monotonic (gate: +2.2 %/−0.6 %/−0.3 %)
- [x] Angle trend (S-M-1/2/3) not degraded — monotonic, −12.7 %/+2.2 %/+15.5 %, all inside the ±20 % parity band; every pre-existing pinned baseline shows zero drift
- [x] Reproducible harness for the in-repo datasets (`python scripts/validate.py`, drift-gated in CI via `test_ledger.py`)
- [x] Li 2025 documented in the README validation section — all 6 cases including S-A-2 (the through-thickness position parameter now exists, so S-A-2 is included rather than excluded)

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green on the touched surfaces (31 validation tests)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean
- [x] Docs/README updated
- [x] `CHANGELOG.md` `[Unreleased]` updated (no Numerical-results entry — no prediction path changed)
- [x] `python scripts/validate.py` passes with zero drift on all pre-existing baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_