### PR TITLE
Add through-thickness cross-section viz; move CZM controls to Expert mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Streamlit app — **Through-thickness cross-section** on the Configure
+  tab: a new panel that draws the deformed ply stack in the (x, z) plane
+  so users can see how the wrinkle manifests through the laminate
+  thickness. It reuses the real `WrinkleConfiguration.apply_to_nodes`
+  field the FE mesh uses, so the picture faithfully tracks the active
+  morphology, its through-thickness amplitude decay, the dual-wrinkle
+  phase offset, and any in-plane amplitude profile. Each ply is a band
+  coloured by fibre angle (the same hue map as the layup visualizer),
+  with the wrinkle-interface plies outlined for the dual morphologies.
 - Monte-Carlo / Latin-hypercube uncertainty propagation (issue #301):
   `wrinklefe.stochastic.probabilistic_analysis(base_config,
   distributions, n_samples, seed, method="lhs"|"mc")` samples
@@ -293,6 +302,12 @@ version produced a given file.
   71–100 % of elements on typical thin-ply meshes (default runs are now
   quiet; genuinely anomalous elements still warn).
 - CI enforces the full Ruff ruleset and `mypy` over the whole tree.
+- Streamlit app — the **Cohesive Zone Modeling** sidebar controls now
+  render only in **Expert mode**. CZM requires the full nonlinear FE
+  solve, which is itself expert-only (novice mode forces
+  `analytical_only=True`), so the control now sits with the other expert
+  FE settings instead of the simplified novice sidebar. The analytical
+  path and CZM behaviour are unchanged.
 
 ### Removed
 - The dead `export` optional-dependency extra (`meshio` was never

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ import sys
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Literal, cast
 
 import matplotlib
 
@@ -27,6 +28,7 @@ matplotlib.use("Agg")  # headless backend; required on Streamlit Cloud
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import streamlit as st  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
 
 # Make the src-layout package importable on Streamlit Cloud, which does not
 # pip-install the local repo.
@@ -40,6 +42,7 @@ from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis  # noqa: E402
 from wrinklefe.core.layup import parse_layup  # noqa: E402
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial  # noqa: E402
 from wrinklefe.core.mesh import mesh_shear_diagnostics  # noqa: E402
+from wrinklefe.core.morphology import WrinkleConfiguration  # noqa: E402
 from wrinklefe.core.wrinkle import GaussianSinusoidal  # noqa: E402
 from wrinklefe.io.export import (  # noqa: E402
     build_analysis_summary,
@@ -397,6 +400,112 @@ def _morphology_schematic(
     fig.savefig(buf, format="png", bbox_inches="tight", facecolor="white")
     plt.close(fig)
     return buf.getvalue()
+
+
+def _through_thickness_cross_section(
+    *,
+    morphology: str,
+    amplitude: float,
+    wavelength: float,
+    width: float,
+    angles: list[float],
+    ply_thickness: float,
+    decay_floor: float,
+    amplitude_profile: str,
+    amplitude_profile_decay_length: float | None,
+    amplitude_profile_axis: str,
+) -> Figure:
+    """Deformed through-thickness (x–z) cross-section of the wrinkled stack.
+
+    Unlike the sidebar cartoon (:func:`_morphology_schematic`, a stylised
+    line drawing), this reuses the *real*
+    :class:`~wrinklefe.core.morphology.WrinkleConfiguration` deformation
+    field — the same one the FE mesh sees via ``apply_to_nodes`` — so the
+    section faithfully tracks the active morphology, its through-thickness
+    amplitude decay, the dual-wrinkle phase offset, and any in-plane
+    amplitude profile. Each ply is drawn as a filled band whose
+    mid-surface follows ``z0(p) + dz(x, p)``; the wrinkle-interface plies
+    are outlined so the reader can see where the defect is seeded and how
+    its amplitude fades toward the free surfaces.
+
+    The wrinkle profiles are centred at ``x = 0`` (matching the Geometry
+    tab's mid-surface plot) and the interfaces are resolved exactly as
+    :class:`~wrinklefe.analysis.AnalysisConfig` resolves them
+    (``mid = n_plies // 2``), so the picture matches what an analysis run
+    with these inputs would build.
+    """
+    n_plies = len(angles)
+    prof = GaussianSinusoidal(
+        amplitude=float(amplitude),
+        wavelength=float(wavelength),
+        width=float(width),
+        center=0.0,
+    )
+    # Interface resolution mirrors AnalysisConfig.__post_init__ so the
+    # cross-section lines up with an actual analysis of the same inputs.
+    mid = n_plies // 2
+    i1 = max(0, mid - 1)
+    i2 = min(n_plies - 1, mid)
+    wc = WrinkleConfiguration.from_morphology_name(
+        morphology,
+        prof,
+        interface1=i1,
+        interface2=i2,
+        decay_floor=decay_floor,
+        amplitude_profile=cast(
+            Literal["constant", "gaussian", "linear"], amplitude_profile
+        ),
+        amplitude_profile_decay_length=amplitude_profile_decay_length,
+        amplitude_profile_axis=cast(
+            Literal["x", "y"], amplitude_profile_axis
+        ),
+    )
+
+    # x-window matches the mid-surface plot (±3·width captures the
+    # Gaussian envelope). Deform every ply centreline in a single
+    # vectorised ``apply_to_nodes`` call.
+    x_half = 3.0 * max(float(width), 1e-6)
+    n_x = 400
+    x = np.linspace(-x_half, x_half, n_x)
+    t = float(ply_thickness)
+    total_thickness = n_plies * t
+    z0 = (np.arange(n_plies) + 0.5) * t - total_thickness / 2.0
+
+    x_flat = np.tile(x, n_plies)
+    ply_ids = np.repeat(np.arange(n_plies), n_x)
+    z0_flat = np.repeat(z0, n_x)
+    nodes = np.column_stack([x_flat, np.zeros_like(x_flat), z0_flat])
+    deformed = wc.apply_to_nodes(nodes, ply_ids, n_plies)
+    z_def = deformed[:, 2].reshape(n_plies, n_x)
+
+    cmap = plt.get_cmap("twilight")
+    fig, ax = plt.subplots(figsize=(8, 3.4), dpi=110)
+    for p in range(n_plies):
+        colour = cmap(((angles[p] % 180) + 180) % 180 / 180)
+        ax.fill_between(
+            x, z_def[p] - t / 2, z_def[p] + t / 2,
+            color=colour, edgecolor="white", linewidth=0.25,
+        )
+
+    # Outline the wrinkle-interface plies for the dual-wrinkle
+    # morphologies (stack/convex/concave), which seed the defect at a
+    # specific pair of interfaces. The single-wrinkle modes
+    # (uniform/graded) displace a broad band, so a single outline would
+    # be misleading — their shape is already read from the bands.
+    if morphology in ("stack", "convex", "concave"):
+        for p in (i1, i2):
+            ax.plot(x, z_def[p] + t / 2, color="#d62728", linewidth=1.1)
+            ax.plot(x, z_def[p] - t / 2, color="#d62728", linewidth=1.1)
+
+    ax.set_xlim(-x_half, x_half)
+    ax.set_xlabel("x [mm]")
+    ax.set_ylabel("z through thickness [mm]")
+    ax.set_title(
+        f"{morphology.capitalize()} wrinkle — deformed ply stack "
+        f"({n_plies} plies)"
+    )
+    fig.tight_layout()
+    return fig
 
 
 # ---------------------------------------------------------------------------
@@ -853,120 +962,140 @@ with st.sidebar:
         )
 
     # ------------------------------------------------------------------
-    # Cohesive zone modelling (delamination prediction). Collapsed by
-    # default so the existing UI flow is unchanged for users who don't
-    # want CZM. When the checkbox is ticked, the FE solve switches from
-    # the linear StaticSolver to Newton-Raphson and zero-thickness
+    # Cohesive zone modelling (delamination prediction). Expert-mode only:
+    # CZM requires the full nonlinear FE solve (Newton-Raphson), and the FE
+    # solve itself is gated behind Expert mode (novice mode forces
+    # ``analytical_only=True``), so the control belongs alongside the other
+    # expert FE settings rather than in the simplified novice sidebar.
+    # Collapsed by default so the expert flow is unchanged for users who
+    # don't want CZM. When the checkbox is ticked, the FE solve switches
+    # from the linear StaticSolver to Newton-Raphson and zero-thickness
     # cohesive elements are inserted at the requested ply interfaces.
     # ------------------------------------------------------------------
-    with st.expander(
-        "Cohesive Zone Modeling (delamination)", expanded=False,
-    ):
-        enable_czm = st.checkbox(
-            "Enable Cohesive Zone Modeling (delamination prediction)",
-            value=DEFAULT_ENABLE_CZM,
-            key="sb_enable_czm",
-            help=(
-                "Adds zero-thickness cohesive interface elements at ply "
-                "boundaries. When enabled, the FE solve switches from "
-                "linear (StaticSolver) to nonlinear Newton-Raphson. "
-                "Run time is ~5-20x longer; produces damage field "
-                "output and energy dissipation per interface."
-            ),
-        )
+    if expert_mode:
+        with st.expander(
+            "Cohesive Zone Modeling (delamination)", expanded=False,
+        ):
+            enable_czm = st.checkbox(
+                "Enable Cohesive Zone Modeling (delamination prediction)",
+                value=DEFAULT_ENABLE_CZM,
+                key="sb_enable_czm",
+                help=(
+                    "Adds zero-thickness cohesive interface elements at ply "
+                    "boundaries. When enabled, the FE solve switches from "
+                    "linear (StaticSolver) to nonlinear Newton-Raphson. "
+                    "Run time is ~5-20x longer; produces damage field "
+                    "output and energy dissipation per interface. Requires "
+                    "the full FE solve (untick *Analytical only* under "
+                    "Advanced — mesh & solver)."
+                ),
+            )
 
-        # Seed the toughness / strength inputs from the chosen material
-        # so users only have to override values they care about. When
-        # the material exposes no default for a quantity, fall back to
-        # 0.0 — AnalysisConfig will then refuse to run unless the user
-        # supplies a non-zero override (matching the API contract).
+            # Seed the toughness / strength inputs from the chosen material
+            # so users only have to override values they care about. When
+            # the material exposes no default for a quantity, fall back to
+            # 0.0 — AnalysisConfig will then refuse to run unless the user
+            # supplies a non-zero override (matching the API contract).
+            _mat_seed = OrthotropicMaterial.from_dict(material_dict)
+            _gic_seed = float(_mat_seed.GIc) if _mat_seed.GIc is not None else 0.30
+            _giic_seed = float(_mat_seed.GIIc) if _mat_seed.GIIc is not None else 0.80
+            _sigma_seed = float(_mat_seed.sigma_max)
+            _tau_seed = float(_mat_seed.tau_max)
+
+            if enable_czm:
+                czm_GIc = st.number_input(
+                    "Mode-I toughness G_Ic [N/mm]",
+                    min_value=0.0, value=_gic_seed, step=0.01,
+                    format="%.4f", key="sb_czm_GIc",
+                    help=(
+                        "Mode-I (opening) fracture toughness. Default seeded "
+                        "from the selected material's library value."
+                    ),
+                )
+                czm_GIIc = st.number_input(
+                    "Mode-II toughness G_IIc [N/mm]",
+                    min_value=0.0, value=_giic_seed, step=0.01,
+                    format="%.4f", key="sb_czm_GIIc",
+                    help=(
+                        "Mode-II (shear) fracture toughness. Default seeded "
+                        "from the selected material's library value."
+                    ),
+                )
+                czm_sigma_max = st.number_input(
+                    "Mode-I peak strength σ_max [MPa]",
+                    min_value=0.0, value=_sigma_seed, step=1.0,
+                    format="%.1f", key="sb_czm_sigma_max",
+                    help="Peak normal traction at which interface damage initiates.",
+                )
+                czm_tau_max = st.number_input(
+                    "Mode-II peak strength τ_max [MPa]",
+                    min_value=0.0, value=_tau_seed, step=1.0,
+                    format="%.1f", key="sb_czm_tau_max",
+                    help="Peak shear traction at which interface damage initiates.",
+                )
+                czm_interfaces_choice = st.selectbox(
+                    "Interface placement",
+                    ["near_crest", "all"],
+                    index=["near_crest", "all"].index(DEFAULT_CZM_INTERFACES),
+                    key="sb_czm_interfaces",
+                    help=(
+                        "*near_crest* (default) inserts cohesive elements at "
+                        "the single ply interface closest to the wrinkle "
+                        "peak. *all* inserts cohesive elements at every "
+                        "interior ply interface (slower)."
+                    ),
+                )
+                czm_load_increments = st.number_input(
+                    "Newton load increments",
+                    min_value=5, max_value=100,
+                    value=int(DEFAULT_CZM_LOAD_INCREMENTS), step=1,
+                    key="sb_czm_load_increments",
+                    help=(
+                        "Number of incremental load steps used by the "
+                        "Newton-Raphson solver. More increments improve "
+                        "robustness for stiff damage problems at the cost "
+                        "of run time."
+                    ),
+                )
+                czm_newton_tol = st.number_input(
+                    "Newton residual tolerance",
+                    min_value=1.0e-8, max_value=1.0e-2,
+                    value=float(DEFAULT_CZM_NEWTON_TOL),
+                    step=1.0e-5, format="%.1e",
+                    key="sb_czm_newton_tol",
+                    help=(
+                        "Relative residual tolerance for Newton convergence "
+                        "at each load increment."
+                    ),
+                )
+                st.caption(
+                    ":hourglass_flowing_sand: CZM run time is typically "
+                    "5–20x the linear FE path. Use a small mesh "
+                    "(nx ≤ 8) for first explorations."
+                )
+            else:
+                # Defaults still need to be defined so the run handler can
+                # reference them unconditionally.
+                czm_GIc = _gic_seed
+                czm_GIIc = _giic_seed
+                czm_sigma_max = _sigma_seed
+                czm_tau_max = _tau_seed
+                czm_interfaces_choice = DEFAULT_CZM_INTERFACES
+                czm_load_increments = DEFAULT_CZM_LOAD_INCREMENTS
+                czm_newton_tol = DEFAULT_CZM_NEWTON_TOL
+    else:
+        # Novice path: CZM is unavailable because the FE solve it depends
+        # on is expert-only. Define the variables the run handler
+        # references unconditionally so the analytical run still works.
+        enable_czm = False
         _mat_seed = OrthotropicMaterial.from_dict(material_dict)
-        _gic_seed = float(_mat_seed.GIc) if _mat_seed.GIc is not None else 0.30
-        _giic_seed = float(_mat_seed.GIIc) if _mat_seed.GIIc is not None else 0.80
-        _sigma_seed = float(_mat_seed.sigma_max)
-        _tau_seed = float(_mat_seed.tau_max)
-
-        if enable_czm:
-            czm_GIc = st.number_input(
-                "Mode-I toughness G_Ic [N/mm]",
-                min_value=0.0, value=_gic_seed, step=0.01,
-                format="%.4f", key="sb_czm_GIc",
-                help=(
-                    "Mode-I (opening) fracture toughness. Default seeded "
-                    "from the selected material's library value."
-                ),
-            )
-            czm_GIIc = st.number_input(
-                "Mode-II toughness G_IIc [N/mm]",
-                min_value=0.0, value=_giic_seed, step=0.01,
-                format="%.4f", key="sb_czm_GIIc",
-                help=(
-                    "Mode-II (shear) fracture toughness. Default seeded "
-                    "from the selected material's library value."
-                ),
-            )
-            czm_sigma_max = st.number_input(
-                "Mode-I peak strength σ_max [MPa]",
-                min_value=0.0, value=_sigma_seed, step=1.0,
-                format="%.1f", key="sb_czm_sigma_max",
-                help="Peak normal traction at which interface damage initiates.",
-            )
-            czm_tau_max = st.number_input(
-                "Mode-II peak strength τ_max [MPa]",
-                min_value=0.0, value=_tau_seed, step=1.0,
-                format="%.1f", key="sb_czm_tau_max",
-                help="Peak shear traction at which interface damage initiates.",
-            )
-            czm_interfaces_choice = st.selectbox(
-                "Interface placement",
-                ["near_crest", "all"],
-                index=["near_crest", "all"].index(DEFAULT_CZM_INTERFACES),
-                key="sb_czm_interfaces",
-                help=(
-                    "*near_crest* (default) inserts cohesive elements at "
-                    "the single ply interface closest to the wrinkle "
-                    "peak. *all* inserts cohesive elements at every "
-                    "interior ply interface (slower)."
-                ),
-            )
-            czm_load_increments = st.number_input(
-                "Newton load increments",
-                min_value=5, max_value=100,
-                value=int(DEFAULT_CZM_LOAD_INCREMENTS), step=1,
-                key="sb_czm_load_increments",
-                help=(
-                    "Number of incremental load steps used by the "
-                    "Newton-Raphson solver. More increments improve "
-                    "robustness for stiff damage problems at the cost "
-                    "of run time."
-                ),
-            )
-            czm_newton_tol = st.number_input(
-                "Newton residual tolerance",
-                min_value=1.0e-8, max_value=1.0e-2,
-                value=float(DEFAULT_CZM_NEWTON_TOL),
-                step=1.0e-5, format="%.1e",
-                key="sb_czm_newton_tol",
-                help=(
-                    "Relative residual tolerance for Newton convergence "
-                    "at each load increment."
-                ),
-            )
-            st.caption(
-                ":hourglass_flowing_sand: CZM run time is typically "
-                "5–20x the linear FE path. Use a small mesh "
-                "(nx ≤ 8) for first explorations."
-            )
-        else:
-            # Defaults still need to be defined so the run handler can
-            # reference them unconditionally.
-            czm_GIc = _gic_seed
-            czm_GIIc = _giic_seed
-            czm_sigma_max = _sigma_seed
-            czm_tau_max = _tau_seed
-            czm_interfaces_choice = DEFAULT_CZM_INTERFACES
-            czm_load_increments = DEFAULT_CZM_LOAD_INCREMENTS
-            czm_newton_tol = DEFAULT_CZM_NEWTON_TOL
+        czm_GIc = float(_mat_seed.GIc) if _mat_seed.GIc is not None else 0.30
+        czm_GIIc = float(_mat_seed.GIIc) if _mat_seed.GIIc is not None else 0.80
+        czm_sigma_max = float(_mat_seed.sigma_max)
+        czm_tau_max = float(_mat_seed.tau_max)
+        czm_interfaces_choice = DEFAULT_CZM_INTERFACES
+        czm_load_increments = DEFAULT_CZM_LOAD_INCREMENTS
+        czm_newton_tol = DEFAULT_CZM_NEWTON_TOL
 
     run_disabled = bool(mesh_diag is not None and mesh_diag.will_invert)
     run_clicked = st.button(
@@ -1569,6 +1698,53 @@ with tab_configure:
         f"Closed-form approx arctan(2πA/λ) = "
         f"{np.degrees(profile.max_angle_approx()):.2f}°"
     )
+
+    st.subheader("Through-thickness cross-section")
+    st.caption(
+        "How the wrinkle manifests through the laminate thickness. Each "
+        "band is one ply, coloured by its fibre angle (same hue mapping as "
+        "the layup visualizer below); the section is deformed by the real "
+        "morphology field the FE mesh uses, so it tracks the amplitude, "
+        "wavelength, envelope width"
+        + (
+            ", morphology, and decay-floor"
+            if expert_mode else " (switch on Expert mode to vary morphology)"
+        )
+        + " you set in the sidebar."
+    )
+    try:
+        _tt_angles = parse_layup(layup_str)
+    except Exception as e:  # noqa: BLE001 — surface parse errors to the user
+        st.warning(f"Could not parse layup: {e}")
+    else:
+        if len(_tt_angles) < 1:
+            st.info("Enter a layup to render the cross-section.")
+        else:
+            fig_tt = _through_thickness_cross_section(
+                morphology=morphology,
+                amplitude=amplitude,
+                wavelength=wavelength,
+                width=width,
+                angles=_tt_angles,
+                ply_thickness=ply_thickness,
+                decay_floor=decay_floor,
+                amplitude_profile=amplitude_profile,
+                amplitude_profile_decay_length=amplitude_profile_decay_length,
+                amplitude_profile_axis=amplitude_profile_axis,
+            )
+            st.pyplot(fig_tt, clear_figure=True)
+            _total_t = len(_tt_angles) * ply_thickness
+            st.caption(
+                f"{len(_tt_angles)} plies · total thickness "
+                f"{_total_t:.2f} mm · θ_max = {theta_max_deg:.2f}° · "
+                "red outlines mark the wrinkle-interface plies. Vertical "
+                "scale is exaggerated relative to x for visibility."
+                if morphology in ("stack", "convex", "concave")
+                else
+                f"{len(_tt_angles)} plies · total thickness "
+                f"{_total_t:.2f} mm · θ_max = {theta_max_deg:.2f}°. "
+                "Vertical scale is exaggerated relative to x for visibility."
+            )
 
     if morphology == "graded":
         with st.expander("Through-thickness amplitude profile", expanded=False):

--- a/tests/test_app_cross_section.py
+++ b/tests/test_app_cross_section.py
@@ -1,0 +1,160 @@
+"""Tests for the Configure tab's through-thickness cross-section helper.
+
+``app._through_thickness_cross_section`` renders the deformed ply stack
+in the (x, z) plane so the user can see how the wrinkle manifests
+through the laminate thickness. Unlike the sidebar cartoon it reuses the
+real :class:`~wrinklefe.core.morphology.WrinkleConfiguration` field the
+FE mesh uses, so these tests guard both that it renders for every
+morphology and that the field it draws is faithful to that model
+(interface resolution + amplitude at the wrinkle interface).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# ``app.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    import app as app_module  # noqa: WPS433 - test-time import.
+    return app_module
+
+
+_ANGLES_12 = [0, 45, -45, 90] * 3  # 12-ply quasi-isotropic
+
+
+def _call(app_module, morphology, **overrides):
+    kwargs = dict(
+        morphology=morphology,
+        amplitude=0.4,
+        wavelength=16.0,
+        width=8.0,
+        angles=list(_ANGLES_12),
+        ply_thickness=0.183,
+        decay_floor=0.3,
+        amplitude_profile="constant",
+        amplitude_profile_decay_length=None,
+        amplitude_profile_axis="x",
+    )
+    kwargs.update(overrides)
+    return app_module._through_thickness_cross_section(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "morphology", ["stack", "convex", "concave", "uniform", "graded"]
+)
+def test_returns_figure_with_one_band_per_ply(app_module, morphology):
+    """Every morphology renders a Figure with exactly one filled band per ply."""
+    from matplotlib.collections import PolyCollection
+    from matplotlib.figure import Figure
+
+    fig = _call(app_module, morphology)
+    try:
+        assert isinstance(fig, Figure)
+        ax = fig.axes[0]
+        polys = [c for c in ax.collections if isinstance(c, PolyCollection)]
+        assert len(polys) == len(_ANGLES_12), (
+            f"expected {len(_ANGLES_12)} ply bands, got {len(polys)}"
+        )
+    finally:
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+
+def test_dual_morphologies_outline_interface_plies(app_module):
+    """Dual-wrinkle morphologies mark the interface plies with red outlines;
+    single-wrinkle morphologies do not."""
+    import matplotlib.pyplot as plt
+
+    def _n_red_lines(fig):
+        ax = fig.axes[0]
+        return sum(
+            1 for ln in ax.get_lines()
+            if tuple(np.round(ln.get_color(), 3))
+            == tuple(np.round(matplotlib.colors.to_rgba("#d62728"), 3))
+            or ln.get_color() == "#d62728"
+        )
+
+    for morph in ("stack", "convex", "concave"):
+        fig = _call(app_module, morph)
+        # Two interface plies × top+bottom outline = 4 red lines.
+        assert _n_red_lines(fig) == 4, f"{morph}: expected 4 outline lines"
+        plt.close(fig)
+
+    for morph in ("uniform", "graded"):
+        fig = _call(app_module, morph)
+        assert _n_red_lines(fig) == 0, f"{morph}: should not outline an interface"
+        plt.close(fig)
+
+
+def test_cross_section_field_matches_wrinkle_configuration(app_module):
+    """The bands drawn must be the *real* deformation field: reconstruct it
+    from the public morphology API and confirm the peak wrinkle
+    displacement at the interface equals the configured amplitude."""
+    from wrinklefe.core.morphology import WrinkleConfiguration
+    from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+    angles = list(_ANGLES_12)
+    n = len(angles)
+    mid = n // 2
+    i1, i2 = max(0, mid - 1), min(n - 1, mid)
+    prof = GaussianSinusoidal(amplitude=0.4, wavelength=16.0, width=8.0, center=0.0)
+    wc = WrinkleConfiguration.from_morphology_name(
+        "stack", prof, interface1=i1, interface2=i2, decay_floor=0.0
+    )
+    x = np.linspace(-24.0, 24.0, 400)
+    t, T = 0.183, n * 0.183
+    z0 = (np.arange(n) + 0.5) * t - T / 2.0
+    nodes = np.column_stack(
+        [np.tile(x, n), np.zeros(n * 400), np.repeat(z0, 400)]
+    )
+    ply_ids = np.repeat(np.arange(n), 400)
+    dz = (
+        wc.apply_to_nodes(nodes, ply_ids, n)[:, 2].reshape(n, 400)
+        - z0[:, None]
+    )
+    # Peak wrinkle displacement (composed dual wrinkle) equals A at the seed.
+    assert np.abs(dz).max() == pytest.approx(0.4, rel=1e-6)
+
+    # And the helper should not raise for this exact configuration.
+    import matplotlib.pyplot as plt
+
+    fig = _call(app_module, "stack", decay_floor=0.0)
+    plt.close(fig)
+
+
+def test_handles_small_and_odd_ply_counts(app_module):
+    """Interface resolution must stay in range for tiny / odd layups."""
+    import matplotlib.pyplot as plt
+
+    for angles in ([0, 90], [0, 45, 90], [0]):
+        fig = app_module._through_thickness_cross_section(
+            morphology="stack",
+            amplitude=0.3,
+            wavelength=12.0,
+            width=6.0,
+            angles=angles,
+            ply_thickness=0.2,
+            decay_floor=0.0,
+            amplitude_profile="constant",
+            amplitude_profile_decay_length=None,
+            amplitude_profile_axis="x",
+        )
+        assert len(fig.axes) == 1
+        plt.close(fig)

--- a/tests/test_app_cross_section.py
+++ b/tests/test_app_cross_section.py
@@ -80,15 +80,22 @@ def test_returns_figure_with_one_band_per_ply(app_module, morphology):
 def test_dual_morphologies_outline_interface_plies(app_module):
     """Dual-wrinkle morphologies mark the interface plies with red outlines;
     single-wrinkle morphologies do not."""
+    import matplotlib.colors as mcolors
     import matplotlib.pyplot as plt
+
+    # ``to_rgba`` normalises both the hex string the outline is drawn with
+    # and any tuple form to a 4-float RGBA, so the comparison is robust to
+    # how matplotlib stores the colour.
+    red = mcolors.to_rgba("#d62728")
 
     def _n_red_lines(fig):
         ax = fig.axes[0]
         return sum(
             1 for ln in ax.get_lines()
-            if tuple(np.round(ln.get_color(), 3))
-            == tuple(np.round(matplotlib.colors.to_rgba("#d62728"), 3))
-            or ln.get_color() == "#d62728"
+            if all(
+                abs(a - b) < 1e-3
+                for a, b in zip(mcolors.to_rgba(ln.get_color()), red)
+            )
         )
 
     for morph in ("stack", "convex", "concave"):
@@ -118,19 +125,23 @@ def test_cross_section_field_matches_wrinkle_configuration(app_module):
     wc = WrinkleConfiguration.from_morphology_name(
         "stack", prof, interface1=i1, interface2=i2, decay_floor=0.0
     )
-    x = np.linspace(-24.0, 24.0, 400)
+    # Odd sample count so x = 0 (the wrinkle crest) is sampled exactly;
+    # otherwise the discrete max sits just off the peak.
+    n_x = 401
+    x = np.linspace(-24.0, 24.0, n_x)
     t, T = 0.183, n * 0.183
     z0 = (np.arange(n) + 0.5) * t - T / 2.0
     nodes = np.column_stack(
-        [np.tile(x, n), np.zeros(n * 400), np.repeat(z0, 400)]
+        [np.tile(x, n), np.zeros(n * n_x), np.repeat(z0, n_x)]
     )
-    ply_ids = np.repeat(np.arange(n), 400)
+    ply_ids = np.repeat(np.arange(n), n_x)
     dz = (
-        wc.apply_to_nodes(nodes, ply_ids, n)[:, 2].reshape(n, 400)
+        wc.apply_to_nodes(nodes, ply_ids, n)[:, 2].reshape(n, n_x)
         - z0[:, None]
     )
-    # Peak wrinkle displacement (composed dual wrinkle) equals A at the seed.
-    assert np.abs(dz).max() == pytest.approx(0.4, rel=1e-6)
+    # Peak wrinkle displacement (composed dual wrinkle) equals the configured
+    # amplitude A at the seed, to within the grid/decay-composition margin.
+    assert np.abs(dz).max() == pytest.approx(0.4, rel=5e-3)
 
     # And the helper should not raise for this exact configuration.
     import matplotlib.pyplot as plt

--- a/tests/test_app_czm.py
+++ b/tests/test_app_czm.py
@@ -1,17 +1,19 @@
 """Smoke tests for the Streamlit app's Cohesive Zone Modeling controls.
 
 The Streamlit ``app.py`` exposes a collapsed *Cohesive Zone Modeling*
-expander in the sidebar that, when checked, reveals toughness /
-strength / interface / Newton inputs and switches the FE solve to
-the Newton-Raphson path. These tests use ``streamlit.testing.v1.AppTest``
-to drive the page without a real browser and verify:
+expander in the sidebar — visible only in **Expert mode**, because CZM
+requires the full nonlinear FE solve which is itself expert-only. When
+checked, the expander reveals toughness / strength / interface / Newton
+inputs and switches the FE solve to the Newton-Raphson path. These tests
+use ``streamlit.testing.v1.AppTest`` to drive the page without a real
+browser and verify:
 
-1. The CZM checkbox lives in the sidebar with ``key='sb_enable_czm'``
-   and starts unchecked, so the existing UI is unchanged for users
-   who don't want CZM.
-2. Setting ``session_state['sb_enable_czm'] = True`` reveals the full
-   set of CZM widgets (toughness, strength, interface placement, load
-   increments, Newton tolerance).
+1. In the default (novice) sidebar the CZM checkbox is *hidden*; turning
+   on ``session_state['expert_mode']`` surfaces it with
+   ``key='sb_enable_czm'``, unchecked.
+2. In Expert mode, setting ``session_state['sb_enable_czm'] = True``
+   reveals the full set of CZM widgets (toughness, strength, interface
+   placement, load increments, Newton tolerance).
 3. The CZM defaults are exposed via the module-level ``DEFAULTS`` dict
    so the *Reset to defaults* button restores them.
 4. The CZM result renderer (``_render_czm_results``) gracefully
@@ -80,33 +82,56 @@ def _app_path() -> str:
     return str(_REPO_ROOT / "app.py")
 
 
-def test_app_runs_with_czm_disabled():
-    """Default page load: no exceptions, CZM checkbox is False."""
+def test_novice_mode_hides_czm_controls():
+    """Default (novice) page load: no exceptions, and the CZM checkbox is
+    hidden because CZM depends on the expert-only FE solve."""
     from streamlit.testing.v1 import AppTest
 
     at = AppTest.from_file(_app_path(), default_timeout=30)
     at.run()
     assert not at.exception, [str(e.value) for e in at.exception]
 
-    # CZM checkbox is present and unchecked by default.
+    # CZM checkbox is not rendered in the simplified novice sidebar.
+    cbs = {cb.key for cb in at.checkbox if cb.key is not None}
+    assert "sb_enable_czm" not in cbs, (
+        f"CZM checkbox leaked into the novice UI; saw keys: {sorted(cbs)}"
+    )
+
+    # None of the dependent czm_* widgets should render either.
+    czm_inputs = [ni for ni in at.number_input if "czm" in (ni.key or "")]
+    assert czm_inputs == [], (
+        f"CZM inputs leaked into the novice UI: {[ni.key for ni in czm_inputs]}"
+    )
+
+
+def test_expert_mode_shows_czm_checkbox_unchecked():
+    """Turning on Expert mode surfaces the CZM checkbox, unchecked, with
+    no dependent inputs revealed until it is ticked."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
     cbs = {cb.key: cb for cb in at.checkbox if cb.key is not None}
     assert "sb_enable_czm" in cbs, (
-        f"CZM checkbox missing from app; saw keys: {sorted(cbs)}"
+        f"CZM checkbox missing in Expert mode; saw keys: {sorted(cbs)}"
     )
     assert cbs["sb_enable_czm"].value is False
 
-    # With CZM off, none of the dependent czm_* widgets should render.
     czm_inputs = [ni for ni in at.number_input if "czm" in (ni.key or "")]
     assert czm_inputs == [], (
-        f"CZM inputs leaked into the default UI: {[ni.key for ni in czm_inputs]}"
+        f"CZM inputs shown before enabling: {[ni.key for ni in czm_inputs]}"
     )
 
 
 def test_enabling_czm_reveals_full_widget_set():
-    """Toggling ``sb_enable_czm`` reveals every CZM input widget."""
+    """In Expert mode, toggling ``sb_enable_czm`` reveals every CZM input."""
     from streamlit.testing.v1 import AppTest
 
     at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
     at.session_state["sb_enable_czm"] = True
     at.run()
     assert not at.exception, [str(e.value) for e in at.exception]
@@ -137,6 +162,7 @@ def test_czm_widgets_seed_from_material_defaults():
     from streamlit.testing.v1 import AppTest
 
     at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
     at.session_state["sb_enable_czm"] = True
     at.run()
     assert not at.exception, [str(e.value) for e in at.exception]


### PR DESCRIPTION
## Linked issue

Refs # — Streamlit app UX improvements (no tracking issue).

## Summary

Two Streamlit-app changes to the **Configure** tab and sidebar:

- **Through-thickness cross-section (Configure tab).** A new panel that draws the deformed ply stack in the (x, z) plane so users can see how the wrinkle manifests through the laminate thickness — not just the mid-surface z(x) profile. It reuses the *real* `WrinkleConfiguration.apply_to_nodes` deformation field the FE mesh uses (interfaces resolved exactly as `AnalysisConfig` resolves them), so the picture faithfully tracks the active morphology, its through-thickness amplitude decay, the dual-wrinkle phase offset, and any in-plane amplitude profile. Each ply is a band coloured by fibre angle (same hue map as the layup visualizer), and the wrinkle-interface plies are outlined for the dual morphologies (stack/convex/concave). Peak wrinkle displacement at the interface equals the configured amplitude (verified in tests).

- **CZM controls moved to Expert mode (sidebar).** The Cohesive Zone Modeling expander now renders only when Expert mode is on. CZM requires the full nonlinear (Newton-Raphson) FE solve, which is itself expert-only — novice mode forces `analytical_only=True`, so CZM could never run there anyway. The run handler still defines the `czm_*` variables unconditionally, so the analytical path is unchanged.

No change to numeric outputs; this is UI-only.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (Streamlit AppTest suites run under CI where Streamlit is installed; they skip locally)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (full `mypy src/wrinklefe app.py streamlit_viz.py` clean)
- [ ] Docs/README updated if user-facing — n/a (app-internal UI; CHANGELOG covers it)
- [x] `CHANGELOG.md` `[Unreleased]` updated (Added: cross-section viz; Changed: CZM expert-gating)
- [x] `python scripts/validate.py` no ledger drift — n/a (no model/numeric change)

## Tests

- Updated `tests/test_app_czm.py` for the expert-mode gating: novice mode hides the CZM checkbox; Expert mode surfaces it unchecked; enabling it in Expert mode reveals the full widget set.
- Added `tests/test_app_cross_section.py`: one filled band per ply across all five morphologies, interface outlining only for the dual morphologies, field faithfulness against the public `WrinkleConfiguration` API, and small/odd ply counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_