### PR TITLE
docs: catch documentation up with recent capabilities; backfill CHANGELOG (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Mesh-resolution warning (issue #306): `WrinkleMesh.generate` warns
+  when the hex mesh samples the wrinkle wavelength with fewer than 4
+  elements (element `dx` vs `lambda`), naming the offending spacing and
+  the `nx` needed — under-sampled wrinkles previously produced silent
+  aliasing noise.
+- CZM-capable glass/aramid presets (issue #268): `S2_GLASS_EPOXY` and
+  `KEVLAR49_EPOXY` now carry representative interlaminar toughness
+  (`GIc`/`GIIc` in the published glass/aramid ranges), so
+  `enable_czm=True` runs for every built-in material instead of raising
+  for those two. Configurations that previously errored now produce
+  cohesive-damage results.
+- Coordinate-aware maxima (issue #297):
+  `FieldResults.max_displacement_location()` and
+  `max_stress_location()` return the physical `(x, y, z)` of the
+  governing node / element centroid alongside the value.
+- Failure-mode breakdown plot (issue #269, part 1):
+  `wrinklefe.viz.plot_failure_mode_breakdown` with a stable
+  per-failure-mode colour map (`MODE_COLORS`).
 - Process-parallel parametric sweeps (issue #260):
   `WrinkleAnalysis.parametric_sweep(..., n_workers=N)`,
   `wrinklefe.sweep.run_sweep(..., n_workers=N)`, and
@@ -237,6 +255,18 @@ version produced a given file.
   access in `max_angle` / `fiber_angles_at_nodes`.
 
 ### Changed
+- `parse_layup` input strictness (issue #308) — **breaking for inputs
+  that previously parsed**: ply-angle tokens with `|angle| > 90` (e.g.
+  the repeat-count-like `[02/902]s`, which silently parsed as 2° and
+  902° plies) and leading-zero tokens now raise `ValueError` instead of
+  building a wrong laminate; ASCII `+-45`/`-+45` are now accepted as
+  the ± shorthand. Scripts feeding the newly-rejected forms must switch
+  to explicit repeat syntax (e.g. `[0_2/90_2]s`).
+- Mesh aspect-ratio warning re-baselined (issue #303): the warning now
+  compares each element against the mesh's own median aspect ratio and
+  flags only outliers, instead of a fixed 10:1 threshold that flagged
+  71–100 % of elements on typical thin-ply meshes (default runs are now
+  quiet; genuinely anomalous elements still warn).
 - CI enforces the full Ruff ruleset and `mypy` over the whole tree.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ Public link, no account needed.
 - **Five morphologies:** Stack, convex, concave, uniform, graded (with configurable decay floor)
 - **Graded averaging:** Through-thickness ply-averaged knockdown for graded wrinkles
 - **Movable wrinkle position:** Configurable through-thickness placement (`wrinkle_z_position`, 0.5 = mid-plane)
+- **Multi-wrinkle configurations:** Arbitrary N-wrinkle layouts via `AnalysisConfig.wrinkles` — a list of `WrinkleSpec(amplitude, wavelength, width, ply_interface, phase_offset)` — through the analytical, FE, penetration-gate (per-spec, weakest-link) and CZM paths
+- **Cohesive-zone delamination (CZM):** Bilinear traction–separation interface elements (`enable_czm=True`) with per-interface damage, energy and crack-length reporting — including continuous cohesive surfaces across adjacent wrinkles for crest-to-crest delamination link-up (see `examples/08_multi_wrinkle_czm_linkup.py`)
 - **Resin-pocket material zone:** Graded neat-epoxy lens at the wrinkle crest (modulus + fibre-angle blend, counted once) via `wrinklefe.core.resin_pocket`
 - **Progressive-damage FE:** Load-stepping `ProgressiveDamageSolver` to ultimate load with optional crack-band (Bažant–Oh) regularization — the first FE route to a UD compression knockdown
 - **Penetration gate (θ, D/T, z):** Closed-form two-parameter UD predictor `KD = 1 − (1 − KD_angle(θ))·S(D/T)·P(z)` with calibrated presets; zero FE cost (`wrinklefe.core.penetration_gate`)
 - **Linear buckling:** Geometric-stiffness eigenvalue solve (`LinearBucklingSolver`) with a microbuckling knockdown — verified structural-buckling infrastructure, but a homogenised-continuum eigenvalue does not capture the *fibre-scale* wrinkle knockdown (it gets the sign wrong: the bifurcation load *rises* with the wrinkle), so it is **not** the production UD predictor (the penetration gate is); see the [modelling findings](docs/wrinkle_modeling_findings.md)
 - **11 built-in laminate materials** (AS4/3501-6, IM7/8552, T300/914, T700/2510, AC318/S6C10 S-glass/epoxy, T800S/M21, IM10/8552, IM6G/3501-6 carbon/epoxy — the Hsiao & Daniel 1996 wavy-UD study, S-2 glass/epoxy, Kevlar-49/epoxy, plus `AC318_S6C10_vacbag` — the Li 2025 vacuum-bag realization, measured Xc=335.5 MPa, E1=50.8 GPa) plus an isotropic neat-epoxy card (`EPOXY_S6C10`) for the resin-pocket zone
+- **Process-parallel sweeps:** `n_workers=N` on both sweep APIs and `wrinklefe sweep --parallel N` fan the independent per-point solves across CPU cores (results identical to and ordered like the sequential run)
 - **Comprehensive test suite** covering all modules (run `pytest` to see the current count)
 
 ## Developer / library install
@@ -230,7 +233,46 @@ print(result.analytical_knockdown)
 ```
 
 When `penetration_gate` is left unset (the default `None`), the
-analytical knockdown is unchanged.
+analytical knockdown is unchanged. With a multi-wrinkle configuration
+(`AnalysisConfig.wrinkles`, below) the gate evaluates each wrinkle on
+its own geometry — `theta_i = arctan(2πA_i/λ_i)`, penetration
+`D_i/T = A_i/T`, and the through-thickness position factor `P(z_i)`
+from the spec's ply interface — and returns the weakest-link (minimum)
+knockdown.
+
+### Multi-wrinkle configurations
+
+Real laminates often carry several wrinkles. Passing a list of
+`WrinkleSpec` entries overrides the single/dual-wrinkle dispatch and
+places each wrinkle at its own ply interface with its own geometry and
+longitudinal position (`phase_offset` shifts a crest by
+`phase·λ/2π`):
+
+```python
+import numpy as np
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis, WrinkleSpec
+
+config = AnalysisConfig(
+    morphology="graded", loading="compression",
+    angles=[0.0] * 14, ply_thickness=0.44,
+    wrinkles=[
+        WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                    ply_interface=6, phase_offset=-2.0 * np.pi),
+        WrinkleSpec(amplitude=0.75, wavelength=12.9, width=6.45,
+                    ply_interface=6, phase_offset=+2.0 * np.pi),
+    ],
+)
+result = WrinkleAnalysis(config).run()
+```
+
+The composed displacement and fibre-angle fields feed the FE solve
+("compose then differentiate"), the penetration gate scores each
+wrinkle and takes the weakest link, and `enable_czm=True` inserts
+cohesive surfaces along the full length of every wrinkle-nominated
+interface — wrinkles sharing an interface get one continuous surface,
+so a delamination can propagate crest-to-crest between neighbours
+(`examples/08_multi_wrinkle_czm_linkup.py` demonstrates the link-up
+vs far-separated contrast).
 
 ### Batch parametric sweeps
 
@@ -254,6 +296,13 @@ for r in results:
     print(f"A={r.config.amplitude:.3f}  KD={r.analytical_knockdown:.4f}")
 ```
 
+Every sweep point is an independent analysis, so full-FE sweeps
+parallelize across processes: pass `n_workers=N` (`0` = all CPU cores)
+and the solves fan out over a process pool with results returned in
+the same order as `values` — measured 3.6× at 4 workers on an 8-value
+FE sweep. Peak memory scales with `n_workers` × the per-solve
+footprint, so size the worker count by available RAM for fine meshes.
+
 For multi-parameter cross-product sweeps with JSON output and plots,
 use `wrinklefe.sweep.run_sweep`:
 
@@ -276,6 +325,10 @@ wrinklefe --help
 
 # Single-parameter sweep (analytical-only is the default, fast)
 wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 5
+
+# Full-FE sweep across 4 worker processes (--parallel 0 = all cores)
+wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
+    --no-analytical-only --parallel 4
 ```
 
 ### Exporting results to CSV / JSON

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,6 +76,8 @@ The same pipeline is available from the command line:
 
 ```bash
 wrinklefe analyze --amplitude 0.366 --wavelength 16 --morphology stack
+wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
+    --no-analytical-only --parallel 4   # full-FE sweep on 4 processes
 wrinklefe converge --tolerance 0.01   # mesh-convergence study
 wrinklefe materials                   # list the material library
 ```
@@ -84,6 +86,7 @@ wrinklefe materials                   # list the material library
 
 The repository's `examples/` directory contains scripts for the common
 workflows — parametric sweeps, morphology comparison, CZM delamination,
-export round-trips, custom materials, mesh convergence — each with its
+multi-wrinkle crest-to-crest delamination link-up, export round-trips,
+custom materials, mesh convergence — each with its
 expected runtime and output in the header. CI executes them all on
 every push.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,6 +29,18 @@ wrinkles distinguished by their through-thickness amplitude profile);
 see the wrinkle-geometry table in the README/landing page for the full
 parameter reference.
 
+Beyond the named morphologies, arbitrary **multi-wrinkle layouts** are
+supported through `AnalysisConfig.wrinkles` — a list of
+{class}`~wrinklefe.analysis.WrinkleSpec` entries, each with its own
+amplitude, wavelength, width, ply interface, and longitudinal position.
+The displacement and fibre-angle fields derive from the composed
+wrinkle field ("compose then differentiate"), the penetration gate
+scores each wrinkle on its own geometry and takes the weakest link, and
+CZM inserts cohesive surfaces along the full length of every
+wrinkle-nominated interface — so a delamination initiating at one crest
+can propagate toward a neighbouring wrinkle on the same interface
+(crest-to-crest link-up).
+
 ## Unidirectional wrinkle-defect capabilities
 
 Angle-based models are scale-invariant: at a *fixed* misalignment angle


### PR DESCRIPTION
## Linked issue

Fixes #347

## Summary

Documentation-only PR bringing the user-facing docs current with the recent merge trains.

**CHANGELOG (closes #347):** adds the six missing `[Unreleased]` entries for PRs #336–#341, in the categories the issue prescribed:
- **Changed** — `parse_layup` strictness (#336/#308): the breaking entry explicitly states the newly-rejected forms (`|angle| > 90` tokens like `[02/902]s` — previously a silent wrong laminate, now `ValueError` — and leading-zero tokens) plus the newly-accepted ASCII `+-`/`-+`; and the median-baselined mesh aspect-ratio warning (#337/#303).
- **Added** — elements-per-wavelength resolution warning (#338/#306); CZM-capable `S2_GLASS_EPOXY`/`KEVLAR49_EPOXY` presets (#339/#268); `max_displacement_location`/`max_stress_location` (#340/#297); `plot_failure_mode_breakdown` + `MODE_COLORS` (#341/#269).

**README:**
- Features list gains the three missing headline capabilities: multi-wrinkle configurations (`WrinkleSpec`), CZM delamination with crest-to-crest link-up, process-parallel sweeps.
- New **Multi-wrinkle configurations** section with a runnable `WrinkleSpec` example and the semantics that landed this cycle (compose-then-differentiate FE fields, per-spec weakest-link penetration gate from #342, full-length cohesive surfaces / link-up from #283).
- Penetration-gate section documents the multi-wrinkle per-spec behaviour.
- Sweep section + CLI snippet document `n_workers` / `--parallel` (#260) with the memory-sizing note.

**docs/overview.md:** multi-wrinkle paragraph in the FE section (with a resolving `WrinkleSpec` cross-reference).
**docs/getting_started.md:** `--parallel` in the CLI snippet; the link-up example added to the runnable-examples list.

No code changes. `sphinx-build -W` clean; `ruff` clean.

### #347 acceptance criteria
- [x] Each of the six PRs has an `[Unreleased]` entry in the appropriate category
- [x] The #336 entry explicitly states the newly-rejected input forms

## Checklist

- [x] Tests — N/A (docs only)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` — untouched
- [x] Docs build: `sphinx-build -W docs docs/_build` clean
- [x] `CHANGELOG.md` updated (that's the point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_