### PR TITLE
Test markers + fast-lane CI split (#267) and a benchmark suite (#271)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,46 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all,dev]"
 
+      # The matrix runs only the fast lane (`-m "not slow"`): the slow
+      # FE/CZM integration solves would multiply the 6-cell wall-time for
+      # little marginal signal. The complete suite (and the Codecov
+      # upload, which needs the slow-path coverage) runs once in
+      # ``test-full`` below.
       - name: Run tests
-        run: pytest --tb=short -q --cov=wrinklefe --cov-report=xml --cov-report=term
+        run: pytest --tb=short -q -m "not slow" --cov=wrinklefe --cov-report=xml --cov-report=term
 
       - name: Check import
         run: python -c "import wrinklefe; print(f'WrinkleFE {wrinklefe.__version__} imported successfully')"
 
+  test-full:
+    # Complete suite on a single interpreter, including the slow FE/CZM
+    # integration solves the matrix job skips. `-m "not benchmark"` runs
+    # everything except the pytest-benchmark performance suite (the
+    # default addopts already exclude it, but an explicit -m on the CLI
+    # overrides that default, so it is restated here). This is the job
+    # that owns the Codecov upload — measuring coverage on the fast lane
+    # alone would under-report the slow integration paths.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Run full test suite
+        run: pytest --tb=short -q -m "not benchmark" --cov=wrinklefe --cov-report=xml --cov-report=term
+
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,54 @@ jobs:
             python "$f"
             echo "::endgroup::"
           done
+
+  benchmarks:
+    # Runs the pytest-benchmark performance suite, autosaves the timings
+    # as a build artifact, and — only once a committed baseline exists —
+    # fails on a median regression. We ship WITHOUT a baseline: timings
+    # captured in a throwaway container are meaningless against a CI
+    # runner, so the regression gate stays dormant until a maintainer
+    # bootstraps `tests/test_benchmarks/baseline/` from a green main run
+    # (see CONTRIBUTING.md). The 2x (median:100%) threshold absorbs the
+    # substantial run-to-run CPU variance of shared CI runners; a tighter
+    # bound (e.g. 50%) would flake.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Run benchmarks (autosave)
+        run: |
+          pytest tests/test_benchmarks -m benchmark \
+            --benchmark-autosave --benchmark-storage=.benchmarks
+
+      - name: Upload benchmark timings
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-timings
+          path: .benchmarks/
+          if-no-files-found: warn
+
+      - name: Compare against committed baseline (if present)
+        run: |
+          if [ -d tests/test_benchmarks/baseline ]; then
+            echo "Baseline found — enforcing median:100% (2x) regression gate."
+            pytest tests/test_benchmarks -m benchmark \
+              --benchmark-storage=tests/test_benchmarks/baseline \
+              --benchmark-compare \
+              --benchmark-compare-fail=median:100%
+          else
+            echo "No baseline at tests/test_benchmarks/baseline — regression gate skipped."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,46 @@ benchmark"`) once and owns the coverage upload. Run the full suite
 locally (`pytest`) before opening a PR when your change touches the FE,
 CZM, or analysis paths.
 
+### Benchmarks
+
+Performance micro-benchmarks for the hot kernels live in
+`tests/test_benchmarks/` and use
+[`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/) (in the
+`dev` extra). Each is marked `benchmark` and `slow`, so it is excluded
+from both a bare `pytest` run and the `-m "not slow"` fast lane. Run and
+save timings explicitly:
+
+```bash
+# run the suite
+pytest tests/test_benchmarks -m benchmark
+
+# capture before/after numbers around a change
+pytest tests/test_benchmarks -m benchmark --benchmark-autosave
+```
+
+CI runs these in a dedicated `benchmarks` job that autosaves the timings
+as a downloadable artifact and, **only if** a committed baseline exists,
+fails the build on a median regression worse than 2x
+(`--benchmark-compare-fail=median:100%`). The 2x threshold is deliberate:
+shared CI runners have large run-to-run CPU variance and a tighter bound
+would flake.
+
+**No baseline is committed.** Timings captured inside an ephemeral
+container are meaningless against a CI runner, so the regression gate is
+dormant by default. To bootstrap it:
+
+1. Download the `benchmark-timings` artifact from a green `main` run of
+   the `benchmarks` job.
+2. Commit the saved `*.json` run into `tests/test_benchmarks/baseline/`
+   in a follow-up PR. The CI compare step activates automatically once
+   that directory exists.
+
+**Refreshing the baseline** is a deliberate, reviewed act — never
+automatic. When an intentional performance change (or a runner upgrade)
+shifts the numbers, capture a fresh artifact from a green `main` run and
+replace the file under `tests/test_benchmarks/baseline/` in its own PR,
+so the reviewer can see exactly which kernels moved and why.
+
 ## Adding Materials
 
 To add a new material to the built-in library, add an entry in `src/wrinklefe/core/material.py` in the `_load_builtins()` method. Include all elastic constants, strength allowables, and a literature reference.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,34 @@ pytest
 - Maintain or improve test coverage
 - Tests are in the `tests/` directory, organized by module
 
+### Test markers and the fast path
+
+The suite carries four registered pytest markers (declared in
+`pyproject.toml`; `--strict-markers` is on, so a typo'd or undeclared
+marker is a hard collection error rather than a silent no-op):
+
+- `slow` — FE/CZM solves taking more than ~5 s per test.
+- `integration` — end-to-end pipeline tests (`tests/integration/` and
+  `tests/test_integration/`).
+- `viz` — needs the streamlit/plotly extras.
+- `benchmark` — the pytest-benchmark performance suite, excluded from a
+  bare `pytest` run by the default `-m 'not benchmark'` in `addopts`.
+
+For the inner development loop, skip the slow integration solves:
+
+```bash
+pytest -m "not slow"
+```
+
+This deselects every `tests/integration/` file and the handful of
+individually-slow tests elsewhere, running in a small fraction of the
+full-suite time while still exercising the unit and fast-integration
+layers. CI mirrors this: the OS/Python matrix job runs `-m "not slow"`,
+and a dedicated `test-full` job runs the complete suite (`-m "not
+benchmark"`) once and owns the coverage upload. Run the full suite
+locally (`pytest`) before opening a PR when your change touches the FE,
+CZM, or analysis paths.
+
 ## Adding Materials
 
 To add a new material to the built-in library, add an entry in `src/wrinklefe/core/material.py` in the `_load_builtins()` method. Include all elastic constants, strength allowables, and a literature reference.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,17 @@ ignore = ["N802", "N803", "N806", "N815", "N816"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+# --strict-markers turns a typo'd or undeclared marker into a collection
+# error. The default -m 'not benchmark' keeps a bare `pytest` invocation
+# fast by excluding the pytest-benchmark performance suite; pass an
+# explicit -m on the CLI (e.g. -m benchmark) to override it.
+addopts = "-v --tb=short --strict-markers -m 'not benchmark'"
+markers = [
+    "slow: FE/CZM solves taking more than ~5s per test",
+    "integration: end-to-end pipeline tests",
+    "viz: requires the streamlit/plotly extras",
+    "benchmark: pytest-benchmark performance suite (excluded by default; select with -m benchmark)",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ streamlit = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-benchmark>=4.0",
     "ruff>=0.1",
     "mypy>=1.5",
     "scipy-stubs>=1.14",

--- a/tests/integration/test_4pb_experimental_validation.py
+++ b/tests/integration/test_4pb_experimental_validation.py
@@ -147,6 +147,7 @@ import matplotlib
 matplotlib.use("Agg")  # non-interactive backend for CI/test runs.
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
+import pytest  # noqa: E402
 
 from wrinklefe.core.cohesive_mesh import insert_cohesive_interface  # noqa: E402
 from wrinklefe.core.laminate import Laminate, Ply  # noqa: E402
@@ -159,6 +160,8 @@ from wrinklefe.elements.cohesive8 import (  # noqa: E402
 from wrinklefe.solver.assembler import GlobalAssembler  # noqa: E402
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler  # noqa: E402
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver  # noqa: E402
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 # ----------------------------------------------------------------------
 # Experimental data (NASA/TM-2020-220498 Section 4.13)

--- a/tests/integration/test_cohesive_newton_integration.py
+++ b/tests/integration/test_cohesive_newton_integration.py
@@ -53,6 +53,8 @@ from wrinklefe.solver.assembler import GlobalAssembler
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ======================================================================
 # Mesh + element construction
 # ======================================================================

--- a/tests/integration/test_dcb_experimental_validation.py
+++ b/tests/integration/test_dcb_experimental_validation.py
@@ -164,6 +164,8 @@ from wrinklefe.solver.assembler import GlobalAssembler  # noqa: E402
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler  # noqa: E402
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver  # noqa: E402
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ----------------------------------------------------------------------
 # Experimental data (NASA/TM-2020-220498 Figure 32)
 # ----------------------------------------------------------------------

--- a/tests/integration/test_dcb_monotonic.py
+++ b/tests/integration/test_dcb_monotonic.py
@@ -120,6 +120,7 @@ from __future__ import annotations
 import math
 
 import numpy as np
+import pytest
 
 from wrinklefe.core.cohesive_mesh import insert_cohesive_interface
 from wrinklefe.core.laminate import Laminate, Ply
@@ -129,6 +130,8 @@ from wrinklefe.elements.cohesive8 import CohesiveProperties
 from wrinklefe.solver.assembler import GlobalAssembler
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 # ----------------------------------------------------------------------
 # Geometry / material / cohesive parameters

--- a/tests/integration/test_enf_experimental_validation.py
+++ b/tests/integration/test_enf_experimental_validation.py
@@ -140,6 +140,7 @@ import matplotlib
 matplotlib.use("Agg")  # non-interactive backend for CI/test runs.
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
+import pytest
 
 from wrinklefe.core.cohesive_mesh import insert_cohesive_interface  # noqa: E402
 from wrinklefe.core.laminate import Laminate, Ply  # noqa: E402
@@ -152,6 +153,8 @@ from wrinklefe.elements.cohesive8 import (  # noqa: E402
 from wrinklefe.solver.assembler import GlobalAssembler  # noqa: E402
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler  # noqa: E402
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver  # noqa: E402
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 # ----------------------------------------------------------------------
 # Experimental data (NASA/TM-2020-220498 Section 4.15)

--- a/tests/integration/test_enf_monotonic.py
+++ b/tests/integration/test_enf_monotonic.py
@@ -163,6 +163,8 @@ from wrinklefe.solver.assembler import GlobalAssembler
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ----------------------------------------------------------------------
 # Geometry / material / cohesive parameters
 # ----------------------------------------------------------------------

--- a/tests/integration/test_mmb_25_experimental_validation.py
+++ b/tests/integration/test_mmb_25_experimental_validation.py
@@ -163,6 +163,8 @@ from wrinklefe.solver.assembler import GlobalAssembler  # noqa: E402
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler  # noqa: E402
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver  # noqa: E402
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ----------------------------------------------------------------------
 # Experimental data (NASA/TM-2020-220498 Section 4.16, Table 15 &
 # Figure 38 -- MMR = 25 %)

--- a/tests/integration/test_mmb_50_experimental_validation.py
+++ b/tests/integration/test_mmb_50_experimental_validation.py
@@ -279,6 +279,8 @@ from wrinklefe.solver.assembler import GlobalAssembler  # noqa: E402
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler  # noqa: E402
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver  # noqa: E402
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ----------------------------------------------------------------------
 # Experimental data (NASA/TM-2020-220498 Section 4.16, Table 15 &
 # Figure 39 -- MMR = 50 %)

--- a/tests/integration/test_mmb_75_experimental_validation.py
+++ b/tests/integration/test_mmb_75_experimental_validation.py
@@ -315,6 +315,8 @@ from wrinklefe.solver.assembler import GlobalAssembler  # noqa: E402
 from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler  # noqa: E402
 from wrinklefe.solver.nonlinear import NewtonRaphsonSolver  # noqa: E402
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ----------------------------------------------------------------------
 # Experimental data (NASA/TM-2020-220498 Section 4.16, Table 15 &
 # Figure 40 -- MMR = 75 %)

--- a/tests/integration/test_mmb_mixity_synthesis.py
+++ b/tests/integration/test_mmb_mixity_synthesis.py
@@ -91,7 +91,10 @@ import matplotlib
 matplotlib.use("Agg")  # non-interactive backend.
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
+import pytest  # noqa: E402
 from scipy.optimize import minimize_scalar  # noqa: E402
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 # ----------------------------------------------------------------------
 # Hard-coded synthesis data

--- a/tests/test_analysis_czm.py
+++ b/tests/test_analysis_czm.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import dataclasses
 
 import numpy as np
+import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
@@ -73,6 +74,7 @@ def _czm_config(**overrides) -> AnalysisConfig:
 
 class TestEnableCzmEndToEnd:
 
+    @pytest.mark.slow
     def test_enable_czm_concave_tension_runs_end_to_end(self):
         """Concave tension wrinkle drives non-zero cohesive damage at the
         crest, the Newton-Raphson loop converges, and the FE knockdown

--- a/tests/test_app_cross_section.py
+++ b/tests/test_app_cross_section.py
@@ -26,6 +26,8 @@ pytest.importorskip("streamlit", reason="Streamlit not installed.")
 
 import matplotlib  # noqa: E402
 
+pytestmark = pytest.mark.viz
+
 matplotlib.use("Agg")
 
 

--- a/tests/test_app_czm.py
+++ b/tests/test_app_czm.py
@@ -29,6 +29,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.viz
+
 # ``app.py`` lives at the repo root, not under ``src/``.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:

--- a/tests/test_app_reset_inputs.py
+++ b/tests/test_app_reset_inputs.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.viz
+
 # ``app.py`` lives at the repo root, not under ``src/``.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:

--- a/tests/test_app_tabs.py
+++ b/tests/test_app_tabs.py
@@ -21,6 +21,8 @@ pytest.importorskip("streamlit", reason="Streamlit not installed.")
 
 import matplotlib  # noqa: E402
 
+pytestmark = pytest.mark.viz
+
 matplotlib.use("Agg")
 
 

--- a/tests/test_benchmarks/README.md
+++ b/tests/test_benchmarks/README.md
@@ -1,0 +1,21 @@
+# Performance benchmarks
+
+Micro-benchmarks for the hot kernels, driven by
+[`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/). Every
+benchmark is marked `benchmark` **and** `slow`, so it is excluded from a
+bare `pytest` run (the default `addopts` carry `-m 'not benchmark'`) and
+from the `-m "not slow"` fast lane. Run them explicitly:
+
+```bash
+pytest tests/test_benchmarks -m benchmark
+```
+
+Each benchmark runs on a small, deterministic input and asserts a
+correctness invariant (finite / bounded / expected shape) so a timing
+harness can never silently pass on a broken kernel.
+
+There is **no committed baseline** — a baseline captured inside an
+ephemeral container is meaningless on CI runners. See the "Benchmarks"
+section of `../../CONTRIBUTING.md` for how to bootstrap and refresh the
+`baseline/` directory from a green `main` run, and how the CI comparison
+gate becomes active once that directory exists.

--- a/tests/test_benchmarks/conftest.py
+++ b/tests/test_benchmarks/conftest.py
@@ -1,0 +1,61 @@
+"""Shared deterministic fixtures for the performance benchmarks.
+
+All inputs are small and fixed so a benchmark run is reproducible and
+fast enough to sit inside the CI ``benchmarks`` job. The heavier
+per-benchmark inputs (stress fields, node clouds, CZM meshes) are built
+in their own modules.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.core.mesh import WrinkleMesh
+from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+
+@pytest.fixture(scope="session")
+def coarse_material() -> OrthotropicMaterial:
+    return OrthotropicMaterial()
+
+
+@pytest.fixture(scope="session")
+def coarse_wrinkled_mesh(coarse_material):
+    """A small 8-ply wrinkled hex8 mesh reused by the FE kernels.
+
+    Returns ``(mesh, laminate)``. Geometry is intentionally coarse
+    (nx=8, ny=4, one element per ply) so assembly and a direct solve
+    complete in well under a second.
+    """
+    laminate = Laminate.from_angles(
+        [0.0] * 8, material=coarse_material, ply_thickness=0.183
+    )
+    wrinkle = GaussianSinusoidal(
+        amplitude=0.2, wavelength=8.0, width=6.0, center=0.0
+    )
+    cfg = WrinkleConfiguration.dual_wrinkle(
+        profile=wrinkle, interface1=3, interface2=4, phase=0.0
+    )
+    gen = WrinkleMesh(
+        laminate=laminate,
+        wrinkle_config=cfg,
+        Lx=10.0,
+        Ly=6.0,
+        nx=8,
+        ny=4,
+        nz_per_ply=1,
+    )
+    return gen.generate(), laminate
+
+
+def stress_sample(n: int, seed: int = 20260713) -> np.ndarray:
+    """Deterministic ``(n, 6)`` stress field spanning the failure regimes."""
+    rng = np.random.default_rng(seed)
+    s = rng.uniform(-800.0, 800.0, (n, 6))
+    # Bias the fibre-direction component so both tension and compression
+    # (and hence the fibre-tension / fibre-kinking branches) are exercised.
+    s[:, 0] = rng.uniform(-2200.0, 2200.0, n)
+    return s

--- a/tests/test_benchmarks/test_bench_assembly.py
+++ b/tests/test_benchmarks/test_bench_assembly.py
@@ -1,0 +1,28 @@
+"""Benchmark: global stiffness assembly on a coarse wrinkled mesh."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from wrinklefe.solver.assembler import GlobalAssembler
+
+pytestmark = [pytest.mark.benchmark, pytest.mark.slow]
+
+
+def test_bench_assemble_stiffness(benchmark, coarse_wrinkled_mesh):
+    mesh, laminate = coarse_wrinkled_mesh
+
+    def _assemble():
+        return GlobalAssembler(mesh, laminate).assemble_stiffness()
+
+    K = benchmark(_assemble)
+
+    # Correctness invariant: a well-formed global stiffness matrix.
+    n = mesh.n_dof
+    assert K.shape == (n, n)
+    assert sparse.issparse(K)
+    assert K.nnz > 0
+    assert np.all(np.isfinite(K.data))
+    # Symmetric to numerical tolerance.
+    assert abs(K - K.T).max() <= 1e-6 * abs(K).max()

--- a/tests/test_benchmarks/test_bench_czm_newton.py
+++ b/tests/test_benchmarks/test_bench_czm_newton.py
@@ -1,0 +1,152 @@
+"""Benchmark: a bounded cohesive (CZM) Newton solve on a coarse DCB.
+
+A deliberately small Double-Cantilever-Beam (few elements, a handful of
+displacement increments) exercises the cohesive-element + Newton-Raphson
+path — the most expensive kernel in the suite — while staying well under
+~30 s. The invariant is that the opening drives real cohesive damage and
+a finite reaction load, so a broken CZM path cannot pass as "fast".
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.cohesive_mesh import insert_cohesive_interface
+from wrinklefe.core.laminate import Laminate, Ply
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.core.mesh import WrinkleMesh
+from wrinklefe.elements.cohesive8 import CohesiveProperties
+from wrinklefe.solver.assembler import GlobalAssembler
+from wrinklefe.solver.boundary import BoundaryCondition, BoundaryHandler
+from wrinklefe.solver.nonlinear import NewtonRaphsonSolver
+
+pytestmark = [pytest.mark.benchmark, pytest.mark.slow]
+
+L_TOTAL = 40.0
+WIDTH = 25.0
+H_ARM = 1.5
+A0_PRECRACK = 20.0
+NX = 10
+NY = 1
+NZ_PER_ARM = 2
+
+MAT = OrthotropicMaterial(
+    name="DCB_CFRP",
+    E1=135_000.0, E2=9_000.0, E3=9_000.0,
+    G12=5_000.0, G13=5_000.0, G23=3_000.0,
+    nu12=0.30, nu13=0.30, nu23=0.40,
+)
+COH_PROPS = CohesiveProperties(
+    K=1.0e6, sigma_max=25.0, tau_max=25.0,
+    GIc=0.28, GIIc=0.79, eta_BK=1.45, beta=1.0,
+)
+DELTA_MAX = 2.5
+N_INC = 5
+
+
+def _laminate() -> Laminate:
+    return Laminate([
+        Ply(material=MAT, angle=0.0, thickness=H_ARM),
+        Ply(material=MAT, angle=0.0, thickness=H_ARM),
+    ])
+
+
+def _build_mesh():
+    wm = WrinkleMesh(
+        laminate=_laminate(), wrinkle_config=None,
+        Lx=L_TOTAL, Ly=WIDTH, nx=NX, ny=NY, nz_per_ply=NZ_PER_ARM,
+    )
+    base_mesh = wm.generate()
+    z_mid = 0.5 * (
+        float(base_mesh.nodes[:, 2].min()) + float(base_mesh.nodes[:, 2].max())
+    )
+    new_mesh, all_coh = insert_cohesive_interface(
+        base_mesh, z_interface=z_mid, cohesive_props=COH_PROPS,
+    )
+    kept = [c for c in all_coh if float(c.node_coords[:4, 0].mean()) >= A0_PRECRACK]
+    for k, c in enumerate(kept):
+        c.elem_id = k
+    return new_mesh, kept
+
+
+def _build_bcs(mesh, delta):
+    tol = 1e-6
+    z, x, y = mesh.nodes[:, 2], mesh.nodes[:, 0], mesh.nodes[:, 1]
+    z_min, z_max = float(z.min()), float(z.max())
+    x_min_v, x_max_v = float(x.min()), float(x.max())
+    on_z_min, on_z_max = np.abs(z - z_min) <= tol, np.abs(z - z_max) <= tol
+    on_x_min, on_x_max = np.abs(x - x_min_v) <= tol, np.abs(x - x_max_v) <= tol
+    on_y_min = np.abs(y - float(y.min())) <= tol
+    on_y_max = np.abs(y - float(y.max())) <= tol
+
+    def fn(m):
+        return np.flatnonzero(m).astype(np.intp)
+
+    half = 0.5 * float(delta)
+    return [
+        BoundaryCondition(
+            bc_type="fixed", node_ids=fn(on_x_max & on_z_min), dofs=[0, 1, 2]
+        ),
+        BoundaryCondition(
+            bc_type="fixed", node_ids=fn(on_x_max & on_z_max), dofs=[0, 1]
+        ),
+        BoundaryCondition(bc_type="fixed", node_ids=fn(on_y_min), dofs=[1]),
+        BoundaryCondition(bc_type="fixed", node_ids=fn(on_y_max), dofs=[1]),
+        BoundaryCondition(
+            bc_type="displacement", node_ids=fn(on_x_min & on_z_max),
+            dofs=[2], value=+half,
+        ),
+        BoundaryCondition(
+            bc_type="displacement", node_ids=fn(on_x_min & on_z_min),
+            dofs=[2], value=-half,
+        ),
+    ]
+
+
+def _drive():
+    mesh, cohesive_elements = _build_mesh()
+    assembler = GlobalAssembler(
+        mesh=mesh, laminate=_laminate(),
+        cohesive_elements=[(c.elem_id, c) for c in cohesive_elements],
+    )
+    bc_handler = BoundaryHandler(mesh)
+    solver = NewtonRaphsonSolver(
+        assembler=assembler, bc_handler=bc_handler,
+        boundary_conditions=_build_bcs(mesh, 0.0),
+        n_increments=1, max_newton_iter=100,
+        tol_residual=1e-4, tol_absolute=1e-8, tol_displacement=1e-9,
+        line_search=False,
+    )
+    u = np.zeros(mesh.n_dof)
+    step = DELTA_MAX / N_INC
+    P_final = 0.0
+    for i in range(N_INC):
+        bcs = _build_bcs(mesh, (i + 1) * step)
+        cons = bc_handler.get_constrained_dofs(bcs)
+        F_ext = bc_handler.get_force_dofs(bcs)
+        u_new, _n, ok = solver._newton_step(u, F_ext, cons, verbose=False, inc=1)
+        if not ok:
+            continue
+        u = u_new
+        solver._commit_state()
+        F_int = assembler.assemble_internal_force(u)
+        P_final = float(np.abs(F_int).max())
+    max_d = max(
+        (s.d for cid in range(len(cohesive_elements)) for s in assembler.cohesive_state[cid]),
+        default=0.0,
+    )
+    n_coh = len(cohesive_elements)
+    return max_d, P_final, n_coh
+
+
+def test_bench_czm_newton_dcb(benchmark):
+    max_d, P_final, n_coh = benchmark.pedantic(
+        _drive, rounds=1, iterations=1, warmup_rounds=0
+    )
+
+    # Correctness invariant: cohesive elements exist, the opening drove
+    # real damage (0 < d), and the reaction load is finite and non-zero.
+    assert n_coh > 0
+    assert 0.0 < max_d <= 1.0
+    assert np.isfinite(P_final)
+    assert P_final > 0.0

--- a/tests/test_benchmarks/test_bench_failure_field.py
+++ b/tests/test_benchmarks/test_bench_failure_field.py
@@ -1,0 +1,40 @@
+"""Benchmark: vectorised LaRC05 field evaluation (guards #299).
+
+The per-Gauss-point failure evaluation is one of the hottest kernels in a
+full analysis; #299 replaced the Python per-point loop with a broadcast
+``evaluate_field``. This benchmark exercises it on a ~20k-point stress
+array so a regression back toward the per-point path is caught.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.material import MaterialLibrary
+from wrinklefe.failure.larc05 import LaRC05Criterion
+
+from .conftest import stress_sample
+
+pytestmark = [pytest.mark.benchmark, pytest.mark.slow]
+
+N_POINTS = 20_000
+
+
+def test_bench_larc05_evaluate_field(benchmark):
+    material = MaterialLibrary().get("IM7_8552")
+    criterion = LaRC05Criterion()
+    stress = stress_sample(N_POINTS)
+
+    def _evaluate():
+        return criterion.evaluate_field(stress, material)
+
+    indices, modes, reserve_factors = benchmark(_evaluate)
+
+    # Correctness invariant: one result per point, all finite and
+    # physically ordered (failure index >= 0, reserve factor > 0).
+    assert indices.shape == (N_POINTS,)
+    assert modes.shape == (N_POINTS,)
+    assert reserve_factors.shape == (N_POINTS,)
+    assert np.all(np.isfinite(indices))
+    assert np.all(indices >= 0.0)
+    assert np.all(reserve_factors > 0.0)

--- a/tests/test_benchmarks/test_bench_modulus_knockdown.py
+++ b/tests/test_benchmarks/test_bench_modulus_knockdown.py
@@ -1,0 +1,73 @@
+"""Benchmark: batched laminate modulus knockdown (guards #301).
+
+``_laminate_modulus_knockdown`` batches the per-(ply, x) off-axis
+rotation and plane-stress condensation over the whole grid (#301, a ~52x
+speedup over the former Python loop). This benchmark drives it on a
+multi-ply, multi-wrinkle grid and checks the knockdown stays in the
+physical ``(0, 1]`` band.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.analysis import _laminate_modulus_knockdown
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import OrthotropicMaterial
+
+pytestmark = [pytest.mark.benchmark, pytest.mark.slow]
+
+ANGLES = [0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0]
+N_X = 4000  # longitudinal stations
+PLY_THICKNESS = 0.183
+DOMAIN = 40.0
+
+
+def _build_inputs():
+    material = OrthotropicMaterial()
+    n_plies = len(ANGLES)
+    x = np.linspace(-DOMAIN / 2.0, DOMAIN / 2.0, N_X)
+
+    # Two wrinkles at distinct interfaces, mirroring the production
+    # slope-field / through-thickness-decay construction.
+    specs = [
+        # (amplitude, wavelength, width, z_center, decay_scale)
+        (0.3, 8.0, 6.0, 3.5 * PLY_THICKNESS, 4.0),
+        (0.2, 12.0, 8.0, 4.5 * PLY_THICKNESS, 6.0),
+    ]
+    n_w = len(specs)
+    slope_field = np.empty((n_w, N_X), dtype=float)
+    ply_decays = np.empty((n_plies, n_w, N_X), dtype=float)
+    for w, (amp, lam, wid, z_center, ds) in enumerate(specs):
+        gauss_env = np.exp(-(x**2) / (wid**2))
+        k = 2.0 * np.pi / lam
+        slope_field[w] = amp * gauss_env * (
+            (-2.0 * x / (wid**2)) * np.cos(k * x) - k * np.sin(k * x)
+        )
+        sigma_sq2 = 2.0 * ds * ds
+        for p in range(n_plies):
+            z_p = (p + 0.5) * PLY_THICKNESS
+            ply_decays[p, w, :] = np.exp(-((z_p - z_center) ** 2) / sigma_sq2)
+
+    laminate = Laminate.from_angles(ANGLES, material, PLY_THICKNESS)
+    return material, laminate, slope_field, ply_decays
+
+
+def test_bench_laminate_modulus_knockdown(benchmark):
+    material, laminate, slope_field, ply_decays = _build_inputs()
+
+    def _knockdown():
+        return _laminate_modulus_knockdown(
+            slope_field=slope_field,
+            ply_decays=ply_decays,
+            angles=ANGLES,
+            stiffness_3d=material.stiffness_matrix,
+            ply_thickness=PLY_THICKNESS,
+            E_x0=laminate.Ex,
+        )
+
+    kd = benchmark(_knockdown)
+
+    # Correctness invariant: a wavy laminate is knocked down into (0, 1].
+    assert np.isfinite(kd)
+    assert 0.0 < kd <= 1.0

--- a/tests/test_benchmarks/test_bench_morphology.py
+++ b/tests/test_benchmarks/test_bench_morphology.py
@@ -1,0 +1,64 @@
+"""Benchmark: vectorised wrinkle morphology on a large node cloud (#185).
+
+``apply_to_nodes`` (mesh deformation) and ``fiber_angles_at_nodes``
+(per-node misalignment) were vectorised over nodes in #185/#252. This
+benchmark drives both on ~50k nodes to guard that vectorisation.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+pytestmark = [pytest.mark.benchmark, pytest.mark.slow]
+
+N_PLIES = 8
+NX = 80
+NY = 80  # 8 * 80 * 80 = 51_200 nodes
+
+
+def _node_cloud():
+    x = np.linspace(-8.0, 8.0, NX)
+    y = np.linspace(-6.0, 6.0, NY)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    xy = np.column_stack([xx.ravel(), yy.ravel()])
+    n_per_ply = xy.shape[0]
+    ply_thickness = 0.183
+    nodes = np.empty((N_PLIES * n_per_ply, 3), dtype=float)
+    ply_ids = np.empty(N_PLIES * n_per_ply, dtype=int)
+    for p in range(N_PLIES):
+        sl = slice(p * n_per_ply, (p + 1) * n_per_ply)
+        nodes[sl, 0] = xy[:, 0]
+        nodes[sl, 1] = xy[:, 1]
+        nodes[sl, 2] = (p + 0.5) * ply_thickness
+        ply_ids[sl] = p
+    return nodes, ply_ids
+
+
+def test_bench_apply_and_angles(benchmark):
+    nodes, ply_ids = _node_cloud()
+    wrinkle = GaussianSinusoidal(
+        amplitude=0.3, wavelength=8.0, width=6.0, center=0.0
+    )
+    cfg = WrinkleConfiguration.dual_wrinkle(
+        profile=wrinkle, interface1=3, interface2=4, phase=0.0
+    )
+
+    def _morph():
+        deformed = cfg.apply_to_nodes(nodes, ply_ids, n_plies=N_PLIES)
+        angles = cfg.fiber_angles_at_nodes(nodes, ply_ids, n_plies=N_PLIES)
+        return deformed, angles
+
+    deformed, angles = benchmark(_morph)
+
+    # Correctness invariant: shapes preserved, all finite, the wrinkle
+    # actually displaces nodes and induces non-zero fibre tilt.
+    assert deformed.shape == nodes.shape
+    assert np.all(np.isfinite(deformed))
+    assert np.abs(deformed[:, 2] - nodes[:, 2]).max() > 0.0
+    assert angles.shape == (nodes.shape[0],)
+    assert np.all(np.isfinite(angles))
+    assert np.all(angles >= 0.0)
+    assert angles.max() > 0.0

--- a/tests/test_benchmarks/test_bench_static_solve.py
+++ b/tests/test_benchmarks/test_bench_static_solve.py
@@ -1,0 +1,26 @@
+"""Benchmark: linear static direct solve on a coarse wrinkled mesh."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.solver.boundary import BoundaryHandler
+from wrinklefe.solver.static import StaticSolver
+
+pytestmark = [pytest.mark.benchmark, pytest.mark.slow]
+
+
+def test_bench_static_solve(benchmark, coarse_wrinkled_mesh):
+    mesh, laminate = coarse_wrinkled_mesh
+    bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.01)
+
+    def _solve():
+        return StaticSolver(mesh, laminate).solve(bcs)
+
+    results = benchmark(_solve)
+
+    # Correctness invariant: a full displacement field, all finite, and a
+    # non-trivial response to the applied compressive strain.
+    assert results.displacement.shape == (mesh.n_nodes, 3)
+    assert np.all(np.isfinite(results.displacement))
+    assert np.abs(results.displacement).max() > 0.0

--- a/tests/test_integration/test_analysis.py
+++ b/tests/test_integration/test_analysis.py
@@ -12,6 +12,8 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 # ======================================================================
 # Fixtures
 # ======================================================================

--- a/tests/test_integration/test_blocked_layup_confinement.py
+++ b/tests/test_integration/test_blocked_layup_confinement.py
@@ -45,6 +45,8 @@ from wrinklefe.analysis import (
 from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 _MUKHOPADHYAY_LAYUP_STR = "[45_2/90_2/-45_2/0_2]_3s"
 _ELHAJJAR_LAYUP_STR = "[0/45/90/-45/0/45/-45/0]_s"
 

--- a/tests/test_integration/test_elhajjar_validation.py
+++ b/tests/test_integration/test_elhajjar_validation.py
@@ -15,6 +15,8 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 # ======================================================================
 # Fixtures
 # ======================================================================

--- a/tests/test_integration/test_multi_wrinkle.py
+++ b/tests/test_integration/test_multi_wrinkle.py
@@ -20,6 +20,8 @@ from wrinklefe.analysis import (
 )
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 # ---------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------

--- a/tests/test_integration/test_multi_wrinkle_czm.py
+++ b/tests/test_integration/test_multi_wrinkle_czm.py
@@ -34,6 +34,8 @@ import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis, WrinkleSpec
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 _ANGLES_8 = [0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0]
 
 # Shared geometry: A=0.3, lambda=8, w=2 at ply interface 3 under 3%

--- a/tests/test_integration/test_multi_wrinkle_fe.py
+++ b/tests/test_integration/test_multi_wrinkle_fe.py
@@ -16,6 +16,8 @@ import pytest
 
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis, WrinkleSpec
 
+pytestmark = pytest.mark.integration
+
 _ANGLES_8 = [0.0, 45.0, -45.0, 90.0, 90.0, -45.0, 45.0, 0.0]
 
 

--- a/tests/test_integration/test_tension_onset.py
+++ b/tests/test_integration/test_tension_onset.py
@@ -25,6 +25,8 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 # ----------------------------------------------------------------------
 # Fixtures
 # ----------------------------------------------------------------------

--- a/tests/test_integration/test_tension_validation.py
+++ b/tests/test_integration/test_tension_validation.py
@@ -17,6 +17,8 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
 # ======================================================================
 # Fixtures
 # ======================================================================

--- a/tests/test_integration/test_through_thickness_decay.py
+++ b/tests/test_integration/test_through_thickness_decay.py
@@ -33,6 +33,8 @@ from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.layup import parse_layup
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 
 def _kd(cfg: AnalysisConfig) -> float:
     return float(WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown)

--- a/tests/test_integration/test_wavelength_estimation.py
+++ b/tests/test_integration/test_wavelength_estimation.py
@@ -19,6 +19,8 @@ import pytest
 
 from wrinklefe.analysis import estimate_wavelength_from_amplitude
 
+pytestmark = pytest.mark.integration
+
 # ----------------------------------------------------------------------
 # Linear scaling
 # ----------------------------------------------------------------------

--- a/tests/test_integration/test_wrinkle_z_position.py
+++ b/tests/test_integration/test_wrinkle_z_position.py
@@ -35,6 +35,8 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.integration
+
 
 def _li_2025_base_kwargs() -> dict:
     """Common AC318_S6C10 / UD [0]_14 / S-M-2 geometry."""

--- a/tests/test_modulus_retention_global.py
+++ b/tests/test_modulus_retention_global.py
@@ -30,6 +30,8 @@ import pytest
 from wrinklefe.analysis import AnalysisConfig, AnalysisResults, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary
 
+pytestmark = pytest.mark.slow
+
 ML = MaterialLibrary()
 
 # A through-thickness ("uniform") UD wrinkle: the wrinkle penetrates the

--- a/tests/test_progressive_damage.py
+++ b/tests/test_progressive_damage.py
@@ -24,6 +24,8 @@ from wrinklefe.solver.progressive_damage import (
     _mode_family,
 )
 
+pytestmark = pytest.mark.slow
+
 ML = MaterialLibrary()
 MAT = ML.get("AC318_S6C10")
 N_PLIES = 15

--- a/tests/test_resin_pocket.py
+++ b/tests/test_resin_pocket.py
@@ -15,6 +15,8 @@ from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
 from wrinklefe.core.resin_pocket import ResinPocketSpec, compute_resin_mask
 
+pytestmark = pytest.mark.slow
+
 
 # ----------------------------------------------------------------------
 # Isotropic material constructor

--- a/tests/test_streamlit_viz.py
+++ b/tests/test_streamlit_viz.py
@@ -24,6 +24,8 @@ pytest.importorskip("plotly")
 
 import streamlit_viz as sv  # noqa: E402
 
+pytestmark = pytest.mark.viz
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_sweep_parallel_issue260.py
+++ b/tests/test_sweep_parallel_issue260.py
@@ -163,6 +163,7 @@ class TestRunSweepParallel:
             assert par["results"][key] == seq["results"][key]
 
     @_FORK_ONLY
+    @pytest.mark.slow
     def test_parallel_is_faster_than_sequential(self):
         """4 workers on 8 quarter-second points must beat sequential by
         a wide margin (generous threshold to stay CI-robust)."""

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -29,6 +29,8 @@ pytest.importorskip("streamlit", reason="Streamlit not installed.")
 
 import usage_tracking  # noqa: E402  - test-time import after path/skip setup.
 
+pytestmark = pytest.mark.viz
+
 
 def test_gate_disabled_via_env_var(monkeypatch):
     """With the off-switch set, the gate is disabled and render_gate no-ops."""

--- a/tests/test_viz/test_no_figure_leak.py
+++ b/tests/test_viz/test_no_figure_leak.py
@@ -25,6 +25,8 @@ import pytest
 from wrinklefe.core.wrinkle import GaussianSinusoidal
 from wrinklefe.viz import figure_context, plot_wrinkle_profile, save_figure
 
+pytestmark = pytest.mark.slow
+
 N_ITERATIONS = 30
 
 


### PR DESCRIPTION
## Linked issue

Fixes #267  Fixes #271

## Summary

Two test-infrastructure changes, split across two commits.

**#267 — pytest marker vocabulary and a fast lane.** Declares four registered markers in `pyproject.toml` (`slow`, `integration`, `viz`, `benchmark`) under `--strict-markers`, with a default `-m 'not benchmark'` so a bare `pytest` stays fast. Files are annotated by **measured** duration (`--durations`), not guesswork:

- `tests/integration/` (all 10 files) → `integration` + `slow` — the CZM Newton solves that dominate CI wall-time.
- `tests/test_integration/` → `integration`; `slow` added only to the two files that contain a measured >5 s test (`test_multi_wrinkle_czm.py`, `test_tension_validation.py`).
- Elsewhere, `slow` on the measured >5 s stragglers: file-level on `test_resin_pocket.py`, `test_progressive_damage.py`, `test_modulus_retention_global.py`, `test_viz/test_no_figure_leak.py`; per-test on the single slow cases in `test_analysis_czm.py` and `test_sweep_parallel_issue260.py`. (`test_cli_czm.py` measured 2.8 s, so it stays in the fast lane.)
- `viz` on the six streamlit/plotly test files.

`pytest -m "not slow"` collects **zero** `tests/integration/` files and runs locally in ~2m22s (1518 passed, 73 deselected).

**CI (`ci.yml`):** the OS/Python matrix job now runs `-m "not slow"`; a new `test-full` job (ubuntu, 3.12) runs the complete suite (`-m "not benchmark"`) and owns the Codecov upload — moved off the matrix so slow-path coverage isn't lost when the slow tests leave the matrix. Existing job names are unchanged (branch-protection). `CONTRIBUTING.md` documents the fast path and the marker meanings.

**#271 — benchmark suite.** New `tests/test_benchmarks/` with six benchmarks over the hot kernels: global stiffness assembly, linear static solve, vectorised LaRC05 field eval (#299), wrinkle morphology apply/angles on ~50k nodes (#185), a bounded coarse-DCB cohesive-Newton solve, and the batched laminate modulus knockdown (#301). Each is marked `benchmark` + `slow` (excluded from both a bare run and the fast lane) and asserts a correctness invariant so a timing harness can't silently pass on a broken kernel. `pytest-benchmark>=4.0` is added to the `dev` extra.

A new `benchmarks` CI job autosaves timings as an artifact and runs a **conditional** regression gate (`--benchmark-compare-fail=median:100%`, i.e. 2x) that activates only once a baseline exists. The 2x threshold (not 50%) deliberately absorbs the large run-to-run CPU variance of shared CI runners; a tighter bound would flake. **No baseline is committed** — timings captured inside an ephemeral container are meaningless against a CI runner. `CONTRIBUTING.md` documents bootstrapping `tests/test_benchmarks/baseline/` from a green `main` artifact and the deliberate, reviewed refresh procedure.

The regression gate was verified locally: injecting a `time.sleep(0.5)` into one kernel produced a ~960% median regression and `--benchmark-compare-fail=median:100%` failed the run (exit 1); the sleep was then removed and never committed.

No numeric outputs change — `python scripts/validate.py` matches all pinned baselines.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (`-m "not slow"`: 1518 passed; full suite runs on the new `test-full` job)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (a pre-existing `app.py:217` note is unrelated to this PR — app.py is untouched and identical on `main`)
- [x] Docs updated (`CONTRIBUTING.md`: fast path, markers, benchmark bootstrap/refresh)
- [ ] `CHANGELOG.md` `[Unreleased]` — not applicable; test/CI infrastructure only, no user-visible or numeric change
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_