### PR TITLE
Add Monte-Carlo/LHS uncertainty propagation; vectorize modulus knockdown (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Monte-Carlo / Latin-hypercube uncertainty propagation (issue #301):
+  `wrinklefe.stochastic.probabilistic_analysis(base_config,
+  distributions, n_samples, seed, method="lhs"|"mc")` samples
+  `AnalysisConfig` fields from user distributions (`("normal", m, s)`,
+  `("uniform", lo, hi)`, `("lognormal", mu, sigma)`, or any frozen
+  `scipy.stats` distribution), runs the analytical path per sample, and
+  returns a `ProbabilisticResults` with percentile
+  knockdowns/strengths, mean ± std, the input samples for sensitivity
+  scatter, an optional histogram+scatter `plot()`, and a `summary()`
+  that explicitly labels the output as model-input-propagation
+  statistics — **not** CMH-17 A-/B-basis allowables. Fixed seeds are
+  fully reproducible; degenerate (zero-variance) distributions
+  reproduce the deterministic result exactly; invalid draws fail loudly
+  instead of being clipped; `n_workers` reuses the #260 process pool
+  for FE-path sampling. 1000 analytical samples run in ~0.7 s for
+  UD/gate configs.
+- Vectorized `_laminate_modulus_knockdown` (issue #301 enabler): the
+  multidirectional analytical modulus knockdown ran a per-(ply,
+  x-station) Python loop (12,000 6×6 rotations/condensations), making
+  every multidirectional analytical run take ~1.2 s. The wrinkle-tilt
+  rotation and plane-stress condensation are now batched over the whole
+  (ply, x) grid (the in-plane rotation is computed once per ply, and
+  `T_sigma(θ)^-1 = T_sigma(−θ)` replaces the batched solve) — 1.18 s →
+  22 ms (~52×) per analytical run, results identical to the loop
+  (regression-tested against it; ledger baselines zero-drift).
 - Mesh-resolution warning (issue #306): `WrinkleMesh.generate` warns
   when the hex mesh samples the wrinkle wavelength with fewer than 4
   elements (element `dx` vs `lambda`), naming the offending spacing and

--- a/README.md
+++ b/README.md
@@ -274,6 +274,51 @@ so a delamination can propagate crest-to-crest between neighbours
 (`examples/08_multi_wrinkle_czm_linkup.py` demonstrates the link-up
 vs far-separated contrast).
 
+### Uncertainty propagation (probabilistic analysis)
+
+Measured wrinkle geometry is uncertain — amplitude and wavelength come
+from a micrograph or C-scan with error. `probabilistic_analysis`
+samples `AnalysisConfig` fields from user-supplied distributions
+(Latin-hypercube by default, plain Monte-Carlo optional) and runs the
+analytical path per sample, turning "the model says 0.64" into "P5–P95
+= 0.59–0.86 given my measurement uncertainty" — the form an NCR
+disposition rationale actually needs:
+
+```python
+from wrinklefe.analysis import AnalysisConfig
+from wrinklefe.core.penetration_gate import GATE_LI2025_VACBAG
+from wrinklefe.stochastic import probabilistic_analysis
+
+base = AnalysisConfig(
+    amplitude=0.75, wavelength=12.9, width=6.45,
+    angles=[0.0] * 14, ply_thickness=0.44, morphology="graded",
+    penetration_gate=GATE_LI2025_VACBAG,
+)
+prob = probabilistic_analysis(
+    base,
+    {"amplitude": ("normal", 0.75, 0.08),
+     "wavelength": ("normal", 12.9, 1.0)},
+    n_samples=1000, seed=42,
+)
+print(prob.summary())                     # P5/P50/P95, mean ± std
+print(prob.knockdown_percentile(5.0))     # 5th-percentile knockdown
+prob.plot()                               # histogram + sensitivity scatter
+```
+
+Distributions accept `("normal", mean, std)`, `("uniform", lo, hi)`,
+`("lognormal", mu, sigma)` or any frozen `scipy.stats` distribution; a
+fixed `seed` makes the whole analysis reproducible, and `n_workers`
+reuses the sweep process pool for FE-path sampling. 1000 analytical
+samples run in under a second for UD/gate configs (~20 s for a 24-ply
+multidirectional layup, or seconds with `n_workers`).
+
+> **Not A-/B-basis values.** The reported percentiles are
+> *model-input-propagation* statistics — the deterministic model driven
+> by sampled geometry. They are **not** CMH-17 A-/B-basis allowables
+> (one-sided tolerance bounds on physical test data with prescribed
+> confidence) and must not be presented as basis values in
+> certification paperwork.
+
 ### Batch parametric sweeps
 
 For exploring how the knockdown varies across a parameter range, use

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ functions, and the CLI.
    :maxdepth: 1
 
    analysis
+   stochastic
    convergence
    core
    solver

--- a/docs/api/stochastic.rst
+++ b/docs/api/stochastic.rst
@@ -1,0 +1,7 @@
+wrinklefe.stochastic
+====================
+
+.. automodule:: wrinklefe.stochastic
+   :members: probabilistic_analysis, ProbabilisticResults
+   :undoc-members:
+   :show-inheritance:

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -588,20 +588,73 @@ def _laminate_modulus_knockdown(
         Axial-modulus knockdown in ``(0, 1]``.
     """
     phis = [math.radians(float(a)) for a in angles]
-    n_x = slope_field.shape[-1]
-    total_thickness = len(phis) * ply_thickness
+    n_plies = len(phis)
+    total_thickness = n_plies * ply_thickness
 
-    inv_E_section = np.empty(n_x, dtype=float)
-    for xi in range(n_x):
-        a_mat = np.zeros((3, 3), dtype=float)
-        for p, phi in enumerate(phis):
-            # Compose the per-wrinkle slopes (each decayed for this ply)
-            # then take the local tilt angle: arctan|sum_w dz_w/dx * Phi_w|.
-            slope_p = float(np.dot(slope_field[:, xi], ply_decays[p, :, xi]))
-            theta = math.atan(abs(slope_p))
-            q_bar = _plane_stress_qbar_tilted(stiffness_3d, phi, theta)
-            a_mat += q_bar * ply_thickness
-        inv_E_section[xi] = np.linalg.inv(a_mat)[0, 0] * total_thickness
+    # Compose the per-wrinkle slopes (each decayed for this ply) then
+    # take the local tilt angle: theta(p, x) = arctan|sum_w dz_w/dx * Phi_w|.
+    slope_px = np.einsum("wx,pwx->px", slope_field, ply_decays)
+    theta_px = np.arctan(np.abs(slope_px))  # (n_plies, n_x)
+
+    # The in-plane (z-axis) rotation depends only on the ply angle, so
+    # rotate the base stiffness once per ply; the wrinkle tilt (y-axis)
+    # rotation and the plane-stress condensation are batched over the
+    # whole (ply, x) grid (issue #301: the previous per-(ply, x) Python
+    # loop made every multidirectional analytical run take seconds).
+    c_phi = np.stack(
+        [rotate_stiffness_3d(stiffness_3d, phi, axis="z") for phi in phis]
+    )  # (n_plies, 6, 6)
+
+    # Batched y-axis stress-transformation matrices T_sigma(theta) and
+    # the engineering-strain counterparts T_eps = R T_sigma R^-1
+    # (row/column Reuter scaling), mirroring
+    # wrinklefe.core.transforms.stress/strain_transformation_3d.
+    def _tsigma_y(cos_t: np.ndarray, sin_t: np.ndarray) -> np.ndarray:
+        c2, s2, sc = cos_t * cos_t, sin_t * sin_t, sin_t * cos_t
+        t = np.zeros(cos_t.shape + (6, 6), dtype=float)
+        t[..., 0, 0] = c2
+        t[..., 0, 2] = s2
+        t[..., 0, 4] = -2.0 * sc
+        t[..., 1, 1] = 1.0
+        t[..., 2, 0] = s2
+        t[..., 2, 2] = c2
+        t[..., 2, 4] = 2.0 * sc
+        t[..., 3, 3] = cos_t
+        t[..., 3, 5] = sin_t
+        t[..., 4, 0] = sc
+        t[..., 4, 2] = -sc
+        t[..., 4, 4] = c2 - s2
+        t[..., 5, 3] = -sin_t
+        t[..., 5, 5] = cos_t
+        return t
+
+    cos_t = np.cos(theta_px)
+    sin_t = np.sin(theta_px)
+    t_sig = _tsigma_y(cos_t, sin_t)
+    # Rotation transformations invert by angle negation:
+    # T_sigma(theta)^-1 == T_sigma(-theta) — a matmul instead of a
+    # batched 6x6 solve.
+    t_sig_inv = _tsigma_y(cos_t, -sin_t)
+    reuter = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+    t_eps = t_sig * (reuter[:, None] / reuter[None, :])
+
+    # C_rot = T_sigma^-1 @ C_phi @ T_eps, batched over (ply, x).
+    c_rot = t_sig_inv @ (c_phi[:, None, :, :] @ t_eps)
+
+    # Plane-stress condensation onto the in-plane Voigt indices
+    # (11, 22, 12): Q-bar = C_ii - C_io @ C_oo^-1 @ C_oi.
+    ip = np.array([0, 1, 5])
+    op = np.array([2, 3, 4])
+    c_ii = c_rot[..., ip[:, None], ip[None, :]]
+    c_io = c_rot[..., ip[:, None], op[None, :]]
+    c_oi = c_rot[..., op[:, None], ip[None, :]]
+    c_oo = c_rot[..., op[:, None], op[None, :]]
+    q_bar = c_ii - c_io @ np.linalg.solve(c_oo, c_oi)
+
+    # Membrane A(x) = sum_p Q-bar_p * t; shared membrane strain gives
+    # E_section(x) = 1 / (inv(A)[0,0] * T).
+    a_mat = q_bar.sum(axis=0) * ply_thickness  # (n_x, 3, 3)
+    inv_E_section = np.linalg.inv(a_mat)[:, 0, 0] * total_thickness
 
     # E_section(x) = 1 / inv_E_section; series-average the compliance.
     e_eff = 1.0 / float(np.mean(inv_E_section))

--- a/src/wrinklefe/stochastic.py
+++ b/src/wrinklefe/stochastic.py
@@ -1,0 +1,452 @@
+"""Monte-Carlo / Latin-hypercube uncertainty propagation (issue #301).
+
+Every deterministic WrinkleFE output answers "what is the knockdown for
+*this* wrinkle geometry?".  In the package's core use case —
+dispositioning a manufacturing defect — the geometry is uncertain:
+amplitude and wavelength come from a measurement with error, and the
+defect population inside one part scatters.  This module propagates
+those input distributions through the analysis so the answer becomes
+"the model says 0.74–0.82 given my measurement uncertainty" instead of
+"the model says 0.78".
+
+The propagation is doubly worthwhile here because the compressive
+knockdown ``1 / (1 + theta_eff / gamma_Y)`` is **concave** in the
+misalignment angle: by Jensen's inequality, evaluating the model at the
+*mean* input overestimates the *mean* knockdown (the fat-tail argument
+of Elhajjar 2025) — a bias only sampling can quantify.
+
+.. warning:: **Not A-/B-basis values.**  The percentiles reported here
+   are *model-input propagation* statistics: the distribution of the
+   deterministic model's output when its geometric inputs are sampled
+   from the distributions you supplied.  They are **not** CMH-17
+   A-/B-basis allowables, which are one-sided statistical tolerance
+   bounds computed from physical *test* data with prescribed confidence
+   levels.  Do not present these percentiles as basis values in
+   certification paperwork.
+
+Example
+-------
+::
+
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.stochastic import probabilistic_analysis
+
+    base = AnalysisConfig(amplitude=0.4, wavelength=16.0, width=12.0)
+    prob = probabilistic_analysis(
+        base,
+        {"amplitude": ("normal", 0.4, 0.05)},
+        n_samples=1000, seed=42,
+    )
+    print(prob.summary())
+    print(prob.knockdown_percentile(5.0))   # 5th-percentile knockdown
+
+References
+----------
+- Elhajjar, R. (2025). Scientific Reports, 15:25977 (fat-tail
+  statistics from concave knockdown laws).
+- CMH-17-1G, Vol. 1, Ch. 8 (statistical basis values — what this
+  module deliberately does *not* compute).
+"""
+
+from __future__ import annotations
+
+import itertools
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass, field, fields, replace
+from typing import Any
+
+import numpy as np
+from scipy import stats
+from scipy.stats import qmc
+
+from wrinklefe.analysis import (
+    AnalysisConfig,
+    AnalysisResults,
+    WrinkleAnalysis,
+    _resolve_sweep_workers,
+    _sweep_run_one,
+)
+
+__all__ = [
+    "ProbabilisticResults",
+    "probabilistic_analysis",
+]
+
+
+# ----------------------------------------------------------------------
+# Distribution specs
+# ----------------------------------------------------------------------
+
+
+def _to_ppf(spec: Any, field_name: str):
+    """Normalise a distribution spec to a ``ppf(u)`` callable.
+
+    Accepted forms:
+
+    * ``("normal", mean, std)`` — Gaussian; ``std == 0`` degenerates to
+      the constant ``mean``.
+    * ``("uniform", lo, hi)`` — uniform on ``[lo, hi]``.
+    * ``("lognormal", mu, sigma)`` — log-normal where ``mu``/``sigma``
+      are the mean and standard deviation of the *underlying normal*
+      (the same convention as ``numpy.random.Generator.lognormal``).
+    * any object with a ``.ppf`` method — e.g. a frozen
+      ``scipy.stats`` distribution such as ``scipy.stats.norm(0.4,
+      0.05)``.
+
+    Sampling is implemented uniformly as ``ppf(u)`` with ``u`` drawn
+    either i.i.d. uniform (plain Monte-Carlo) or from a Latin-hypercube
+    (stratified), which keeps both methods reproducible from one seed.
+    """
+    if hasattr(spec, "ppf"):
+        return spec.ppf
+    if not (isinstance(spec, tuple) and len(spec) == 3):
+        raise ValueError(
+            f"distribution for {field_name!r} must be a 3-tuple "
+            "('normal'|'uniform'|'lognormal', a, b) or an object with a "
+            f".ppf method (e.g. a frozen scipy.stats distribution); got "
+            f"{spec!r}"
+        )
+    kind, a, b = spec
+    kind = str(kind).lower().strip()
+    a = float(a)
+    b = float(b)
+    if kind == "normal":
+        if b < 0:
+            raise ValueError(
+                f"{field_name!r}: normal std must be >= 0, got {b}"
+            )
+        if b == 0.0:
+            return lambda u: np.full_like(np.asarray(u, dtype=float), a)
+        return stats.norm(loc=a, scale=b).ppf
+    if kind == "uniform":
+        if b < a:
+            raise ValueError(
+                f"{field_name!r}: uniform needs lo <= hi, got ({a}, {b})"
+            )
+        if b == a:
+            return lambda u: np.full_like(np.asarray(u, dtype=float), a)
+        return stats.uniform(loc=a, scale=b - a).ppf
+    if kind == "lognormal":
+        if b < 0:
+            raise ValueError(
+                f"{field_name!r}: lognormal sigma must be >= 0, got {b}"
+            )
+        if b == 0.0:
+            const = float(np.exp(a))
+            return lambda u: np.full_like(
+                np.asarray(u, dtype=float), const
+            )
+        # scipy lognorm(s=sigma, scale=exp(mu)) == numpy lognormal(mu, sigma)
+        return stats.lognorm(s=b, scale=float(np.exp(a))).ppf
+    raise ValueError(
+        f"unknown distribution kind {kind!r} for {field_name!r}; "
+        "expected 'normal', 'uniform' or 'lognormal'"
+    )
+
+
+# ----------------------------------------------------------------------
+# Results container
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class ProbabilisticResults:
+    """Sampled-input propagation of the WrinkleFE analysis.
+
+    All arrays share the sample axis (length ``n_samples``).  The
+    reported percentiles are **model-input propagation** statistics —
+    see the module docstring for why they must not be presented as
+    CMH-17 A-/B-basis values.
+    """
+
+    base_config: AnalysisConfig
+    input_samples: dict[str, np.ndarray]
+    knockdown: np.ndarray
+    strength_MPa: np.ndarray
+    modulus_knockdown: np.ndarray
+    n_samples: int
+    seed: int | None
+    method: str
+    analytical_only: bool = True
+    results: list[AnalysisResults] | None = field(default=None, repr=False)
+
+    # -- statistics ----------------------------------------------------
+
+    def knockdown_percentile(self, q) -> float | np.ndarray:
+        """Percentile(s) of the knockdown sample (``q`` in [0, 100])."""
+        out = np.percentile(self.knockdown, q)
+        return float(out) if np.isscalar(q) else np.asarray(out)
+
+    def strength_percentile(self, q) -> float | np.ndarray:
+        """Percentile(s) of the strength sample (``q`` in [0, 100])."""
+        out = np.percentile(self.strength_MPa, q)
+        return float(out) if np.isscalar(q) else np.asarray(out)
+
+    @property
+    def knockdown_mean(self) -> float:
+        return float(np.mean(self.knockdown))
+
+    @property
+    def knockdown_std(self) -> float:
+        return float(np.std(self.knockdown))
+
+    @property
+    def strength_mean(self) -> float:
+        return float(np.mean(self.strength_MPa))
+
+    @property
+    def strength_std(self) -> float:
+        return float(np.std(self.strength_MPa))
+
+    def summary(self) -> str:
+        """Multi-line text summary of the propagated statistics."""
+        kd_p = np.percentile(self.knockdown, [5.0, 50.0, 95.0])
+        s_p = np.percentile(self.strength_MPa, [5.0, 50.0, 95.0])
+        lines = [
+            "=" * 65,
+            "  WrinkleFE Probabilistic Analysis (input propagation)",
+            "=" * 65,
+            "",
+            f"  Samples:            {self.n_samples} "
+            f"({self.method}, seed={self.seed})",
+            f"  Path:               "
+            f"{'analytical' if self.analytical_only else 'full FE'}",
+            "  Sampled inputs:",
+        ]
+        for name, arr in self.input_samples.items():
+            lines.append(
+                f"    {name:<18} mean={np.mean(arr):.4g}  "
+                f"std={np.std(arr):.4g}  "
+                f"range=[{arr.min():.4g}, {arr.max():.4g}]"
+            )
+        lines += [
+            "",
+            f"  Knockdown:          mean={self.knockdown_mean:.4f}  "
+            f"std={self.knockdown_std:.4f}",
+            f"    percentiles       P5={kd_p[0]:.4f}  P50={kd_p[1]:.4f}  "
+            f"P95={kd_p[2]:.4f}",
+            f"  Strength [MPa]:     mean={self.strength_mean:.1f}  "
+            f"std={self.strength_std:.1f}",
+            f"    percentiles       P5={s_p[0]:.1f}  P50={s_p[1]:.1f}  "
+            f"P95={s_p[2]:.1f}",
+            "",
+            "  NOTE: percentiles above are model-INPUT-propagation",
+            "  statistics (the deterministic model driven by sampled",
+            "  geometry), NOT CMH-17 A-/B-basis allowables, which are",
+            "  tolerance bounds on physical test data. Do not present",
+            "  them as basis values.",
+            "=" * 65,
+        ]
+        return "\n".join(lines)
+
+    # -- optional viz ----------------------------------------------------
+
+    def plot(self, show_strength: bool = False):
+        """Histogram of the knockdown (or strength) sample plus one
+        scatter panel per sampled input for sensitivity screening.
+
+        Returns the matplotlib ``Figure``.  Matplotlib is imported
+        lazily so the stochastic module stays import-light.
+        """
+        import matplotlib.pyplot as plt
+
+        y = self.strength_MPa if show_strength else self.knockdown
+        y_label = (
+            "strength [MPa]" if show_strength else "knockdown factor"
+        )
+        n_inputs = len(self.input_samples)
+        fig, axes = plt.subplots(
+            1, 1 + n_inputs, figsize=(4.0 * (1 + n_inputs), 3.4),
+            squeeze=False,
+        )
+        ax0 = axes[0][0]
+        ax0.hist(y, bins=min(40, max(10, self.n_samples // 25)),
+                 color="#4878CF", edgecolor="white")
+        for q, ls in ((5.0, ":"), (50.0, "--"), (95.0, ":")):
+            ax0.axvline(np.percentile(y, q), color="k", linestyle=ls,
+                        linewidth=1.0)
+        ax0.set_xlabel(y_label)
+        ax0.set_ylabel("count")
+        ax0.set_title(f"{y_label} (P5/P50/P95 marked)")
+
+        for k, (name, x) in enumerate(self.input_samples.items()):
+            ax = axes[0][1 + k]
+            ax.plot(x, y, ".", markersize=3, alpha=0.5, color="#4878CF")
+            ax.set_xlabel(name)
+            ax.set_ylabel(y_label)
+            ax.set_title(f"{y_label} vs {name}")
+        fig.tight_layout()
+        return fig
+
+
+# ----------------------------------------------------------------------
+# Driver
+# ----------------------------------------------------------------------
+
+
+def probabilistic_analysis(
+    base_config: AnalysisConfig,
+    distributions: dict[str, Any],
+    n_samples: int = 1000,
+    seed: int | None = None,
+    method: str = "lhs",
+    analytical_only: bool = True,
+    n_workers: int = 1,
+    keep_results: bool = False,
+) -> ProbabilisticResults:
+    """Propagate input distributions through the wrinkle analysis.
+
+    Parameters
+    ----------
+    base_config : AnalysisConfig
+        Deterministic baseline; every non-sampled field is held at its
+        value here.
+    distributions : dict
+        Maps :class:`AnalysisConfig` field names to distribution specs:
+        ``("normal", mean, std)``, ``("uniform", lo, hi)``,
+        ``("lognormal", mu, sigma)`` (parameters of the underlying
+        normal), or any object with a ``.ppf`` method (e.g. a frozen
+        ``scipy.stats`` distribution).
+    n_samples : int
+        Number of samples (>= 1).  The analytical path runs ~1000
+        samples in seconds.
+    seed : int, optional
+        Seed for the sampler.  A fixed seed makes the whole analysis
+        reproducible (same samples, same percentiles) for both methods.
+    method : str
+        ``"lhs"`` (default) — Latin-hypercube stratification, lower
+        variance per sample; ``"mc"`` — plain Monte-Carlo.
+    analytical_only : bool
+        Run only the analytical path per sample (default; recommended).
+        ``False`` runs the full FE pipeline per sample — prohibitive
+        beyond small ``n_samples``; combine with ``n_workers``.
+    n_workers : int
+        Worker processes for the per-sample runs (``0`` = all cores,
+        default ``1`` = in-process), reusing the sweep parallelism of
+        issue #260.  Sampling itself always happens in the parent, so
+        results are identical for any worker count.
+    keep_results : bool
+        Also retain the full per-sample :class:`AnalysisResults` list
+        on the returned object (memory scales with ``n_samples``;
+        mostly useful with ``analytical_only=False``).
+
+    Returns
+    -------
+    ProbabilisticResults
+        Sample arrays, summary statistics and percentile accessors.
+
+    Raises
+    ------
+    ValueError
+        For unknown config fields, malformed distribution specs, or
+        sampled values that fail :class:`AnalysisConfig` validation
+        (e.g. a normal amplitude distribution wide enough to produce
+        negative draws) — fix the distribution rather than relying on
+        silent clipping.
+    """
+    if not isinstance(n_samples, int) or isinstance(n_samples, bool):
+        raise ValueError(f"n_samples must be an int >= 1, got {n_samples!r}")
+    if n_samples < 1:
+        raise ValueError(f"n_samples must be >= 1, got {n_samples}")
+    if method not in ("lhs", "mc"):
+        raise ValueError(
+            f"method must be 'lhs' or 'mc', got {method!r}"
+        )
+    if not distributions:
+        raise ValueError(
+            "distributions must map at least one AnalysisConfig field "
+            "to a distribution spec"
+        )
+    valid_field_names = {f.name for f in fields(base_config)}
+    for name in distributions:
+        if name not in valid_field_names:
+            raise ValueError(
+                f"AnalysisConfig has no field {name!r} to sample"
+            )
+    n_workers = _resolve_sweep_workers(n_workers)
+
+    names = sorted(distributions.keys())
+    ppfs = {name: _to_ppf(distributions[name], name) for name in names}
+
+    # Uniform hypercube samples: stratified (LHS) or i.i.d. (MC), then
+    # mapped through each marginal ppf.  Inputs are sampled
+    # independently — joint/correlated inputs can be expressed by
+    # passing a frozen scipy distribution per field only if marginals
+    # suffice; correlation support is out of scope here.
+    d = len(names)
+    if method == "lhs":
+        sampler = qmc.LatinHypercube(d=d, seed=seed)
+        u = sampler.random(n=n_samples)  # (n, d) in (0, 1)
+    else:
+        rng = np.random.default_rng(seed)
+        u = rng.random((n_samples, d))
+    # Guard the open interval so ppf never sees exactly 0 or 1.
+    tiny = np.finfo(float).tiny
+    u = np.clip(u, tiny, 1.0 - 1e-16)
+
+    input_samples = {
+        name: np.asarray(ppfs[name](u[:, j]), dtype=float)
+        for j, name in enumerate(names)
+    }
+
+    # Build one config per sample; a validation failure points at the
+    # offending sample and field values.
+    configs: list[AnalysisConfig] = []
+    for i in range(n_samples):
+        overrides: dict[str, Any] = {
+            name: float(input_samples[name][i]) for name in names
+        }
+        try:
+            configs.append(replace(base_config, **overrides))
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f"sample {i} ({overrides}) failed AnalysisConfig "
+                f"validation: {exc}. Adjust the distribution (e.g. "
+                "tighten the std or switch to a lognormal) so draws "
+                "stay in the physical range."
+            ) from exc
+
+    # Run the samples — sequentially, or over the #260 process pool.
+    if n_workers == 1:
+        results = [
+            WrinkleAnalysis(cfg).run(analytical_only=analytical_only)
+            for cfg in configs
+        ]
+    else:
+        executor = ProcessPoolExecutor(max_workers=n_workers)
+        try:
+            results = list(
+                executor.map(
+                    _sweep_run_one,
+                    configs,
+                    itertools.repeat(analytical_only),
+                )
+            )
+        except BaseException:
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
+        else:
+            executor.shutdown(wait=True)
+
+    knockdown = np.array(
+        [r.analytical_knockdown for r in results], dtype=float
+    )
+    strength = np.array(
+        [r.analytical_strength_MPa for r in results], dtype=float
+    )
+    modulus = np.array(
+        [r.analytical_modulus_knockdown for r in results], dtype=float
+    )
+
+    return ProbabilisticResults(
+        base_config=base_config,
+        input_samples=input_samples,
+        knockdown=knockdown,
+        strength_MPa=strength,
+        modulus_knockdown=modulus,
+        n_samples=n_samples,
+        seed=seed,
+        method=method,
+        analytical_only=analytical_only,
+        results=list(results) if keep_results else None,
+    )

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -1,0 +1,253 @@
+"""Monte-Carlo / LHS uncertainty propagation (issue #301).
+
+``probabilistic_analysis`` samples AnalysisConfig fields from user
+distributions, runs the analytical path per sample, and reports
+percentile knockdowns/strengths — model-input propagation statistics,
+deliberately *not* CMH-17 basis values (the summary carries the
+disclaimer, pinned here).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.stochastic import probabilistic_analysis
+
+
+def _base(**overrides) -> AnalysisConfig:
+    cfg = dict(amplitude=0.4, wavelength=16.0, width=12.0,
+               analytical_only=True)
+    cfg.update(overrides)
+    return AnalysisConfig(**cfg)
+
+
+def _ud_gate_base() -> AnalysisConfig:
+    from wrinklefe.core.penetration_gate import GATE_LI2025_VACBAG
+
+    return AnalysisConfig(
+        amplitude=0.75, wavelength=12.9, width=6.45,
+        angles=[0.0] * 14, ply_thickness=0.44, morphology="graded",
+        penetration_gate=GATE_LI2025_VACBAG, analytical_only=True,
+    )
+
+
+class TestReproducibilityAndDegeneracy:
+
+    def test_fixed_seed_reproduces_everything(self):
+        kwargs = dict(
+            distributions={"amplitude": ("normal", 0.4, 0.05)},
+            n_samples=64, seed=42,
+        )
+        a = probabilistic_analysis(_base(), **kwargs)
+        b = probabilistic_analysis(_base(), **kwargs)
+        np.testing.assert_array_equal(a.knockdown, b.knockdown)
+        np.testing.assert_array_equal(a.strength_MPa, b.strength_MPa)
+        np.testing.assert_array_equal(
+            a.input_samples["amplitude"], b.input_samples["amplitude"]
+        )
+
+    @pytest.mark.parametrize("method", ["lhs", "mc"])
+    @pytest.mark.parametrize(
+        "dist",
+        [("normal", 0.4, 0.0), ("uniform", 0.4, 0.4), ("lognormal",
+                                                       float(np.log(0.4)),
+                                                       0.0)],
+    )
+    def test_zero_variance_reproduces_deterministic(self, method, dist):
+        """Degenerate distributions == the deterministic run, exactly."""
+        prob = probabilistic_analysis(
+            _base(), {"amplitude": dist}, n_samples=8, seed=1,
+            method=method,
+        )
+        det = WrinkleAnalysis(
+            _base(amplitude=0.4)
+        ).run(analytical_only=True)
+        # lognormal exp(log(0.4)) reproduces 0.4 to float rounding.
+        rtol = 0.0 if dist[0] != "lognormal" else 1e-12
+        np.testing.assert_allclose(
+            prob.knockdown, det.analytical_knockdown, rtol=rtol
+        )
+        np.testing.assert_allclose(
+            prob.strength_MPa, det.analytical_strength_MPa, rtol=rtol
+        )
+
+
+class TestStatistics:
+
+    def test_percentiles_monotone_and_bracket_median(self):
+        prob = probabilistic_analysis(
+            _ud_gate_base(),
+            {"amplitude": ("normal", 0.75, 0.08),
+             "wavelength": ("normal", 12.9, 1.0)},
+            n_samples=400, seed=7,
+        )
+        p5, p50, p95 = prob.knockdown_percentile([5.0, 50.0, 95.0])
+        assert p5 < p50 < p95
+        s5, s50, s95 = prob.strength_percentile([5.0, 50.0, 95.0])
+        assert s5 < s50 < s95
+        # Nonzero variance must actually spread the output.
+        assert prob.knockdown_std > 0.01
+
+    def test_amplitude_knockdown_anticorrelated(self):
+        """Physical sanity: larger sampled amplitude -> lower knockdown."""
+        prob = probabilistic_analysis(
+            _ud_gate_base(), {"amplitude": ("normal", 0.75, 0.08)},
+            n_samples=300, seed=11,
+        )
+        r = np.corrcoef(prob.input_samples["amplitude"], prob.knockdown)
+        assert r[0, 1] < -0.9
+
+    def test_summary_carries_basis_value_disclaimer(self):
+        prob = probabilistic_analysis(
+            _base(), {"amplitude": ("normal", 0.4, 0.03)},
+            n_samples=16, seed=0,
+        )
+        text = prob.summary()
+        assert "NOT CMH-17 A-/B-basis" in text
+        assert "P5=" in text and "P95=" in text
+
+    def test_scipy_frozen_distribution_accepted(self):
+        frozen = stats.norm(loc=0.4, scale=0.05)
+        a = probabilistic_analysis(
+            _base(), {"amplitude": frozen}, n_samples=64, seed=42,
+        )
+        b = probabilistic_analysis(
+            _base(), {"amplitude": ("normal", 0.4, 0.05)},
+            n_samples=64, seed=42,
+        )
+        np.testing.assert_allclose(a.knockdown, b.knockdown, rtol=1e-12)
+
+    def test_keep_results_returns_full_objects(self):
+        prob = probabilistic_analysis(
+            _base(), {"amplitude": ("normal", 0.4, 0.03)},
+            n_samples=5, seed=0, keep_results=True,
+        )
+        assert prob.results is not None and len(prob.results) == 5
+        assert prob.results[0].analytical_knockdown == prob.knockdown[0]
+
+
+class TestParallelAndPlot:
+
+    def test_parallel_identical_to_sequential(self):
+        """Sampling happens in the parent, so worker count cannot change
+        the numbers (real cross-process run)."""
+        kwargs = dict(
+            distributions={"amplitude": ("normal", 0.75, 0.08)},
+            n_samples=60, seed=3,
+        )
+        seq = probabilistic_analysis(_ud_gate_base(), **kwargs, n_workers=1)
+        par = probabilistic_analysis(_ud_gate_base(), **kwargs, n_workers=2)
+        np.testing.assert_array_equal(seq.knockdown, par.knockdown)
+
+    def test_plot_returns_figure(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        prob = probabilistic_analysis(
+            _base(), {"amplitude": ("normal", 0.4, 0.03)},
+            n_samples=32, seed=0,
+        )
+        fig = prob.plot()
+        # Histogram panel + one scatter per sampled input.
+        assert len(fig.axes) == 2
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+
+class TestValidation:
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValueError, match="no field"):
+            probabilistic_analysis(
+                _base(), {"not_a_field": ("normal", 1.0, 0.1)},
+                n_samples=4,
+            )
+
+    def test_malformed_spec_rejected(self):
+        with pytest.raises(ValueError, match="3-tuple"):
+            probabilistic_analysis(
+                _base(), {"amplitude": ("normal", 0.4)}, n_samples=4,
+            )
+        with pytest.raises(ValueError, match="unknown distribution"):
+            probabilistic_analysis(
+                _base(), {"amplitude": ("weibull", 0.4, 0.1)}, n_samples=4,
+            )
+
+    def test_unphysical_sample_fails_loudly(self):
+        """A distribution wide enough to draw an invalid value must
+        raise a targeted error, not silently clip."""
+        with pytest.raises(ValueError, match="failed AnalysisConfig"):
+            probabilistic_analysis(
+                _base(), {"wavelength": ("normal", 1.0, 5.0)},
+                n_samples=64, seed=0,
+            )
+
+    @pytest.mark.parametrize("bad_n", [0, -1, 2.5])
+    def test_bad_n_samples_rejected(self, bad_n):
+        with pytest.raises(ValueError, match="n_samples"):
+            probabilistic_analysis(
+                _base(), {"amplitude": ("normal", 0.4, 0.01)},
+                n_samples=bad_n,
+            )
+
+    def test_bad_method_rejected(self):
+        with pytest.raises(ValueError, match="method"):
+            probabilistic_analysis(
+                _base(), {"amplitude": ("normal", 0.4, 0.01)},
+                n_samples=4, method="sobol",
+            )
+
+    def test_empty_distributions_rejected(self):
+        with pytest.raises(ValueError, match="at least one"):
+            probabilistic_analysis(_base(), {}, n_samples=4)
+
+
+class TestModulusVectorizationEquivalence:
+    """The batched `_laminate_modulus_knockdown` (the enabler for
+    interactive sampling) must match the original per-(ply, x) loop."""
+
+    def test_batched_matches_loop_reference(self):
+        import math
+
+        from wrinklefe.analysis import (
+            _laminate_modulus_knockdown,
+            _plane_stress_qbar_tilted,
+        )
+
+        rng = np.random.default_rng(5)
+        n_w, n_x, n_p = 2, 40, 6
+        slope_field = rng.uniform(-0.3, 0.3, (n_w, n_x))
+        ply_decays = rng.uniform(0.0, 1.0, (n_p, n_w, n_x))
+        angles = [0.0, 45.0, -45.0, 90.0, 30.0, 0.0]
+        # A representative orthotropic 3D stiffness from the library.
+        from wrinklefe.core.laminate import Laminate
+        from wrinklefe.core.material import MaterialLibrary
+
+        mat = MaterialLibrary().get("IM7_8552")
+        lam = Laminate.from_angles(angles, mat, ply_thickness=0.183)
+        C = mat.stiffness_matrix
+        E_x0 = lam.Ex
+
+        got = _laminate_modulus_knockdown(
+            slope_field, ply_decays, angles, C, 0.183, E_x0
+        )
+
+        # Original loop implementation as the oracle.
+        phis = [math.radians(a) for a in angles]
+        inv_E = np.empty(n_x)
+        for xi in range(n_x):
+            a_mat = np.zeros((3, 3))
+            for p, phi in enumerate(phis):
+                slope_p = float(
+                    np.dot(slope_field[:, xi], ply_decays[p, :, xi])
+                )
+                theta = math.atan(abs(slope_p))
+                a_mat += _plane_stress_qbar_tilted(C, phi, theta) * 0.183
+            inv_E[xi] = np.linalg.inv(a_mat)[0, 0] * (n_p * 0.183)
+        expected = float(1.0 / np.mean(inv_E) / E_x0)
+
+        assert got == pytest.approx(expected, rel=1e-10)


### PR DESCRIPTION
## Linked issue

Fixes #301

## Summary

Every WrinkleFE output was a deterministic point estimate for one assumed geometry, but in the NCR-disposition use case the inputs are uncertain — amplitude and wavelength come from a measurement with error. `wrinklefe.stochastic.probabilistic_analysis` samples `AnalysisConfig` fields from user distributions and reports percentile knockdowns/strengths, turning "the model says 0.64" into "P5–P95 = 0.59–0.86 given my measurement uncertainty".

**The feature:**
- Distributions: `("normal", m, s)`, `("uniform", lo, hi)`, `("lognormal", mu, sigma)`, or any frozen `scipy.stats` object. Sampling is ppf-based over a Latin-hypercube (default) or i.i.d. uniforms, so **fixed seeds reproduce both methods exactly**.
- `ProbabilisticResults`: sample arrays, percentile accessors, mean±std, a histogram + per-input sensitivity-scatter `plot()`, and a `summary()` that explicitly labels the output as **model-input-propagation statistics — not CMH-17 A-/B-basis allowables** (the distinction is documented in the module docstring, the summary text, and the README, and pinned by test).
- Degenerate (zero-variance) distributions reproduce the deterministic result **exactly**; draws that fail `AnalysisConfig` validation raise a targeted error naming the sample instead of silently clipping; `n_workers` reuses the #260 process pool (sampling stays in the parent, so results are worker-count-invariant — regression-tested cross-process).

**The enabler:** the "1000 samples in seconds" acceptance criterion was unreachable because every *multidirectional* analytical run took ~1.2 s — a per-(ply, x-station) Python loop in `_laminate_modulus_knockdown` (12,000 6×6 rotate/condense calls). The wrinkle-tilt rotation and plane-stress condensation are now batched over the whole (ply, x) grid: the in-plane rotation is computed once per ply, and the rotation-group identity `T_σ(θ)⁻¹ = T_σ(−θ)` replaces the batched 6×6 solve. **1.18 s → 22 ms (~52×) per analytical run**, results equal to the original loop (kept in the test file as the oracle, `rel=1e-10`) and **zero drift** on every pinned ledger baseline. Every analytical caller in the package benefits.

**Measured:** 1000 samples in **0.7 s** for the UD/penetration-gate configuration (the core NCR case, 2 sampled inputs); ~20 s for a 24-ply multidirectional layup sequentially, seconds with `n_workers`.

### #301 acceptance criteria
- [x] `probabilistic_analysis` returns percentile knockdowns/strengths from sampled parameters, reproducibly under a fixed seed
- [x] 1000 analytical samples stay interactive (0.7 s UD/gate; multidirectional made feasible by the 52× modulus vectorization + `n_workers`)
- [x] Docs explain the percentiles are model-input propagation and explicitly distinguish them from CMH-17 A-/B-basis values (README call-out box + module docstring + `summary()` disclaimer, test-pinned)
- [x] Unit tests: zero-variance distributions reproduce the deterministic result exactly (all three tuple kinds × both methods); nonzero variance yields monotone percentile ordering; plus amplitude–knockdown anticorrelation, frozen-scipy equivalence, loud unphysical-draw failure, parallel invariance, and the batched-vs-loop modulus oracle

## Checklist

- [x] Tests added or updated for the change (23 new tests; 108 integration + 73 suite tests green on the touched analytical surface)
- [x] `pytest` green on touched surfaces
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (54 files)
- [x] Docs updated (README "Uncertainty propagation" section with the basis-value warning; `docs/api/stochastic.rst`; sphinx `-W` clean)
- [x] `CHANGELOG.md` `[Unreleased]` updated (two Added entries; no Numerical-results entry — ledger zero-drift, modulus results loop-equal)
- [x] `python scripts/validate.py` — all pinned baselines match (zero drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_