### PR TITLE
Fix penetration gate × multi-wrinkle: per-spec D/T, weakest-link KD (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,19 @@ version produced a given file.
   imported; native `.inp`/VTK writers need no extra).
 
 ### Numerical results
+- **Penetration gate × multi-wrinkle (issue #342)**: with a
+  `penetration_gate` preset and the geometry supplied via
+  `AnalysisConfig.wrinkles`, the gate previously took its angle from the
+  wrinkle specs but its penetration `D/T` from the leftover scalar
+  `cfg.amplitude` (typically the unused 0.366 default) — a silently
+  plausible wrong knockdown (0.98 instead of 0.64 on the issue's repro).
+  The gate now evaluates per spec — `theta_i = arctan(2πA_i/λ_i)`,
+  `D_i/T = A_i/T`, and `z_i = (ply_interface+1)/n_plies` through the
+  position factor `P(z)` (`cfg.wrinkle_z_position` is a scalar-path
+  parameter and is ignored when specs are present) — and returns the
+  weakest-link (minimum) knockdown over the wrinkles. Scalar-config gate
+  results are unchanged (pinned ledger baselines show zero drift); any
+  gate × `wrinkles` configuration returns different (correct) values.
 - **LaRC05 / Puck last-bit normalization (issue #299)**: the scalar
   `evaluate()` paths now square via an explicit product (`x * x`)
   instead of `x ** 2` — scalar `np.float64` pow routes through libm and

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -2886,11 +2886,41 @@ class WrinkleAnalysis:
         if cfg.penetration_gate is not None:
             angles_g = cfg.angles if cfg.angles else [0]
             T = cfg.ply_thickness * len(angles_g)
-            dt = (cfg.amplitude / T) if T > 0 else 0.0
-            kd_gate = penetration_gate_kd(
-                math.degrees(theta_max), dt, cfg.penetration_gate,
-                z_position=float(cfg.wrinkle_z_position),
-            )
+            if cfg.wrinkles is not None:
+                # Multi-wrinkle gate (issue #342): evaluate the gate per
+                # spec — each wrinkle carries its own angle
+                # theta_i = arctan(2*pi*A_i/lambda_i), penetration
+                # D_i/T = A_i/T, and through-thickness position
+                # z_i = (ply_interface + 1) / n_plies (the boundary the
+                # spec nominates; ``cfg.wrinkle_z_position`` is a
+                # scalar-path parameter and is ignored here) — and take
+                # the weakest-link (minimum) knockdown.  Previously
+                # ``dt`` silently read the leftover scalar
+                # ``cfg.amplitude`` while theta came from the specs,
+                # producing a plausible-looking wrong answer (e.g. kd
+                # 0.98 instead of 0.64 on the issue's repro).
+                n_plies_g = len(angles_g)
+                kd_gate = 1.0
+                for spec in cfg.wrinkles:
+                    if spec.wavelength > 1e-12:
+                        theta_i = float(np.arctan(
+                            2.0 * np.pi * spec.amplitude / spec.wavelength
+                        ))
+                    else:
+                        theta_i = 0.0
+                    dt_i = (spec.amplitude / T) if T > 0 else 0.0
+                    z_i = (spec.ply_interface + 1) / n_plies_g
+                    kd_i = penetration_gate_kd(
+                        math.degrees(theta_i), dt_i, cfg.penetration_gate,
+                        z_position=float(z_i),
+                    )
+                    kd_gate = min(kd_gate, float(kd_i))
+            else:
+                dt = (cfg.amplitude / T) if T > 0 else 0.0
+                kd_gate = penetration_gate_kd(
+                    math.degrees(theta_max), dt, cfg.penetration_gate,
+                    z_position=float(cfg.wrinkle_z_position),
+                )
             results.morphology_factor = mf
             results.max_angle_rad = theta_max
             results.effective_angle_rad = theta_eff

--- a/tests/test_penetration_gate.py
+++ b/tests/test_penetration_gate.py
@@ -172,3 +172,105 @@ class TestPositionFactor:
     def test_rejects_bad_position_q(self):
         with pytest.raises(ValueError):
             GateParameters(0.5, 0.1, 4.0, position_q=-1.0)
+
+
+class TestGateMultiWrinkle:
+    """Gate x AnalysisConfig.wrinkles interaction (issue #342).
+
+    The gate previously read theta from the wrinkle specs but D/T from
+    the leftover scalar ``cfg.amplitude`` — a silently wrong knockdown
+    (0.98 instead of 0.64 on the repro below). The gate now evaluates
+    per spec (theta_i, A_i/T, z_i from the spec's ply interface) and
+    takes the weakest-link minimum.
+    """
+
+    @staticmethod
+    def _cfg(wrinkles, **overrides):
+        from wrinklefe.analysis import AnalysisConfig
+
+        base = dict(
+            angles=[0.0] * 14, ply_thickness=0.44, morphology="graded",
+            loading="compression", penetration_gate=GATE_LI2025_VACBAG,
+            wrinkles=wrinkles, analytical_only=True,
+        )
+        base.update(overrides)
+        return AnalysisConfig(**base)
+
+    @staticmethod
+    def _kd(cfg) -> float:
+        from wrinklefe.analysis import WrinkleAnalysis
+
+        return float(
+            WrinkleAnalysis(cfg).run(analytical_only=True)
+            .analytical_knockdown
+        )
+
+    def test_issue_342_repro_uses_spec_amplitude(self):
+        """The issue's exact repro: D/T must come from the spec
+        (kd ~ 0.643), not the leftover scalar default (kd ~ 0.984)."""
+        from wrinklefe.analysis import WrinkleSpec
+
+        cfg = self._cfg([
+            WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                        ply_interface=6, phase_offset=0.0),
+        ])
+        kd = self._kd(cfg)
+        assert kd == pytest.approx(0.6427, abs=2e-4)
+        assert kd < 0.7  # loudly not the stale-amplitude 0.98 value
+
+    def test_single_spec_matches_scalar_gate_config(self):
+        """One spec at the midplane boundary reproduces the scalar-config
+        gate exactly (same theta, D/T and z)."""
+        from wrinklefe.analysis import AnalysisConfig, WrinkleSpec
+
+        kd_multi = self._kd(self._cfg([
+            WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                        ply_interface=6),
+        ]))
+        scalar = AnalysisConfig(
+            amplitude=0.75, wavelength=12.9, width=6.45,
+            angles=[0.0] * 14, ply_thickness=0.44, morphology="graded",
+            loading="compression", penetration_gate=GATE_LI2025_VACBAG,
+            wrinkle_z_position=7.0 / 14.0,
+            analytical_only=True,
+        )
+        assert kd_multi == pytest.approx(self._kd(scalar), rel=1e-12)
+
+    def test_weakest_link_governs(self):
+        """Adding a milder (near-surface) wrinkle must not raise the
+        knockdown above the severe midplane wrinkle's own value."""
+        from wrinklefe.analysis import WrinkleSpec
+
+        severe = WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                             ply_interface=6)
+        mild = WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                           ply_interface=9)
+        kd_severe = self._kd(self._cfg([severe]))
+        kd_mild = self._kd(self._cfg([mild]))
+        kd_both = self._kd(self._cfg([mild, severe]))
+        assert kd_mild > kd_severe
+        assert kd_both == pytest.approx(kd_severe, rel=1e-12)
+
+    def test_per_spec_position_factor_engaged(self):
+        """A near-surface spec (interface 9 of 14 -> z = 10/14) rides the
+        gate's P(z) to the measured S-A-2-style mildness."""
+        from wrinklefe.analysis import WrinkleSpec
+
+        kd = self._kd(self._cfg([
+            WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                        ply_interface=9),
+        ]))
+        assert kd == pytest.approx(0.9812, abs=2e-4)
+
+    def test_scalar_amplitude_is_ignored(self):
+        """The leftover scalar amplitude/wavelength must have no effect
+        on a multi-wrinkle gate knockdown."""
+        from wrinklefe.analysis import WrinkleSpec
+
+        spec = [WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                            ply_interface=6)]
+        kd_default = self._kd(self._cfg(spec))
+        kd_other = self._kd(
+            self._cfg(spec, amplitude=1.9, wavelength=40.0, width=3.0)
+        )
+        assert kd_default == pytest.approx(kd_other, rel=1e-12)


### PR DESCRIPTION
## Linked issue

Fixes #342

## Summary

With a `penetration_gate` preset and the geometry supplied via `AnalysisConfig.wrinkles`, the gate composed its **angle** from the wrinkle specs but read the penetration **D/T** from the leftover scalar `cfg.amplitude` — for a multi-wrinkle config an unused default (0.366) — returning a plausible-looking wrong knockdown with no warning: **0.9838 instead of 0.6427** on the issue's repro. That's a 0.34 silent error on the package's headline UD predictor, on exactly the D/T axis the gate was built to capture (and more pressing since PR #350 made the gate the pinned, README-documented UD strength path).

**Fix (the issue's option 1):** when `cfg.wrinkles` is set, the gate evaluates **per spec** — `theta_i = arctan(2πA_i/λ_i)`, `D_i/T = A_i/T`, and `z_i = (ply_interface + 1)/n_plies` through the position factor `P(z)` (`cfg.wrinkle_z_position` is a scalar-path parameter and is ignored when specs are present) — and returns the **weakest-link (minimum) knockdown** over the wrinkles.

Verified semantics:
- The issue's repro now returns **0.6427** and is *exactly* equal to the scalar-config gate at the same geometry.
- A near-surface spec (interface 9 of 14 → z = 10/14) rides `P(z)` to 0.9812 — the measured S-A-2-style mildness — so the multi-wrinkle gate inherits the position axis for free.
- Adding a milder wrinkle never raises the knockdown (weakest link).
- The leftover scalar `amplitude`/`wavelength` fields have no effect on a multi-wrinkle gate result.

**Scalar-config gate behaviour is unchanged:** `python scripts/validate.py` shows zero drift on all pinned gate/BF/modulus ledger baselines.

### #342 acceptance criteria
- [x] The repro returns kd ≈ 0.643 (spec-derived D/T) — not 0.984
- [x] Single-wrinkle (scalar) gate behaviour unchanged — pinned gate tests pass, ledger zero-drift
- [x] Regression tests cover the gate × `wrinkles` combination (`TestGateMultiWrinkle`, 5 tests: repro, exact scalar equivalence, weakest-link ordering, per-spec `P(z)`, leftover-scalar insensitivity)

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green on touched surfaces (22 gate tests, 31 ledger tests, multi-wrinkle + sweep suites — 51 in the combined run)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean
- [x] Docs — in-code comments document the per-spec semantics; CHANGELOG carries the user-facing note
- [x] `CHANGELOG.md` updated under **Numerical results** (gate × `wrinkles` configs return different — correct — values; scalar configs bit-unchanged)
- [x] `python scripts/validate.py` — zero drift on all pinned baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_