### PR TITLE
Correctness batch: canonical ply-angle validation (#343, #344) + results-export schema drift (#345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,16 @@ version produced a given file.
   access in `max_angle` / `fiber_angles_at_nodes`.
 
 ### Changed
+- `AnalysisConfig` now validates ply angles at construction (issue #344)
+  — **breaking only for previously-accepted invalid inputs**: a config
+  with `|angle| > 90` (e.g. `angles=[900.0, 0.0, 452.0]`) now raises
+  `ValueError` naming the offending index and value instead of silently
+  flowing a non-canonical angle into CLT trig, where the tension-mechanism
+  heuristic mis-classified it (a 900° ply read as a 90° ply). The check
+  reuses the shared `validate_ply_angle` rule from `core.layup` (issue
+  #343), so the parser and the config validator can never drift. Valid
+  layups (decimals, `±90`, long stacks) are unaffected. Follow-up:
+  `Laminate.from_angles` is intentionally left unvalidated for now.
 - `parse_layup` input strictness (issue #308) — **breaking for inputs
   that previously parsed**: ply-angle tokens with `|angle| > 90` (e.g.
   the repeat-count-like `[02/902]s`, which silently parsed as 2° and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,20 @@ version produced a given file.
 - GitHub issue forms, pull-request template, and this changelog.
 
 ### Fixed
+- Results-export schema drift (issue #345): the structured JSON export
+  (`wrinklefe.io.results.results_to_dict` / `export_results_json`) and the
+  NCR validation summary (`wrinklefe.io.export.build_analysis_summary`)
+  silently dropped several `AnalysisResults` fields. `results_to_dict`
+  now serialises `modulus_retention_global` and `analytical_onset_knockdown`,
+  and — for progressive-damage runs — a gated `progressive` block
+  (`strength_MPa`, `pristine_strength_MPa`, `knockdown`, `n_increments`,
+  and the `(strain, stress)` load history). The NCR markdown/PDF renderers
+  now surface the global coupon modulus retention and a progressive-damage
+  section, wired end-to-end from the Streamlit Export tab. A new
+  dataclass-walking drift-guard test asserts every `AnalysisResults` field
+  is either exported or on an explicit allowlist, so a future field cannot
+  silently go unexported. Analytical-only runs are unchanged (no
+  `progressive` block, no empty NCR rows).
 - Dual-wrinkle amplitude contract in the FE mesh (issue #305): the
   `stack`/`convex`/`concave` morphologies build the mesh by summing two
   through-thickness–decayed displacement fields, and each constituent
@@ -289,6 +303,10 @@ version produced a given file.
   access in `max_angle` / `fiber_angles_at_nodes`.
 
 ### Changed
+- Results-export `SCHEMA_VERSION` bumped `1.0` → `1.1` (issue #345): the
+  additive `modulus_retention_global`, `analytical_onset_knockdown`, and
+  gated `progressive` fields in the structured JSON export. Additive only;
+  existing consumers of 1.0 fields are unaffected.
 - `AnalysisConfig` now validates ply angles at construction (issue #344)
   — **breaking only for previously-accepted invalid inputs**: a config
   with `|angle| > 90` (e.g. `angles=[900.0, 0.0, 452.0]`) now raises

--- a/app.py
+++ b/app.py
@@ -1249,6 +1249,9 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
                 fi_vmax_per_crit[crit] = 1.0
         fe = {
             "modulus_retention": float(result.modulus_retention),
+            "modulus_retention_global": float(
+                result.modulus_retention_global
+            ),
             "retention_factors": {
                 k: float(v) for k, v in (result.retention_factors or {}).items()
             },
@@ -1353,6 +1356,20 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         ),
         "fe": fe,
         "czm": czm_payload,
+        # Progressive-damage summary — only when a progressive run happened
+        # (``progressive_history`` is the reliable sentinel; the scalars
+        # default to 0.0 / 1.0).
+        "progressive": (
+            {
+                "knockdown": float(result.progressive_knockdown),
+                "strength_MPa": float(result.progressive_strength_MPa),
+                "pristine_strength_MPa": float(
+                    result.progressive_pristine_strength_MPa
+                ),
+            }
+            if result.progressive_history is not None
+            else None
+        ),
     }
 
 
@@ -2462,6 +2479,9 @@ with tab_export:
                     "fe": (
                         {
                             "modulus_retention": _fe.get("modulus_retention"),
+                            "modulus_retention_global": _fe.get(
+                                "modulus_retention_global"
+                            ),
                             "retention_factors": _fe.get(
                                 "retention_factors"
                             ),
@@ -2474,6 +2494,7 @@ with tab_export:
                         if _fe
                         else None
                     ),
+                    "progressive": _res.get("progressive"),
                 },
                 reference=summary_reference,
                 prepared_by=summary_prepared_by,

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -49,6 +49,7 @@ import numpy as np
 
 from wrinklefe.core.cohesive_mesh import insert_cohesive_interface
 from wrinklefe.core.laminate import Laminate, LoadState
+from wrinklefe.core.layup import validate_ply_angle
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
 from wrinklefe.core.mesh import MeshData, WrinkleMesh
 from wrinklefe.core.morphology import (
@@ -1223,6 +1224,15 @@ class AnalysisConfig:
         """
         # ``angles`` is filled in __post_init__ before _validate runs.
         assert self.angles is not None
+        # --- Ply angles ------------------------------------------------
+        # Enforce the canonical fibre-angle range (|angle| <= 90) using
+        # the shared parser rule so a mis-typed layup (e.g. 900°) fails
+        # loudly at construction instead of flowing into CLT trig and
+        # being silently mis-classified by the tension-mechanism heuristic.
+        for i, angle in enumerate(self.angles):
+            validate_ply_angle(
+                float(angle), context=f"AnalysisConfig.angles[{i}] = "
+            )
         # --- Wrinkle geometry -----------------------------------------
         # amplitude == 0 is a legitimate "no wrinkle" (flat) case: the
         # mid-surface profile z(x) = A * envelope reduces to 0, so the

--- a/src/wrinklefe/core/layup.py
+++ b/src/wrinklefe/core/layup.py
@@ -26,10 +26,36 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 
-__all__ = ["parse_layup", "to_contracted_layup"]
+__all__ = ["parse_layup", "to_contracted_layup", "validate_ply_angle"]
 
 
 _MAX_PLY_ANGLE = 90.0
+
+_CANONICAL_RANGE_MSG = (
+    "Ply angle {angle:g}° is outside the canonical fibre-angle range [-90, 90]."
+)
+
+
+def validate_ply_angle(angle: float, *, context: str = "") -> float:
+    """Raise :class:`ValueError` if ``|angle| > 90``; return the angle unchanged.
+
+    This is the single source of truth for the canonical fibre-angle rule
+    (``|angle| <= 90``) shared by the layup parser
+    (:func:`parse_layup` / :func:`to_contracted_layup`) and downstream
+    validators such as ``AnalysisConfig``. ``0``, ``±90``, decimals, and
+    negatives are all valid.
+
+    Parameters
+    ----------
+    angle:
+        The ply angle in degrees.
+    context:
+        Optional prefix for the error message (e.g. ``"AnalysisConfig.angles[0] = "``)
+        so callers can name the offending field or index.
+    """
+    if abs(angle) > _MAX_PLY_ANGLE:
+        raise ValueError(context + _CANONICAL_RANGE_MSG.format(angle=angle))
+    return angle
 
 
 _PLY_TOKEN_RE = re.compile(
@@ -107,10 +133,7 @@ def _expand_ply_token(token: str) -> list[float]:
             if hint
             else ""
         )
-        raise ValueError(
-            f"Ply angle {angle:g}° is outside the canonical fibre-angle "
-            f"range [-90, 90].{suggestion}"
-        )
+        raise ValueError(_CANONICAL_RANGE_MSG.format(angle=angle) + suggestion)
 
     sign = m.group("sign")
     if sign in ("±", "+-"):
@@ -206,8 +229,15 @@ def to_contracted_layup(angles: Sequence[float]) -> str:
     when no contraction applies the full bracketed angle list is
     returned, so the output is never ambiguous.
 
-    Round-trip property: ``parse_layup(to_contracted_layup(a)) == a``
-    for any non-empty list of angles.
+    Round-trip property: ``parse_layup(to_contracted_layup(a)) == a`` for
+    any non-empty list of canonical angles (``|angle| <= 90``).
+
+    Raises
+    ------
+    ValueError
+        If ``angles`` is empty, or if any angle is non-canonical
+        (``|angle| > 90``) and therefore cannot be represented in
+        contracted notation.
 
     Examples
     --------
@@ -221,6 +251,12 @@ def to_contracted_layup(angles: Sequence[float]) -> str:
     plies = [float(a) for a in angles]
     if not plies:
         raise ValueError("Layup is empty.")
+    for a in plies:
+        if abs(a) > _MAX_PLY_ANGLE:
+            raise ValueError(
+                f"Cannot render non-canonical ply angle {a:g}° in contracted "
+                "notation; angles must be within [-90, 90]."
+            )
 
     candidates: list[str] = []
     n = len(plies)

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -584,9 +584,13 @@ def build_analysis_summary(
     engineering : dict
         WrinkleFE results.  Recognised keys: ``analytical_knockdown``,
         ``analytical_strength_MPa``, ``damage_index``, ``max_angle_deg``,
-        ``effective_angle_deg``, ``morphology_factor``, and an optional
-        ``fe`` sub-dict (``modulus_retention``, ``retention_factors``,
-        ``critical_criterion``, ``critical_mode``, ``critical_ply``).
+        ``effective_angle_deg``, ``morphology_factor``, an optional
+        ``fe`` sub-dict (``modulus_retention``,
+        ``modulus_retention_global``, ``retention_factors``,
+        ``critical_criterion``, ``critical_mode``, ``critical_ply``), and
+        an optional ``progressive`` sub-dict (``knockdown``,
+        ``strength_MPa``, ``pristine_strength_MPa``) present only when a
+        progressive-damage run was performed.
     reference : str, optional
         Free-text label tying this attachment to its NCR (e.g. the NCR
         number or part reference).  Optional by design.
@@ -630,6 +634,7 @@ def build_analysis_summary(
         min_ret = min(retention.values()) if retention else None
         fe_block = {
             "modulus_retention": fe.get("modulus_retention"),
+            "modulus_retention_global": fe.get("modulus_retention_global"),
             "min_strength_retention": min_ret,
             "retention_factors": retention,
             "critical_criterion": fe.get("critical_criterion"),
@@ -645,6 +650,20 @@ def build_analysis_summary(
                    if fe.get("critical_mode") else "")
                 + "."
             )
+
+    prog = engineering.get("progressive") or None
+    progressive_block: dict | None = None
+    if prog:
+        progressive_block = {
+            "knockdown": prog.get("knockdown"),
+            "strength_MPa": prog.get("strength_MPa"),
+            "pristine_strength_MPa": prog.get("pristine_strength_MPa"),
+        }
+        criteria.append(
+            "Progressive-damage (crack-band) finite-element strength "
+            "prediction — peak carried nominal stress, wrinkled vs "
+            "pristine coupon."
+        )
     criteria.append(
         "Generic severity banding in this summary is advisory only and is "
         "superseded by the program-specific allowables, drawing "
@@ -694,6 +713,7 @@ def build_analysis_summary(
             ),
             "morphology_factor": engineering.get("morphology_factor"),
             "finite_element": fe_block,
+            "progressive_damage": progressive_block,
         },
         "criteria_cited": criteria,
         "disposition_recommendation": {
@@ -825,8 +845,14 @@ def render_summary_markdown(summary: dict) -> str:
         lines.append("**Finite-element evaluation**")
         lines.append("")
         lines.append(
-            f"- Modulus retention: {_fmt(fe_block['modulus_retention'])}"
+            f"- Modulus retention (local σ₁₁ proxy): "
+            f"{_fmt(fe_block['modulus_retention'])}"
         )
+        if fe_block.get("modulus_retention_global") is not None:
+            lines.append(
+                f"- Modulus retention (global coupon E_x/E_x0): "
+                f"{_fmt(fe_block['modulus_retention_global'])}"
+            )
         lines.append(
             f"- Min strength retention: "
             f"{_fmt(fe_block['min_strength_retention'])}"
@@ -836,6 +862,23 @@ def render_summary_markdown(summary: dict) -> str:
             f"{_fmt(fe_block['critical_criterion'])}"
             f" (mode: {_fmt(fe_block['critical_mode'])}, "
             f"ply: {_fmt(fe_block['critical_ply'])})"
+        )
+    prog_block = ea.get("progressive_damage")
+    if prog_block:
+        lines.append("")
+        lines.append("**Progressive-damage evaluation**")
+        lines.append("")
+        lines.append(
+            f"- Progressive knockdown: "
+            f"**{_fmt(prog_block['knockdown'])}**"
+        )
+        lines.append(
+            f"- Predicted strength: "
+            f"{_fmt(prog_block['strength_MPa'])} MPa"
+        )
+        lines.append(
+            f"- Pristine strength: "
+            f"{_fmt(prog_block['pristine_strength_MPa'])} MPa"
         )
     lines.append("")
     lines.append("## 4. Criteria cited")

--- a/src/wrinklefe/io/results.py
+++ b/src/wrinklefe/io/results.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 # ----------------------------------------------------------------------
 
 #: Bump this when the public JSON layout changes in a non-additive way.
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
 
 #: 1D arrays at or below this length are serialised in full; longer
 #: arrays are reduced to {min, max, mean, p95}.  A few-hundred-element
@@ -249,6 +249,8 @@ def _knockdown_factors(results: AnalysisResults) -> dict:
         out["fe_per_criterion"] = {k: float(v) for k, v in retention.items()}
     if results.modulus_retention is not None:
         out["modulus_retention"] = _f(results.modulus_retention)
+    if results.modulus_retention_global is not None:
+        out["modulus_retention_global"] = _f(results.modulus_retention_global)
     return out
 
 
@@ -309,6 +311,11 @@ def results_to_dict(results: AnalysisResults) -> dict:
             "effective_angle_deg": _f(np.degrees(results.effective_angle_rad)),
             "damage_index": _f(results.damage_index),
             "analytical_knockdown": _f(results.analytical_knockdown),
+            "analytical_onset_knockdown": (
+                _f(results.analytical_onset_knockdown)
+                if results.analytical_onset_knockdown is not None
+                else None
+            ),
             "analytical_modulus_knockdown": _f(
                 results.analytical_modulus_knockdown
             ),
@@ -341,6 +348,24 @@ def results_to_dict(results: AnalysisResults) -> dict:
         payload["tension_mechanisms"] = {
             k: (_f(v) if isinstance(v, (int, float, np.floating)) else v)
             for k, v in results.tension_mechanisms.items()
+        }
+
+    # Progressive-damage block — only when a progressive run happened.
+    # ``progressive_history`` is the reliable sentinel (the scalar fields
+    # default to 0.0 / 1.0); it holds ``(applied_strain, nominal_stress)``
+    # samples from the wrinkled coupon's load history.
+    if results.progressive_history is not None:
+        payload["progressive"] = {
+            "strength_MPa": _f(results.progressive_strength_MPa),
+            "pristine_strength_MPa": _f(
+                results.progressive_pristine_strength_MPa
+            ),
+            "knockdown": _f(results.progressive_knockdown),
+            "n_increments": len(results.progressive_history),
+            "history": [
+                [_f(strain), _f(stress)]
+                for strain, stress in results.progressive_history
+            ],
         }
 
     return payload

--- a/tests/test_analysis_config.py
+++ b/tests/test_analysis_config.py
@@ -134,11 +134,23 @@ def test_boundary_valid_values_accepted():
         ({"nx": 0}, r"nx must be >= 1.*got 0"),
         ({"ny": 0}, r"ny must be >= 1.*got 0"),
         ({"nz_per_ply": -2}, r"nz_per_ply must be >= 1.*got -2"),
+        ({"angles": [900.0]},
+         r"AnalysisConfig\.angles\[0\] = .*900.*\[-90, 90\]"),
+        ({"angles": [0.0, 452.0, 0.0]},
+         r"AnalysisConfig\.angles\[1\] = .*452.*\[-90, 90\]"),
+        ({"angles": [0.0, 90.0, -95.0, 0.0]},
+         r"AnalysisConfig\.angles\[2\] = .*-95.*\[-90, 90\]"),
     ],
 )
 def test_invalid_config_raises_value_error(kwargs, match):
     with pytest.raises(ValueError, match=match):
         AnalysisConfig(**kwargs)
+
+
+def test_canonical_angles_accepted():
+    """Boundary and decimal canonical angles construct fine."""
+    cfg = AnalysisConfig(angles=[90.0, -90.0, 0.0, 45.5], analytical_only=True)
+    assert cfg.angles == [90.0, -90.0, 0.0, 45.5]
 
 
 def test_explicit_phase_does_not_require_dual_wrinkle_name():

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -611,6 +611,47 @@ class TestBuildAnalysisSummary:
             "hashin" in c.lower() for c in s["criteria_cited"]
         )
 
+    def test_modulus_retention_global_carried_in_fe_block(self, summary_inputs):
+        """Issue #345: the global coupon modulus retention reaches the
+        NCR fe sub-block."""
+        defect, engineering = summary_inputs
+        eng = dict(engineering)
+        eng["fe"] = {
+            "modulus_retention": 0.92,
+            "modulus_retention_global": 0.85,
+            "retention_factors": {"hashin": 0.81},
+            "critical_criterion": "hashin",
+            "critical_mode": "fiber_compression",
+            "critical_ply": 3,
+        }
+        s = build_analysis_summary(defect=defect, engineering=eng)
+        fe_block = s["engineering_analysis"]["finite_element"]
+        assert fe_block["modulus_retention_global"] == pytest.approx(0.85)
+
+    def test_progressive_block_present_and_cited(self, summary_inputs):
+        """Issue #345: a progressive-damage run reaches the NCR summary."""
+        defect, engineering = summary_inputs
+        eng = dict(engineering)
+        eng["progressive"] = {
+            "knockdown": 0.77,
+            "strength_MPa": 812.5,
+            "pristine_strength_MPa": 1050.0,
+        }
+        s = build_analysis_summary(defect=defect, engineering=eng)
+        prog = s["engineering_analysis"]["progressive_damage"]
+        assert prog is not None
+        assert prog["knockdown"] == pytest.approx(0.77)
+        assert prog["strength_MPa"] == pytest.approx(812.5)
+        assert any(
+            "progressive" in c.lower() for c in s["criteria_cited"]
+        )
+
+    def test_no_progressive_block_when_absent(self, summary_inputs):
+        """Analytical-only inputs carry no progressive sub-block."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        assert s["engineering_analysis"]["progressive_damage"] is None
+
 
 class TestRenderAndExportSummary:
     """Tests for render_summary_markdown / pdf and export_summary."""
@@ -644,6 +685,41 @@ class TestRenderAndExportSummary:
         )
         assert "- Layup: [0/±45/90]s" in md
         assert "- Layup (deg, expanded): [0.0, 45.0, -45.0, 90.0" in md
+
+    def test_markdown_shows_progressive_and_global_modulus(
+        self, summary_inputs
+    ):
+        """Issue #345: the NCR markdown renders the progressive block and
+        the global modulus retention when present."""
+        defect, engineering = summary_inputs
+        eng = dict(engineering)
+        eng["fe"] = {
+            "modulus_retention": 0.92,
+            "modulus_retention_global": 0.85,
+            "retention_factors": {"hashin": 0.81},
+            "critical_criterion": "hashin",
+            "critical_mode": "fiber_compression",
+            "critical_ply": 3,
+        }
+        eng["progressive"] = {
+            "knockdown": 0.77,
+            "strength_MPa": 812.5,
+            "pristine_strength_MPa": 1050.0,
+        }
+        md = render_summary_markdown(
+            build_analysis_summary(defect=defect, engineering=eng)
+        )
+        assert "Modulus retention (global coupon E_x/E_x0): 0.85" in md
+        assert "Progressive-damage evaluation" in md
+        assert "Progressive knockdown" in md
+
+    def test_markdown_omits_progressive_when_absent(self, summary_inputs):
+        """No empty progressive rows on an analytical-only NCR."""
+        defect, engineering = summary_inputs
+        md = render_summary_markdown(
+            build_analysis_summary(defect=defect, engineering=engineering)
+        )
+        assert "Progressive-damage evaluation" not in md
 
     def test_export_md(self, summary_inputs, tmp_path):
         defect, engineering = summary_inputs

--- a/tests/test_io/test_export_results.py
+++ b/tests/test_io/test_export_results.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 import csv
 import json
 import warnings
+from dataclasses import fields
 
 import numpy as np
 import pytest
 
-from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.analysis import AnalysisConfig, AnalysisResults, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 from wrinklefe.io.results import (
     SCHEMA_VERSION,
@@ -315,3 +316,157 @@ class TestExportResultsCSV:
         out = tmp_path / "sub" / "deep" / "per_ply.csv"
         export_results_csv(fe_result, out)
         assert out.exists()
+
+
+# ----------------------------------------------------------------------
+# Progressive-damage + modulus_retention_global export (issue #345)
+# ----------------------------------------------------------------------
+
+def _minimal_config():
+    """A cheap analytical-only config for direct-construction tests."""
+    return AnalysisConfig(
+        angles=[0, 45, -45, 90, 90, -45, 45, 0],
+        analytical_only=True,
+    )
+
+
+def _progressive_result():
+    """AnalysisResults with the progressive-damage fields populated.
+
+    Built by direct construction — the exporter only reads attributes, so
+    no FE/progressive solve is needed to exercise the serialisation path.
+    """
+    return AnalysisResults(
+        config=_minimal_config(),
+        modulus_retention_global=0.87,
+        tension_mechanisms={"kd_fiber": 0.91, "mode": "fiber"},
+        retention_factors={"tsai_wu": 0.82, "hashin": 0.90},
+        progressive_strength_MPa=812.5,
+        progressive_pristine_strength_MPa=1050.0,
+        progressive_knockdown=0.7738,
+        progressive_history=[
+            (0.0, 0.0),
+            (0.001, 520.0),
+            (0.002, 812.5),
+            (0.003, 640.0),
+        ],
+    )
+
+
+class TestProgressiveExport:
+    """The progressive block appears only for progressive runs (#345)."""
+
+    def test_progressive_block_present_with_values(self):
+        payload = results_to_dict(_progressive_result())
+        assert "progressive" in payload
+        prog = payload["progressive"]
+        assert prog["strength_MPa"] == pytest.approx(812.5)
+        assert prog["pristine_strength_MPa"] == pytest.approx(1050.0)
+        assert prog["knockdown"] == pytest.approx(0.7738)
+        assert prog["n_increments"] == 4
+        assert prog["history"][2] == [pytest.approx(0.002), pytest.approx(812.5)]
+
+    def test_progressive_block_json_round_trips(self):
+        payload = results_to_dict(_progressive_result())
+        restored = json.loads(json.dumps(payload, sort_keys=True))
+        assert restored["progressive"]["n_increments"] == 4
+        assert restored["progressive"]["history"][1] == [0.001, 520.0]
+
+    def test_no_progressive_block_for_analytical_run(self, analytical_result):
+        """Analytical-only runs (history is None) carry no progressive key."""
+        payload = results_to_dict(analytical_result)
+        assert "progressive" not in payload
+
+    def test_modulus_retention_global_in_knockdown_factors(self):
+        payload = results_to_dict(_progressive_result())
+        kd = payload["knockdown_factors"]
+        assert kd["modulus_retention_global"] == pytest.approx(0.87)
+
+
+# ----------------------------------------------------------------------
+# Export drift guard — every AnalysisResults field is exported or
+# explicitly allowlisted (prevents a recurrence of issue #345).
+# ----------------------------------------------------------------------
+
+#: AnalysisResults fields whose export key differs from the field name.
+FIELD_TO_EXPORT_KEY = {
+    "retention_factors": "knockdown_factors.fe_per_criterion",
+    "progressive_strength_MPa": "progressive.strength_MPa",
+    "progressive_pristine_strength_MPa": "progressive.pristine_strength_MPa",
+    "progressive_knockdown": "progressive.knockdown",
+    "progressive_history": "progressive.history",
+}
+
+#: Fields intentionally not serialised by results_to_dict, each with a
+#: reason. Heavy objects / large arrays are summarised elsewhere or are
+#: internal intermediates; CZM results are surfaced via the app's own
+#: CZM payload rather than the structured results export.
+INTENTIONALLY_UNEXPORTED = {
+    "mesh": "heavy MeshData; summarised as the top-level 'mesh' block when present",
+    "wrinkle_config": "WrinkleConfiguration object; geometry captured under config",
+    "laminate": "Laminate object; layup captured under config.angles",
+    "field_results": "heavy FE fields; summarised as fe.stress_field_summary",
+    "failure_report": "LaminateFailureReport; flattened into per_ply/first_ply_failure",
+    "failure_indices": "per-criterion FE failure-index arrays (large)",
+    "failure_modes": "per-criterion failure-mode string arrays (large)",
+    "baseline_fi": "pristine per-criterion max FI; retention-calc intermediate",
+    "mesh_max_angle_rad": "FE-mesh diagnostic; analytical max_angle_rad is exported",
+    "czm_damage": "CZM result; surfaced via the app CZM payload, not results_to_dict",
+    "czm_separation": "CZM result; surfaced via the app CZM payload",
+    "czm_traction": "CZM result; surfaced via the app CZM payload",
+    "czm_energy_dissipated": "CZM result; surfaced via the app CZM payload",
+    "czm_energy_per_interface": "CZM result; surfaced via the app CZM payload",
+    "czm_crack_length_per_interface": "CZM result; surfaced via the app CZM payload",
+    "czm_load_displacement": "CZM result; surfaced via the app CZM payload",
+    "czm_converged": "CZM result; surfaced via the app CZM payload",
+    "czm_interfaces_used": "CZM result; surfaced via the app CZM payload",
+    "czm_delamination_report": "CZM result; surfaced via the app CZM payload",
+    "czm_element_centroids": "CZM result; surfaced via the app CZM payload",
+}
+
+
+def _collect_keys(node, acc):
+    """Recursively gather every dict key appearing in a payload."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            acc.add(k)
+            _collect_keys(v, acc)
+    elif isinstance(node, list):
+        for v in node:
+            _collect_keys(v, acc)
+
+
+def _resolve(payload, dotted):
+    """Follow a dotted export path (e.g. 'progressive.strength_MPa')."""
+    node = payload
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
+def test_every_results_field_is_exported_or_allowlisted():
+    """Walk AnalysisResults fields; each must be exported by
+    results_to_dict (directly, or via a mapped key) or explicitly
+    allowlisted. Building the representative payload needs no FE solve —
+    the exporters only read attributes."""
+    payload = results_to_dict(_progressive_result())
+    keys: set[str] = set()
+    _collect_keys(payload, keys)
+
+    for f in fields(AnalysisResults):
+        name = f.name
+        if name in keys:
+            continue
+        if name in FIELD_TO_EXPORT_KEY:
+            assert _resolve(payload, FIELD_TO_EXPORT_KEY[name]), (
+                f"field {name!r} maps to {FIELD_TO_EXPORT_KEY[name]!r} but "
+                "that path is missing from the results_to_dict payload"
+            )
+            continue
+        assert name in INTENTIONALLY_UNEXPORTED, (
+            f"field {name!r} is neither exported by results_to_dict nor "
+            "allowlisted — wire it into io/results.py or add it to "
+            "INTENTIONALLY_UNEXPORTED with a reason."
+        )

--- a/tests/test_layup.py
+++ b/tests/test_layup.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 import pytest
 
-from wrinklefe.core.layup import parse_layup, to_contracted_layup
+from wrinklefe.core.layup import (
+    parse_layup,
+    to_contracted_layup,
+    validate_ply_angle,
+)
 
 # --------------------------------------------------------------------------- #
 # Contracted notation
@@ -198,6 +202,44 @@ def test_contracted_asymmetric_falls_back_to_expanded():
 def test_contracted_empty_raises():
     with pytest.raises(ValueError):
         to_contracted_layup([])
+
+
+@pytest.mark.parametrize("bad", [100.0, -95.0, 900.0])
+def test_contracted_non_canonical_raises(bad):
+    """Non-canonical angles raise a renderer error, not a parser error."""
+    with pytest.raises(ValueError) as exc:
+        to_contracted_layup([0.0, bad, 45.0])
+    msg = str(exc.value)
+    assert f"{bad:g}" in msg
+    assert "[-90, 90]" in msg
+    # Must read as a renderer error, not leak contracted-string syntax.
+    assert "_n" not in msg
+    assert "Did you mean" not in msg
+
+
+def test_contracted_boundary_angles_round_trip():
+    """±90 and 0 are canonical and still render/round-trip."""
+    angles = [90.0, -90.0, 0.0]
+    out = to_contracted_layup(angles)
+    assert parse_layup(out) == angles
+
+
+def test_validate_ply_angle_accepts_canonical():
+    for a in (0.0, 90.0, -90.0, 45.5, -12.345):
+        assert validate_ply_angle(a) == a
+
+
+@pytest.mark.parametrize("bad", [90.1, -90.1, 900.0, -450.0])
+def test_validate_ply_angle_rejects_non_canonical(bad):
+    with pytest.raises(ValueError) as exc:
+        validate_ply_angle(bad)
+    assert "[-90, 90]" in str(exc.value)
+
+
+def test_validate_ply_angle_context_prefix():
+    with pytest.raises(ValueError) as exc:
+        validate_ply_angle(900.0, context="AnalysisConfig.angles[0] = ")
+    assert str(exc.value).startswith("AnalysisConfig.angles[0] = ")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Linked issue

Fixes #343  Fixes #344  Fixes #345

## Summary

A three-commit correctness/consistency batch — no solver or prediction changes (the validation ledger shows zero drift).

**#343 — `to_contracted_layup` raises cleanly on non-canonical angles.**
Since the #336 parser hardening, `to_contracted_layup([100.0])` raised a *parser* `ValueError` about a contracted string the caller never wrote (its internal round-trip check re-parses candidates). The canonical fibre-angle rule (`|angle| <= 90`) is now extracted into a shared public helper `validate_ply_angle` in `core/layup.py` (single-sourcing the bound and message template with the parser), and `to_contracted_layup` validates every angle at entry, raising a renderer-flavoured error. Docstring scoped to canonical angles.

**#344 — validate `angles` at the `AnalysisConfig` boundary.**
`AnalysisConfig._validate()` now rejects any resolved ply angle with `|angle| > 90` using the **shared** `validate_ply_angle` rule (not a duplicate), naming the offending index and value. Previously a config like `angles=[900.0, 0.0, 452.0]` was accepted and a 900° ply flowed into CLT trig, silently mis-classified as a 90° ply by the tension-mechanism heuristic. `Laminate.from_angles` is intentionally left unvalidated (optional in the issue; used by low-level synthetic-laminate drivers) — a possible follow-up.

**#345 — export the progressive-damage results and `modulus_retention_global`.**
Several `AnalysisResults` fields were never serialised. `results_to_dict` now emits `modulus_retention_global`, `analytical_onset_knockdown`, and — for progressive-damage runs only (gated on `progressive_history`) — a `progressive` block (`strength_MPa`, `pristine_strength_MPa`, `knockdown`, `n_increments`, `(strain, stress)` history). The NCR summary (`build_analysis_summary`) and both renderers (markdown + PDF) surface the global coupon modulus retention and a progressive-damage section, wired end-to-end from the Streamlit Export tab. A new dataclass-walking **drift-guard test** asserts every `AnalysisResults` field is either exported or explicitly allowlisted, so a field cannot silently go unexported again.

### Behavior changes
- **Invalid ply angles now raise.** Configs / layups with `|angle| > 90` that were previously accepted (mis-classified) now raise `ValueError` at construction / render. Breaking *only* for previously-invalid inputs; all valid canonical layups (decimals, `±90`, long stacks) are unchanged.
- **Results-export `SCHEMA_VERSION` bumped `1.0` → `1.1`** (additive fields only; 1.0 consumers unaffected).

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (1392 passed / 10 skipped, excluding the slow FE integration suites; the full matrix runs in CI)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (also `app.py`, `streamlit_viz.py`)
- [ ] Docs/README updated if user-facing (no doc surface for these fixes)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_