### PR TITLE
Save/load AnalysisConfig: --config flag + to_dict/from_dict (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Save / load an `AnalysisConfig` (issue #259).
+  `AnalysisConfig.to_dict()` / `from_dict()` provide a round-trippable,
+  `config_version`-stamped serialisation; `save_json` / `load_json`
+  (and extension-dispatching `save` / `load`, plus optional YAML when
+  PyYAML is installed) read and write config files. Library materials
+  serialise by preset name, custom materials inline, and penetration-gate
+  presets by their registry name (new
+  `wrinklefe.core.penetration_gate.GATE_PRESETS`). Loading rejects
+  unknown keys and version mismatches loudly. The `wrinklefe analyze`
+  CLI gains `--config PATH` (load a config, with explicitly-passed flags
+  overriding the file) and `--save-config PATH` (write the effective
+  config). A follow-up will surface the same config download/upload in
+  the Streamlit app.
 - Streamlit app — **Through-thickness cross-section** on the Configure
   tab: a new panel that draws the deformed ply stack in the (x, z) plane
   so users can see how the wrinkle manifests through the laminate

--- a/README.md
+++ b/README.md
@@ -376,6 +376,32 @@ wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
     --no-analytical-only --parallel 4
 ```
 
+### Saving and reusing a configuration
+
+`analyze` can persist and reload a full `AnalysisConfig`. `--save-config`
+writes the *effective* configuration (after any `--config` file and CLI
+overrides are applied); `--config` reloads it. Any flag given on the same
+command line as `--config` overrides the file value, while flags left off
+keep the file's value:
+
+```bash
+# Save the effective config to a file, then reuse it verbatim
+wrinklefe analyze --amplitude 0.4 --morphology concave --save-config case.json
+wrinklefe analyze --config case.json
+
+# Reuse the file but override one parameter (0.9 wins over the file's value)
+wrinklefe analyze --config case.json --amplitude 0.9
+```
+
+The same round-trip is available programmatically via
+`AnalysisConfig.to_dict()` / `from_dict()` and the
+`save_json` / `load_json` (and extension-dispatching `save` / `load`)
+helpers. The JSON pins a `config_version` field; loading a file with an
+unknown key or a mismatched version fails loudly. YAML is supported when
+PyYAML is installed (it is not a required dependency). Library materials
+serialise by name, custom materials inline, and penetration-gate presets
+serialise by their registry name.
+
 ### Exporting results to CSV / JSON
 
 Numeric outputs (load factor, per-ply failure index, knockdown factors,

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -82,6 +82,20 @@ wrinklefe converge --tolerance 0.01   # mesh-convergence study
 wrinklefe materials                   # list the material library
 ```
 
+An `analyze` run can be saved to a config file and reloaded later.
+`--save-config PATH` writes the effective configuration; `--config PATH`
+reloads it, with any flag on the same command line overriding the file
+value:
+
+```bash
+wrinklefe analyze --amplitude 0.4 --morphology concave --save-config case.json
+wrinklefe analyze --config case.json                  # reuse verbatim
+wrinklefe analyze --config case.json --amplitude 0.9  # override one value
+```
+
+The same round-trip is available on {class}`~wrinklefe.analysis.AnalysisConfig`
+via `to_dict` / `from_dict` and `save_json` / `load_json`.
+
 ## Runnable examples
 
 The repository's `examples/` directory contains scripts for the common

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -37,12 +37,14 @@ References
 from __future__ import annotations
 
 import itertools
+import json
 import logging
 import math
 import os
 from collections.abc import Callable, Sequence
 from concurrent.futures import ProcessPoolExecutor
-from dataclasses import dataclass, fields, replace
+from dataclasses import asdict, dataclass, fields, replace
+from pathlib import Path
 from typing import Any, Literal, cast
 
 import numpy as np
@@ -59,6 +61,7 @@ from wrinklefe.core.morphology import (
     WrinklePlacement,
 )
 from wrinklefe.core.penetration_gate import (
+    GATE_PRESETS,
     GateParameters,
     penetration_gate_kd,
 )
@@ -820,6 +823,98 @@ class WrinkleSpec:
     width: float
     ply_interface: int
     phase_offset: float = 0.0
+
+
+#: Schema version stamped into :meth:`AnalysisConfig.to_dict` output and
+#: verified by :meth:`AnalysisConfig.from_dict`.  Bump this whenever the
+#: serialised config layout changes in a non-round-trippable way so old
+#: files fail loudly rather than load into a mismatched schema.
+CONFIG_VERSION = 1
+
+
+def _material_to_jsonable(mat: OrthotropicMaterial | None) -> dict | None:
+    """Serialise a material as a library-preset reference or inline custom.
+
+    A material equal (field-for-field) to the like-named library preset is
+    written as ``{"preset": name}`` so the file stays compact and tracks
+    library updates; any other material — including one that reuses a
+    library name but tweaks a property — is written as
+    ``{"custom": material.to_dict()}`` so no information is lost.
+    """
+    if mat is None:
+        return None
+    try:
+        preset = MaterialLibrary().get(mat.name)
+    except KeyError:
+        preset = None
+    if preset is not None and preset.to_dict() == mat.to_dict():
+        return {"preset": mat.name}
+    return {"custom": mat.to_dict()}
+
+
+def _material_from_jsonable(
+    value: dict | None, *, field: str
+) -> OrthotropicMaterial | None:
+    """Inverse of :func:`_material_to_jsonable`."""
+    if value is None:
+        return None
+    if (
+        not isinstance(value, dict)
+        or len(value) != 1
+        or next(iter(value)) not in ("preset", "custom")
+    ):
+        raise ValueError(
+            f"AnalysisConfig.from_dict: {field} must be null, "
+            f"{{'preset': name}}, or {{'custom': {{...}}}}, got {value!r}"
+        )
+    if "preset" in value:
+        try:
+            return MaterialLibrary().get(value["preset"])
+        except KeyError as exc:
+            raise ValueError(
+                f"AnalysisConfig.from_dict: {field} references unknown "
+                f"material preset {value['preset']!r}"
+            ) from exc
+    return OrthotropicMaterial.from_dict(value["custom"])
+
+
+def _gate_to_jsonable(gate: GateParameters | None) -> dict | None:
+    """Serialise a penetration gate as a registered-preset reference.
+
+    Only the calibrated presets in
+    :data:`wrinklefe.core.penetration_gate.GATE_PRESETS` are serialisable
+    (the parameters are material-realization specific and are not meant to
+    be hand-authored inline).  An unregistered custom gate raises so the
+    lossy write surfaces loudly instead of silently dropping data.
+    """
+    if gate is None:
+        return None
+    preset = GATE_PRESETS.get(gate.name)
+    if preset is not None and preset == gate:
+        return {"preset": gate.name}
+    raise ValueError(
+        f"AnalysisConfig.to_dict: penetration_gate {gate.name!r} is not a "
+        f"registered preset and inline custom gates are not serialisable; "
+        f"use one of {sorted(GATE_PRESETS)} or None"
+    )
+
+
+def _gate_from_jsonable(value: dict | None) -> GateParameters | None:
+    """Inverse of :func:`_gate_to_jsonable`."""
+    if value is None:
+        return None
+    if not isinstance(value, dict) or set(value) != {"preset"}:
+        raise ValueError(
+            "AnalysisConfig.from_dict: penetration_gate must be null or "
+            f"{{'preset': name}}, got {value!r}"
+        )
+    name = value["preset"]
+    if name not in GATE_PRESETS:
+        raise ValueError(
+            f"AnalysisConfig.from_dict: unknown penetration_gate preset "
+            f"{name!r}; available {sorted(GATE_PRESETS)}"
+        )
+    return GATE_PRESETS[name]
 
 
 @dataclass
@@ -1648,6 +1743,195 @@ class AnalysisConfig:
                         f"AnalysisConfig.wrinkles[{i}].phase_offset must "
                         f"be finite, got {spec.phase_offset}"
                     )
+
+    # ------------------------------------------------------------------
+    # Serialisation (round-trippable save / load) — issue #259
+    # ------------------------------------------------------------------
+    #: Object-valued fields serialised through dedicated encoders rather
+    #: than emitted as-is.  Every remaining field is a JSON-native scalar
+    #: or list, so this list plus the plain fields covers the dataclass in
+    #: full — the completeness guard in the test-suite pins that invariant.
+    _NON_PRIMITIVE_FIELDS = frozenset(
+        {"material", "resin_pocket_material", "angles", "wrinkles",
+         "penetration_gate"}
+    )
+
+    def to_dict(self) -> dict:
+        """Serialise this config to a plain, JSON-round-trippable dict.
+
+        The dict carries a ``config_version`` key and one entry per
+        dataclass field.  Non-primitive fields are handled explicitly:
+        materials become ``{"preset": name}`` or ``{"custom": {...}}``,
+        ``angles`` the resolved ply list, ``wrinkles`` a list of plain
+        dicts, and ``penetration_gate`` a ``{"preset": name}`` reference.
+        Because the values are the *resolved* ones (post ``__post_init__``),
+        the file is self-contained and ``load`` -> ``to_dict`` is
+        idempotent.
+
+        See Also
+        --------
+        from_dict : Inverse constructor.
+        save_json, load_json : File helpers.
+        """
+        out: dict = {"config_version": CONFIG_VERSION}
+        for f in fields(self):
+            value = getattr(self, f.name)
+            if f.name in ("material", "resin_pocket_material"):
+                out[f.name] = _material_to_jsonable(value)
+            elif f.name == "wrinkles":
+                out[f.name] = (
+                    None if value is None else [asdict(s) for s in value]
+                )
+            elif f.name == "penetration_gate":
+                out[f.name] = _gate_to_jsonable(value)
+            elif f.name == "angles":
+                out[f.name] = (
+                    None if value is None else [float(a) for a in value]
+                )
+            elif isinstance(value, np.ndarray):
+                out[f.name] = value.tolist()
+            elif isinstance(value, (list, tuple)):
+                out[f.name] = [
+                    float(v) if isinstance(v, (np.integer, np.floating)) else v
+                    for v in value
+                ]
+            elif isinstance(value, np.integer):
+                out[f.name] = int(value)
+            elif isinstance(value, np.floating):
+                out[f.name] = float(value)
+            else:
+                out[f.name] = value
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict) -> AnalysisConfig:
+        """Reconstruct an :class:`AnalysisConfig` from :meth:`to_dict` output.
+
+        The ``config_version`` must match :data:`CONFIG_VERSION` and every
+        remaining key must name a dataclass field — an unknown key or a
+        version mismatch raises :class:`ValueError` naming the offender
+        rather than being silently ignored.  Construction runs the normal
+        ``__post_init__`` / ``_validate`` path, so a malformed file fails
+        with the same messages a bad in-code config would.
+
+        Raises
+        ------
+        ValueError
+            On version mismatch, unknown keys, or invalid field values.
+        """
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"AnalysisConfig.from_dict expects a dict, got "
+                f"{type(data).__name__}"
+            )
+        payload = dict(data)
+        version = payload.pop("config_version", None)
+        if version != CONFIG_VERSION:
+            raise ValueError(
+                f"AnalysisConfig.from_dict: unsupported config_version "
+                f"{version!r} (expected {CONFIG_VERSION})"
+            )
+        valid = {f.name for f in fields(cls)}
+        unknown = set(payload) - valid
+        if unknown:
+            raise ValueError(
+                f"AnalysisConfig.from_dict: unknown key(s) "
+                f"{sorted(unknown)}; valid fields are {sorted(valid)}"
+            )
+        kwargs = dict(payload)
+        for mkey in ("material", "resin_pocket_material"):
+            if mkey in kwargs:
+                kwargs[mkey] = _material_from_jsonable(kwargs[mkey], field=mkey)
+        if kwargs.get("wrinkles") is not None:
+            specs = kwargs["wrinkles"]
+            if not isinstance(specs, list):
+                raise ValueError(
+                    "AnalysisConfig.from_dict: wrinkles must be null or a "
+                    f"list, got {type(specs).__name__}"
+                )
+            rebuilt: list[WrinkleSpec] = []
+            for i, entry in enumerate(specs):
+                if not isinstance(entry, dict):
+                    raise ValueError(
+                        f"AnalysisConfig.from_dict: wrinkles[{i}] must be a "
+                        f"dict, got {type(entry).__name__}"
+                    )
+                spec_fields = {f.name for f in fields(WrinkleSpec)}
+                extra = set(entry) - spec_fields
+                if extra:
+                    raise ValueError(
+                        f"AnalysisConfig.from_dict: wrinkles[{i}] has "
+                        f"unknown key(s) {sorted(extra)}"
+                    )
+                rebuilt.append(WrinkleSpec(**entry))
+            kwargs["wrinkles"] = rebuilt
+        if "penetration_gate" in kwargs:
+            kwargs["penetration_gate"] = _gate_from_jsonable(
+                kwargs["penetration_gate"]
+            )
+        return cls(**kwargs)
+
+    def to_json(self) -> str:
+        """Return the config as a deterministic JSON string."""
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def save_json(self, path: str | Path) -> None:
+        """Write the config to ``path`` as JSON (parent dirs created)."""
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(self.to_json(), encoding="utf-8")
+
+    @classmethod
+    def load_json(cls, path: str | Path) -> AnalysisConfig:
+        """Load a config from a JSON file written by :meth:`save_json`."""
+        text = Path(path).read_text(encoding="utf-8")
+        return cls.from_dict(json.loads(text))
+
+    def save_yaml(self, path: str | Path) -> None:
+        """Write the config as YAML.
+
+        Optional: requires PyYAML (not a hard dependency).  Raises
+        :class:`ImportError` with an actionable message when it is absent.
+        """
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - env-dependent
+            raise ImportError(
+                "PyYAML is required for YAML config I/O; install it "
+                "(`pip install pyyaml`) or use the JSON helpers."
+            ) from exc
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            yaml.safe_dump(self.to_dict(), sort_keys=True), encoding="utf-8"
+        )
+
+    @classmethod
+    def load_yaml(cls, path: str | Path) -> AnalysisConfig:
+        """Load a config from a YAML file (requires PyYAML)."""
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - env-dependent
+            raise ImportError(
+                "PyYAML is required for YAML config I/O; install it "
+                "(`pip install pyyaml`) or use the JSON helpers."
+            ) from exc
+        text = Path(path).read_text(encoding="utf-8")
+        return cls.from_dict(yaml.safe_load(text))
+
+    def save(self, path: str | Path) -> None:
+        """Save the config, dispatching to YAML for ``.yaml`` / ``.yml``."""
+        if Path(path).suffix.lower() in (".yaml", ".yml"):
+            self.save_yaml(path)
+        else:
+            self.save_json(path)
+
+    @classmethod
+    def load(cls, path: str | Path) -> AnalysisConfig:
+        """Load a config, dispatching to YAML for ``.yaml`` / ``.yml``."""
+        if Path(path).suffix.lower() in (".yaml", ".yml"):
+            return cls.load_yaml(path)
+        return cls.load_json(path)
 
 
 # ======================================================================

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -1894,7 +1894,7 @@ class AnalysisConfig:
         :class:`ImportError` with an actionable message when it is absent.
         """
         try:
-            import yaml
+            import yaml  # type: ignore[import-untyped]
         except ImportError as exc:  # pragma: no cover - env-dependent
             raise ImportError(
                 "PyYAML is required for YAML config I/O; install it "
@@ -1910,7 +1910,7 @@ class AnalysisConfig:
     def load_yaml(cls, path: str | Path) -> AnalysisConfig:
         """Load a config from a YAML file (requires PyYAML)."""
         try:
-            import yaml
+            import yaml  # type: ignore[import-untyped]
         except ImportError as exc:  # pragma: no cover - env-dependent
             raise ImportError(
                 "PyYAML is required for YAML config I/O; install it "

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -285,6 +285,38 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # ------------------------------------------------------------------ #
+    # Config file save / load (issue #259).
+    # ------------------------------------------------------------------ #
+    p_analyze.add_argument(
+        "--config", type=str, default=None, dest="config",
+        help=(
+            "Load an AnalysisConfig from a JSON (or .yaml/.yml, if PyYAML "
+            "is installed) file written by --save-config. Any analyze flag "
+            "given on the same command line overrides the file value; flags "
+            "left off take the file value."
+        ),
+    )
+    p_analyze.add_argument(
+        "--save-config", type=str, default=None, dest="save_config",
+        help=(
+            "Write the effective configuration (after applying any --config "
+            "file and CLI overrides) to this path as JSON (or YAML for a "
+            ".yaml/.yml extension) and continue with the analysis."
+        ),
+    )
+
+    # Config-file precedence (issue #259): give every analyze option a
+    # SUPPRESS default so ``vars(args)`` contains only the flags the user
+    # actually passed. ``_cmd_analyze`` starts from the --config file (or
+    # the AnalysisConfig defaults) and overrides only those explicit flags,
+    # so a flag left off the command line keeps the file's value. Scoped to
+    # the analyze subparser only — the other subcommands keep their
+    # ordinary defaults.
+    for _action in p_analyze._actions:
+        if _action.dest != "help":
+            _action.default = argparse.SUPPRESS
+
+    # ------------------------------------------------------------------ #
     # compare
     # ------------------------------------------------------------------ #
     p_compare = subparsers.add_parser(
@@ -635,75 +667,115 @@ def _parse_angles(angles_str: str | None) -> list[float] | None:
 
 
 def _cmd_analyze(args: argparse.Namespace) -> None:
-    """Handle the ``analyze`` subcommand."""
+    """Handle the ``analyze`` subcommand.
+
+    Config-file precedence (issue #259): the analyze subparser uses
+    ``argparse.SUPPRESS`` defaults, so ``vars(args)`` contains only the
+    flags the user actually passed. We start from the ``--config`` file
+    (or the ``AnalysisConfig`` defaults when there is no file) and apply
+    each explicitly-passed flag as an override — a flag left off keeps the
+    file's value.
+    """
+    import dataclasses
+
     from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
     from wrinklefe.core.material import MaterialLibrary
 
-    # Resolve material
-    material = None
-    if args.material is not None:
-        lib = MaterialLibrary()
-        material = lib.get(args.material)
+    present = vars(args)
 
-    angles = _parse_angles(args.angles)
+    def given(name: str) -> bool:
+        return name in present
+
+    # Base config: a --config file, or None (fall back to dataclass
+    # defaults built by the constructor below).
+    base: AnalysisConfig | None = None
+    if given("config"):
+        try:
+            base = AnalysisConfig.load(args.config)
+        except (OSError, ValueError, ImportError) as exc:
+            print(f"error: could not load --config: {exc}", file=sys.stderr)
+            sys.exit(2)
+
+    # Direct field overrides from explicitly-passed flags. ``strain`` and
+    # ``material`` / ``angles`` map onto renamed / parsed config fields.
+    overrides: dict = {}
+    _direct = (
+        "amplitude", "wavelength", "width", "morphology",
+        "amplitude_profile", "amplitude_profile_decay_length",
+        "amplitude_profile_axis", "loading", "interface_1", "interface_2",
+        "nx", "ny", "solver", "verbose",
+    )
+    for name in _direct:
+        if given(name):
+            overrides[name] = getattr(args, name)
+    if given("strain"):
+        overrides["applied_strain"] = args.strain
+    if given("material"):
+        overrides["material"] = (
+            MaterialLibrary().get(args.material)
+            if args.material is not None else None
+        )
+    if given("angles"):
+        overrides["angles"] = _parse_angles(args.angles)
+
+    # CZM overrides. Each maps to its AnalysisConfig field; --enable-czm is
+    # a store_true so it only appears when set.
+    if given("enable_czm"):
+        overrides["enable_czm"] = True
+    if given("czm_interfaces"):
+        overrides["czm_interfaces"] = _parse_czm_interfaces(args.czm_interfaces)
+    for name in ("czm_GIc", "czm_GIIc", "czm_sigma_max", "czm_tau_max",
+                 "czm_newton_tol"):
+        if given(name):
+            overrides[name] = getattr(args, name)
+    if given("czm_load_increments"):
+        overrides["czm_n_load_increments"] = args.czm_load_increments
 
     # Resolve analytical-only vs. full FE intent.
     #
     # Precedence (highest first):
-    #   1. --enable-czm      -> force full FE solve (CZM requires NR)
-    #   2. --analytical-only -> skip FE
-    #   3. --fe              -> full FE solve
-    #   4. --no-fe           -> analytical-only
-    #   5. default           -> full FE solve
-    enable_czm = bool(getattr(args, "enable_czm", False))
-    if enable_czm:
+    #   1. --enable-czm (or a config with CZM on) -> force FE (CZM needs NR)
+    #   2. --analytical-only                       -> skip FE
+    #   3. --fe / --no-fe                          -> FE / analytical-only
+    #   4. --config file's analytical_only value   -> inherit
+    #   5. default                                 -> full FE solve
+    enable_czm_eff = overrides.get("enable_czm", False) or (
+        base is not None and base.enable_czm
+    )
+    if enable_czm_eff:
         analytical_only = False
-    elif args.analytical_only:
+    elif given("analytical_only"):
         analytical_only = True
-    elif args.fe is True:
+    elif given("fe") and args.fe is True:
         analytical_only = False
-    elif args.fe is False:
+    elif given("fe") and args.fe is False:
         analytical_only = True
+    elif base is not None:
+        analytical_only = base.analytical_only
     else:
         analytical_only = False
+    overrides["analytical_only"] = analytical_only
 
-    # CZM kwargs. When --enable-czm is absent these defaults exactly
-    # match ``AnalysisConfig``'s class defaults so the resulting config
-    # is bit-identical to the pre-CZM behaviour.
-    czm_kwargs: dict = {}
-    if enable_czm:
-        czm_kwargs = dict(
-            enable_czm=True,
-            czm_interfaces=_parse_czm_interfaces(args.czm_interfaces),
-            czm_GIc=args.czm_GIc,
-            czm_GIIc=args.czm_GIIc,
-            czm_sigma_max=args.czm_sigma_max,
-            czm_tau_max=args.czm_tau_max,
-            czm_n_load_increments=args.czm_load_increments,
-            czm_newton_tol=args.czm_newton_tol,
-        )
+    try:
+        if base is None:
+            config = AnalysisConfig(**overrides)
+        else:
+            config = dataclasses.replace(base, **overrides)
+    except (ValueError, KeyError) as exc:
+        print(f"error: invalid configuration: {exc}", file=sys.stderr)
+        sys.exit(2)
 
-    config = AnalysisConfig(
-        amplitude=args.amplitude,
-        wavelength=args.wavelength,
-        width=args.width,
-        morphology=args.morphology,
-        amplitude_profile=args.amplitude_profile,
-        amplitude_profile_decay_length=args.amplitude_profile_decay_length,
-        amplitude_profile_axis=args.amplitude_profile_axis,
-        loading=args.loading,
-        material=material,
-        angles=angles,
-        interface_1=args.interface_1,
-        interface_2=args.interface_2,
-        nx=args.nx,
-        ny=args.ny,
-        applied_strain=args.strain,
-        solver=args.solver,
-        analytical_only=analytical_only,
-        verbose=args.verbose,
-        **czm_kwargs,
-    )
+    enable_czm = config.enable_czm
+
+    # Persist the effective config before running, if requested.
+    if given("save_config"):
+        try:
+            config.save(args.save_config)
+        except (OSError, ValueError, ImportError) as exc:
+            print(f"error: could not write --save-config: {exc}",
+                  file=sys.stderr)
+            sys.exit(2)
+        print(f"Effective configuration written to: {args.save_config}")
 
     analysis = WrinkleAnalysis(config)
     try:
@@ -723,7 +795,7 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         _print_czm_extras(result)
 
     # Optional CZM figure export.
-    if enable_czm and args.save_czm_figure is not None:
+    if enable_czm and given("save_czm_figure") and args.save_czm_figure is not None:
         if result.czm_damage is None or not result.czm_damage.size:
             print(
                 "warning: --save-czm-figure ignored, no CZM damage data "
@@ -748,7 +820,7 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
                 )
 
     # Export to JSON if requested
-    if args.output_json is not None:
+    if given("output_json") and args.output_json is not None:
         from wrinklefe.io.export import export_results_json
         export_results_json(result, args.output_json)
         print(f"\nResults exported to: {args.output_json}")

--- a/src/wrinklefe/core/penetration_gate.py
+++ b/src/wrinklefe/core/penetration_gate.py
@@ -106,6 +106,17 @@ GATE_LI2025_VACBAG = GateParameters(
 )
 
 
+#: Name -> :class:`GateParameters` registry of the calibrated presets.
+#: Used by :meth:`wrinklefe.analysis.AnalysisConfig.to_dict` /
+#: :meth:`~wrinklefe.analysis.AnalysisConfig.from_dict` so a saved config
+#: can reference a gate by name rather than inlining (material-realization
+#: specific) constants.  Keyed by each preset's ``.name``.
+GATE_PRESETS: dict[str, GateParameters] = {
+    GATE_LI2024_MOULDED.name: GATE_LI2024_MOULDED,
+    GATE_LI2025_VACBAG.name: GATE_LI2025_VACBAG,
+}
+
+
 def angle_floor(theta_deg, gamma_Y: float):
     """Budiansky-Fleck angle-only knockdown ``1 / (1 + theta_rad/gamma_Y)``.
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,319 @@
+"""Save / load round-trips for :class:`AnalysisConfig` (issue #259).
+
+Covers the canonical serialisation contract:
+
+* ``from_dict(to_dict(cfg))`` reproduces ``cfg`` for defaults, a custom
+  material, a CZM config, a multi-wrinkle config, and a penetration-gate
+  preset.
+* ``save_json`` / ``load_json`` (and the extension-dispatching
+  ``save`` / ``load``) round-trip through a file.
+* Unknown keys and a ``config_version`` mismatch are rejected loudly,
+  naming the offender.
+* The ``analyze --config`` CLI path reaches the same config as the
+  equivalent explicit flags, and an explicit flag overrides the file.
+* A completeness guard walks ``dataclasses.fields(AnalysisConfig)`` so a
+  silently-dropped field fails the suite (the #345-style drift guard).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wrinklefe.analysis import (
+    CONFIG_VERSION,
+    AnalysisConfig,
+    WrinkleSpec,
+)
+from wrinklefe.core.material import OrthotropicMaterial
+from wrinklefe.core.penetration_gate import (
+    GATE_LI2024_MOULDED,
+    GATE_LI2025_VACBAG,
+)
+
+# --------------------------------------------------------------------------- #
+# Sample configs
+# --------------------------------------------------------------------------- #
+
+_SMALL_LAYUP = [0.0, 45.0, -45.0, 90.0]
+_UD_LAYUP = [0.0, 0.0, 0.0, 0.0]
+
+
+def _sample_configs() -> dict[str, AnalysisConfig]:
+    return {
+        "defaults": AnalysisConfig(),
+        "custom_material": AnalysisConfig(
+            material=OrthotropicMaterial(name="mine", E1=101_000.0, E2=8_000.0),
+            angles=list(_SMALL_LAYUP),
+        ),
+        "czm": AnalysisConfig(
+            enable_czm=True,
+            czm_interfaces=[1, 2],
+            czm_GIc=0.3,
+            angles=[0.0, 90.0, 0.0, 90.0],
+            analytical_only=False,
+        ),
+        "multi_wrinkle": AnalysisConfig(
+            wrinkles=[
+                WrinkleSpec(0.3, 16.0, 12.0, 1),
+                WrinkleSpec(0.2, 10.0, 8.0, 2, phase_offset=0.5),
+            ],
+            angles=list(_SMALL_LAYUP),
+            analytical_only=True,
+        ),
+        "penetration_gate": AnalysisConfig(
+            penetration_gate=GATE_LI2024_MOULDED,
+            angles=list(_UD_LAYUP),
+        ),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Round-trips
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", list(_sample_configs()))
+def test_dict_round_trip(name):
+    """``from_dict(to_dict(cfg))`` reproduces the config (dict + object eq)."""
+    cfg = _sample_configs()[name]
+    d = cfg.to_dict()
+    assert d["config_version"] == CONFIG_VERSION
+    restored = AnalysisConfig.from_dict(d)
+    # Idempotent serialisation and full dataclass equality.
+    assert restored.to_dict() == d
+    assert restored == cfg
+
+
+def test_material_preset_serialised_by_name():
+    """A library material serialises as a preset reference, not inline."""
+    cfg = AnalysisConfig()  # default material is the IM7_8552 preset
+    assert cfg.to_dict()["material"] == {"preset": "IM7_8552"}
+
+
+def test_custom_material_serialised_inline():
+    """A material that differs from the like-named preset is inlined."""
+    cfg = AnalysisConfig(
+        material=OrthotropicMaterial(name="IM7_8552", E1=1.0e5),
+        angles=list(_SMALL_LAYUP),
+    )
+    mat = cfg.to_dict()["material"]
+    assert set(mat) == {"custom"}
+    assert mat["custom"]["E1"] == pytest.approx(1.0e5)
+
+
+def test_penetration_gate_preset_reference():
+    cfg = AnalysisConfig(
+        penetration_gate=GATE_LI2025_VACBAG, angles=list(_UD_LAYUP)
+    )
+    assert cfg.to_dict()["penetration_gate"] == {
+        "preset": "AC318_S6C10_vacbag"
+    }
+
+
+def test_unregistered_gate_raises_on_to_dict():
+    from wrinklefe.core.penetration_gate import GateParameters
+
+    cfg = AnalysisConfig(
+        penetration_gate=GateParameters(0.2, 0.1, 3.0, name="homebrew"),
+        angles=list(_UD_LAYUP),
+    )
+    with pytest.raises(ValueError, match="homebrew"):
+        cfg.to_dict()
+
+
+# --------------------------------------------------------------------------- #
+# File helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_save_load_json_file(tmp_path):
+    cfg = _sample_configs()["multi_wrinkle"]
+    path = tmp_path / "case.json"
+    cfg.save_json(path)
+    assert path.is_file()
+    assert AnalysisConfig.load_json(path).to_dict() == cfg.to_dict()
+
+
+def test_save_load_dispatch_by_extension(tmp_path):
+    """``save``/``load`` pick JSON for a .json path."""
+    cfg = AnalysisConfig(amplitude=0.42)
+    path = tmp_path / "cfg.json"
+    cfg.save(path)
+    assert AnalysisConfig.load(path).amplitude == pytest.approx(0.42)
+
+
+def test_save_load_yaml_file(tmp_path):
+    """YAML round-trips when PyYAML is installed; skipped otherwise."""
+    pytest.importorskip("yaml")
+    cfg = _sample_configs()["custom_material"]
+    path = tmp_path / "case.yaml"
+    cfg.save(path)
+    assert AnalysisConfig.load(path).to_dict() == cfg.to_dict()
+
+
+# --------------------------------------------------------------------------- #
+# Loud failures
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_key_rejected_by_name():
+    d = AnalysisConfig().to_dict()
+    d["totally_bogus"] = 123
+    with pytest.raises(ValueError, match="totally_bogus"):
+        AnalysisConfig.from_dict(d)
+
+
+def test_version_mismatch_rejected():
+    d = AnalysisConfig().to_dict()
+    d["config_version"] = CONFIG_VERSION + 1
+    with pytest.raises(ValueError, match="config_version"):
+        AnalysisConfig.from_dict(d)
+
+
+def test_missing_version_rejected():
+    d = AnalysisConfig().to_dict()
+    del d["config_version"]
+    with pytest.raises(ValueError, match="config_version"):
+        AnalysisConfig.from_dict(d)
+
+
+def test_unknown_material_preset_rejected():
+    d = AnalysisConfig().to_dict()
+    d["material"] = {"preset": "no_such_material"}
+    with pytest.raises(ValueError, match="no_such_material"):
+        AnalysisConfig.from_dict(d)
+
+
+# --------------------------------------------------------------------------- #
+# Completeness guard (#345-style drift guard)
+# --------------------------------------------------------------------------- #
+
+#: Fields intentionally not exported by ``to_dict``. Empty today: every
+#: field must round-trip. A new field silently dropped from ``to_dict``
+#: is the failure mode this guard exists to catch.
+_TO_DICT_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def test_to_dict_exports_every_field():
+    """Every ``AnalysisConfig`` field is exported (or explicitly allowlisted)."""
+    exported = set(AnalysisConfig().to_dict())
+    for f in dataclasses.fields(AnalysisConfig):
+        assert f.name in exported or f.name in _TO_DICT_ALLOWLIST, (
+            f"AnalysisConfig field {f.name!r} is neither exported by "
+            f"to_dict() nor in the allowlist — it would be silently "
+            f"dropped on save."
+        )
+
+
+def test_from_dict_accepts_all_exported_keys():
+    """The full exported dict loads without an unknown-key rejection."""
+    for cfg in _sample_configs().values():
+        AnalysisConfig.from_dict(cfg.to_dict())
+
+
+# --------------------------------------------------------------------------- #
+# CLI --config parity and override
+# --------------------------------------------------------------------------- #
+
+
+def _capture_cli_config():
+    """Stub ``WrinkleAnalysis.run`` and capture the config it received."""
+    captured: dict = {}
+
+    def fake_run(self, analytical_only=None):
+        captured["config"] = self.config
+        captured["analytical_only"] = analytical_only
+        result = MagicMock()
+        result.summary.return_value = "<stub>"
+        result.czm_damage = None
+        return result
+
+    return captured, patch(
+        "wrinklefe.analysis.WrinkleAnalysis.run", new=fake_run
+    )
+
+
+def test_cli_config_parity_with_flags(tmp_path):
+    """``analyze --config file`` reaches the same config as equivalent flags."""
+    from wrinklefe.cli import main as cli_main
+
+    cfg = AnalysisConfig(
+        amplitude=0.4,
+        wavelength=12.0,
+        morphology="concave",
+        angles=list(_SMALL_LAYUP),
+        analytical_only=True,
+    )
+    path = tmp_path / "case.json"
+    cfg.save_json(path)
+
+    cap_file, patch_file = _capture_cli_config()
+    with patch_file:
+        cli_main(["analyze", "--config", str(path)])
+    from_file = cap_file["config"]
+
+    cap_flags, patch_flags = _capture_cli_config()
+    with patch_flags:
+        cli_main([
+            "analyze",
+            "--amplitude", "0.4",
+            "--wavelength", "12.0",
+            "--morphology", "concave",
+            "--angles", "0,45,-45,90",
+            "--analytical-only",
+        ])
+    from_flags = cap_flags["config"]
+
+    assert from_file.to_dict() == from_flags.to_dict()
+    # Analytical knockdowns therefore match too.
+    from wrinklefe.analysis import WrinkleAnalysis
+    kd_file = WrinkleAnalysis(from_file).run(
+        analytical_only=True
+    ).analytical_knockdown
+    kd_flags = WrinkleAnalysis(from_flags).run(
+        analytical_only=True
+    ).analytical_knockdown
+    assert kd_file == pytest.approx(kd_flags)
+
+
+def test_cli_explicit_flag_overrides_config(tmp_path):
+    """An explicit flag wins over the --config file value."""
+    from wrinklefe.cli import main as cli_main
+
+    cfg = AnalysisConfig(
+        amplitude=0.4, angles=list(_SMALL_LAYUP), analytical_only=True
+    )
+    path = tmp_path / "case.json"
+    cfg.save_json(path)
+
+    captured, patcher = _capture_cli_config()
+    with patcher:
+        cli_main([
+            "analyze", "--config", str(path), "--amplitude", "0.9",
+        ])
+    assert captured["config"].amplitude == pytest.approx(0.9)
+    # Un-overridden file values are preserved.
+    assert captured["config"].angles == _SMALL_LAYUP
+    assert captured["config"].analytical_only is True
+
+
+def test_cli_save_config_writes_effective(tmp_path):
+    """``--save-config`` writes the post-override effective config."""
+    from wrinklefe.cli import main as cli_main
+
+    out = tmp_path / "effective.json"
+    captured, patcher = _capture_cli_config()
+    with patcher:
+        cli_main([
+            "analyze", "--analytical-only",
+            "--amplitude", "0.55", "--wavelength", "9.0",
+            "--save-config", str(out),
+        ])
+    assert out.is_file()
+    loaded = AnalysisConfig.load_json(out)
+    assert loaded.amplitude == pytest.approx(0.55)
+    assert loaded.wavelength == pytest.approx(9.0)
+    assert loaded.analytical_only is True


### PR DESCRIPTION
## Linked issue

Fixes #259

## Summary

Adds a round-trippable, versioned serialisation for `AnalysisConfig` plus CLI support to save and reload it.

**Library (`analysis.py`)**
- `AnalysisConfig.to_dict()` / `from_dict()` with a `config_version` stamp. Non-primitive fields are handled explicitly:
  - `material` / `resin_pocket_material`: a library material serialises as `{"preset": name}`; any other (incl. one reusing a library name but tweaking a property) inlines as `{"custom": material.to_dict()}`.
  - `angles`: the *resolved* ply list (self-contained file, idempotent `load` -> `to_dict`).
  - `wrinkles`: a list of plain dicts (`WrinkleSpec`).
  - `penetration_gate`: a `{"preset": name}` reference against a new `GATE_PRESETS` registry; an unregistered custom gate raises on save rather than silently dropping data.
  - `from_dict` rejects unknown keys and `config_version` mismatches loudly (naming the offender) and re-runs `__post_init__`/`_validate` for free validation.
- `save_json` / `load_json`, plus extension-dispatching `save` / `load` and optional `save_yaml` / `load_yaml` (only when `import yaml` succeeds — PyYAML is **not** a new dependency).

**CLI (`cli.py`)**
- `wrinklefe analyze --config PATH` and `--save-config PATH`.
- `--config` precedence: the `analyze` subparser now uses `argparse.SUPPRESS` defaults, so `vars(args)` holds only the flags the user actually passed. `_cmd_analyze` starts from the `--config` file (or the dataclass defaults when there is no file) and overrides only those explicitly-passed flags — a flag left off keeps the file's value. `--save-config` writes the effective (post-override) config.

**Follow-up:** the Streamlit app config download/upload is intentionally out of scope here (Phase B reworks the app); `app.py` / `usage_tracking.py` are untouched.

No numeric outputs change.

## Checklist

- [x] Tests added or updated for the change (`tests/test_config_io.py`: dict/file round-trips for defaults, custom material, CZM, multi-wrinkle, penetration-gate preset; unknown-key + version rejection; CLI parity vs equivalent flags; CLI override precedence; a completeness guard walking `dataclasses.fields(AnalysisConfig)`)
- [x] `pytest -m "not slow"` green (1539 passed, 73 deselected)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (only the pre-existing `app.py:217` error on main remains, out of scope)
- [x] Docs/README updated (README + getting-started CLI + `AnalysisConfig` serialisation notes)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_