### PR TITLE
Tool-flat surfaces with surface resin pockets (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Tool-flat surfaces with surface resin pockets (issue #361).
+  Parts cured against rigid tooling / a caul sheet keep perfectly flat
+  outer surfaces while the fibres undulate internally; the wrinkle
+  troughs fill with neat resin just under the flat surface. New
+  `SurfacePocketSpec` / `compute_surface_resin_blend` in
+  `wrinklefe.core.resin_pocket` tag, per column, the transition element
+  that stretches to span the gap between the flat surface and the
+  outermost undulating ply, weighting it by the excess-stretch fraction
+  `max(0, (h - h0) / h)` — exactly volume-conserving (equal to the
+  integrated kinematic gap `-w(x)·decay_last`). Enabled via
+  `AnalysisConfig.enable_surface_resin_pockets`, `surface_pocket_side`
+  (`top`/`bottom`/`both`) and `surface_pocket_min_gap`, reusing
+  `resin_pocket_material` / `resin_pocket_graded`. FE-only effect
+  (`modulus_retention_global` and first-ply failure in the isotropic
+  resin zone); it composes with the crest lens (per-element maximum) and
+  needs no solver changes. Requires a tool-flat morphology whose decay
+  reaches 0 at the chosen surface (`stack`/`convex`/`concave`, or
+  `graded` with `decay_floor=0`); `uniform` and `graded` with a non-zero
+  floor are rejected with a message naming the fix. Disabled by default
+  (bit-identical results when off).
 - Save / load an `AnalysisConfig` (issue #259).
   `AnalysisConfig.to_dict()` / `from_dict()` provide a round-trippable,
   `config_version`-stamped serialisation; `save_json` / `load_json`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Public link, no account needed.
 - **Multi-wrinkle configurations:** Arbitrary N-wrinkle layouts via `AnalysisConfig.wrinkles` — a list of `WrinkleSpec(amplitude, wavelength, width, ply_interface, phase_offset)` — through the analytical, FE, penetration-gate (per-spec, weakest-link) and CZM paths
 - **Cohesive-zone delamination (CZM):** Bilinear traction–separation interface elements (`enable_czm=True`) with per-interface damage, energy and crack-length reporting — including continuous cohesive surfaces across adjacent wrinkles for crest-to-crest delamination link-up (see `examples/08_multi_wrinkle_czm_linkup.py`)
 - **Resin-pocket material zone:** Graded neat-epoxy lens at the wrinkle crest (modulus + fibre-angle blend, counted once) via `wrinklefe.core.resin_pocket`
+- **Tool-flat surfaces & surface resin pockets:** Parts cured against rigid tooling / a caul sheet keep perfectly flat outer surfaces while the fibres undulate internally; the wrinkle troughs fill with neat resin under the flat surface (`enable_surface_resin_pockets`, `surface_pocket_side` = `top`/`bottom`/`both`). FE-only, trough-following, volume-conserving; composes with the crest lens
 - **Progressive-damage FE:** Load-stepping `ProgressiveDamageSolver` to ultimate load with optional crack-band (Bažant–Oh) regularization — the first FE route to a UD compression knockdown
 - **Penetration gate (θ, D/T, z):** Closed-form two-parameter UD predictor `KD = 1 − (1 − KD_angle(θ))·S(D/T)·P(z)` with calibrated presets; zero FE cost (`wrinklefe.core.penetration_gate`)
 - **Linear buckling:** Geometric-stiffness eigenvalue solve (`LinearBucklingSolver`) with a microbuckling knockdown — verified structural-buckling infrastructure, but a homogenised-continuum eigenvalue does not capture the *fibre-scale* wrinkle knockdown (it gets the sign wrong: the bifurcation load *rises* with the wrinkle), so it is **not** the production UD predictor (the penetration gate is); see the [modelling findings](docs/wrinkle_modeling_findings.md)
@@ -198,6 +199,42 @@ config = AnalysisConfig(
 result = WrinkleAnalysis(config).run()
 print(result.progressive_knockdown, result.progressive_strength_MPa)
 ```
+
+### Tool-flat surfaces & surface resin pockets (FE)
+
+Parts cured against rigid tooling (or under a caul sheet) keep
+**perfectly flat outer surfaces**: the fibre undulation is confined to
+the interior, and where the outermost undulating ply dips away from the
+flat surface the gap fills with **neat resin** — surface-visible pockets
+over the wrinkle troughs, thinning to nothing over the crests. WrinkleFE's
+default through-thickness decay already leaves the outer surfaces exactly
+flat (for `stack`/`convex`/`concave`, or `graded` with `decay_floor=0`);
+`enable_surface_resin_pockets` supplies the missing *material* — it tags
+the stretched transition elements as fibre-free isotropic resin (a
+stiffness hole and a matrix-cracking site where fibre-misalignment
+criteria are meaningless).
+
+```python
+config = AnalysisConfig(
+    amplitude=0.354, wavelength=7.4, width=3.7,
+    morphology="graded", loading="compression",   # graded, decay_floor=0 ⇒ flat surface
+    material=lib.get("AC318_S6C10"), angles=[0.0] * 15, ply_thickness=0.42,
+    enable_surface_resin_pockets=True,             # trough pockets under the flat surface
+    surface_pocket_side="both",                    # "top" | "bottom" | "both"
+    resin_pocket_material=lib.get("EPOXY_S6C10"),  # default if left None
+)
+result = WrinkleAnalysis(config).run()
+print(result.modulus_retention_global)
+```
+
+The pocket geometry is volume-conserving (the tagged resin equals the
+integrated kinematic gap between the flat surface and the outermost
+undulating ply) and reuses the crest-lens material plumbing, so the two
+zones **compose** (per-element maximum) when both are enabled. This is an
+**FE-only** effect: the closed-form analytical path keeps using fibre
+angles only. A `uniform` morphology (never flat) or `graded` with
+`decay_floor > 0` (wavy surface) is rejected with a message naming the
+fix.
 
 ### Penetration gate (θ, D/T, z) — UD, zero FE cost
 

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -1208,6 +1208,33 @@ class AnalysisConfig:
     resin_pocket_length_scale: float = 1.0
 
     # ------------------------------------------------------------------
+    # Surface resin pockets (tool-flat outer surface; issue #361).
+    # ------------------------------------------------------------------
+    # Parts cured against rigid tooling / a caul sheet have perfectly flat
+    # outer surfaces: the fibre undulation is confined to the interior and
+    # the wrinkle troughs fill with neat resin just under the flat surface.
+    # When ``enable_surface_resin_pockets`` is True the FE path tags, in the
+    # chosen outer band(s), the transition element that stretches to span
+    # the gap between the flat surface and the outermost undulating ply, and
+    # blends in the isotropic resin card by the excess-stretch fraction
+    # (fibre-free, misalignment angle suppressed).  This is the *complement*
+    # of the crest lens (surface-bonded, trough-following) and reuses
+    # ``resin_pocket_material`` / ``resin_pocket_graded`` for the material
+    # and blend behaviour.  FE-only effect (``modulus_retention_global`` and
+    # FPF in the resin zone); no analytical-path change.  Requires a
+    # tool-flat morphology whose decay reaches 0 at the chosen surface
+    # (``stack``/``convex``/``concave`` or ``graded`` with
+    # ``decay_floor == 0``); ``uniform`` and ``graded`` with a floor leave
+    # wavy surfaces and are rejected.
+    enable_surface_resin_pockets: bool = False
+    # Which tool-flat surface(s) to tag: "top" (+z), "bottom" (-z), "both".
+    surface_pocket_side: str = "top"
+    # Absolute gap (mm) below which an element is treated as flat, so
+    # numerically-flat regions do not produce resin "dust".  ``None`` uses
+    # the ply-thickness-scaled default (0.01 * ply_thickness).
+    surface_pocket_min_gap: float | None = None
+
+    # ------------------------------------------------------------------
     # Progressive-damage FE path (load-stepping ply-discount to ultimate
     # load).  When ``enable_progressive_damage`` is True the FE solve runs
     # the :class:`~wrinklefe.solver.progressive_damage.ProgressiveDamageSolver`
@@ -1550,6 +1577,66 @@ class AnalysisConfig:
                 raise ValueError(
                     f"AnalysisConfig.{name} must be a finite positive "
                     f"float, got {val!r}"
+                )
+
+        # --- Surface resin pockets (tool-flat surface; issue #361) ----
+        if not isinstance(self.enable_surface_resin_pockets, bool):
+            raise ValueError(
+                f"AnalysisConfig.enable_surface_resin_pockets must be a "
+                f"bool, got {self.enable_surface_resin_pockets!r}"
+            )
+        if self.surface_pocket_side not in ("top", "bottom", "both"):
+            raise ValueError(
+                f"AnalysisConfig.surface_pocket_side must be 'top', "
+                f"'bottom' or 'both', got {self.surface_pocket_side!r}"
+            )
+        if self.surface_pocket_min_gap is not None and not (
+            isinstance(self.surface_pocket_min_gap, (int, float))
+            and not isinstance(self.surface_pocket_min_gap, bool)
+            and math.isfinite(self.surface_pocket_min_gap)
+            and self.surface_pocket_min_gap >= 0.0
+        ):
+            raise ValueError(
+                f"AnalysisConfig.surface_pocket_min_gap must be a "
+                f"non-negative finite float or None, got "
+                f"{self.surface_pocket_min_gap!r}"
+            )
+        if self.enable_surface_resin_pockets:
+            # Surface pockets are an FE-only material effect; they have no
+            # analytical-path knockdown, so an analytical-only run would
+            # silently drop them (mirrors the FE-only nature of the crest
+            # pocket, but rejected explicitly so it cannot no-op unnoticed).
+            if self.analytical_only:
+                raise ValueError(
+                    "AnalysisConfig: enable_surface_resin_pockets requires "
+                    "the FE path (an isotropic resin zone in the mesh); it "
+                    "has no effect under analytical_only=True. Set "
+                    "analytical_only=False or disable surface resin pockets."
+                )
+            # The chosen surface must be tool-flat, i.e. the through-thickness
+            # decay must reach 0 there. ``uniform`` never decays (wavy
+            # surfaces); ``graded`` with a non-zero floor leaves residual
+            # surface waviness.  Name the conflict and the fix.
+            morph = (
+                self.morphology.lower().strip()
+                if isinstance(self.morphology, str)
+                else self.morphology
+            )
+            if morph == "uniform":
+                raise ValueError(
+                    "AnalysisConfig: uniform morphology has wavy outer "
+                    "surfaces (displacement never decays through the "
+                    "thickness); surface resin pockets require a tool-flat "
+                    "morphology. Use 'stack'/'convex'/'concave', or 'graded' "
+                    "with decay_floor=0."
+                )
+            if morph == "graded" and self.decay_floor > 0.0:
+                raise ValueError(
+                    "AnalysisConfig: graded morphology with decay_floor="
+                    f"{self.decay_floor} leaves the outer surfaces wavy "
+                    "(the floor is a residual surface amplitude); surface "
+                    "resin pockets require a tool-flat surface. Set "
+                    "decay_floor=0 (or use 'stack'/'convex'/'concave')."
                 )
 
         # --- Progressive-damage path ----------------------------------
@@ -2443,6 +2530,12 @@ class WrinkleAnalysis:
         # 4a2. Resin-pocket material zone (Li et al. 2024/2025).
         if cfg.enable_resin_pocket:
             self._attach_resin_pocket(mesh, laminate)
+
+        # 4a3. Surface resin pockets under a tool-flat surface (issue #361).
+        # Runs after the crest lens so the two compose (per-element max)
+        # rather than overwrite.
+        if cfg.enable_surface_resin_pockets:
+            self._attach_surface_resin_pockets(mesh, laminate, wrinkle_config)
 
         results.mesh = mesh
 
@@ -3937,6 +4030,75 @@ class WrinkleAnalysis:
                 "graded" if cfg.resin_pocket_graded else "binary",
                 n_resin, mesh.n_elements, spec.half_length,
                 spec.h_center, z_center,
+            )
+
+    def _attach_surface_resin_pockets(
+        self, mesh: MeshData, laminate: Laminate,
+        wrinkle_config: WrinkleConfiguration,
+    ) -> None:
+        """Tag the surface resin pockets under the tool-flat surface(s).
+
+        Computes the per-element surface-pocket blend weight from the
+        deformed mesh (:func:`compute_surface_resin_blend`) and attaches it
+        to *mesh* using the same fields the crest lens uses, so the
+        assembler / stress-recovery / failure paths pick it up unchanged.
+
+        The two pocket systems **compose**: when the crest lens has already
+        written ``resin_blend`` / ``resin_blend_materials`` (or the binary
+        ``resin_mask``), the surface weight is merged by per-element maximum
+        and the blended materials are rebuilt from the combined weight, so
+        no element is double-blended.  Both reuse ``resin_pocket_material``.
+        """
+        from wrinklefe.core.resin_pocket import (
+            SurfacePocketSpec,
+            compute_surface_resin_blend,
+        )
+
+        cfg = self.config
+        spec = SurfacePocketSpec(
+            side=cfg.surface_pocket_side,
+            min_gap_threshold=cfg.surface_pocket_min_gap,
+        )
+        weight = compute_surface_resin_blend(mesh, wrinkle_config, spec)
+
+        resin_material = cfg.resin_pocket_material
+        if resin_material is None:
+            resin_material = MaterialLibrary().get("EPOXY_S6C10")
+        mesh.resin_material = resin_material
+
+        if cfg.resin_pocket_graded:
+            # Compose with any crest-lens weight already on the mesh, then
+            # rebuild the blended materials from the combined weight so ties
+            # resolve to the larger resin fraction (no double-blend).
+            if mesh.resin_blend is not None:
+                weight = np.maximum(mesh.resin_blend, weight)
+            mesh.resin_blend = weight
+            blend_mats: dict[int, OrthotropicMaterial] = {}
+            for e_np in np.flatnonzero(weight > 0.0):
+                e = int(e_np)
+                ply_mat = laminate.plies[int(mesh.ply_ids[e])].material
+                blend_mats[e] = ply_mat.blend(resin_material, float(weight[e]))
+            mesh.resin_blend_materials = blend_mats
+            n_surface = int((weight > 0.0).sum())
+        else:
+            surface_mask = weight > 0.5
+            if mesh.resin_mask is not None:
+                surface_mask = surface_mask | mesh.resin_mask
+            mesh.resin_mask = surface_mask
+            n_surface = int(surface_mask.sum())
+
+        max_gap = 0.0
+        if np.any(weight > 0.0):
+            ez = mesh.nodes[mesh.elements][:, :, 2]
+            h = ez.max(axis=1) - ez.min(axis=1)
+            max_gap = float(np.max(weight * h))
+
+        if cfg.verbose:
+            import logging
+            logging.getLogger(__name__).info(
+                "Surface resin pockets (%s): %d/%d elements tagged "
+                "(max gap %.3g mm)",
+                cfg.surface_pocket_side, n_surface, mesh.n_elements, max_gap,
             )
 
     def _evaluate_failure(

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -4081,7 +4081,12 @@ class WrinkleAnalysis:
             mesh.resin_blend_materials = blend_mats
             n_surface = int((weight > 0.0).sum())
         else:
-            surface_mask = weight > 0.5
+            # Binary rule for surface pockets: any transition element with a
+            # gap above ``surface_pocket_min_gap`` is neat resin.  (Unlike the
+            # crest lens, the excess-stretch fraction is a partial fill that
+            # rarely exceeds 0.5, so a ``> 0.5`` cut would tag nothing; graded
+            # is the default and recommended path.)
+            surface_mask = weight > 0.0
             if mesh.resin_mask is not None:
                 surface_mask = surface_mask | mesh.resin_mask
             mesh.resin_mask = surface_mask

--- a/src/wrinklefe/core/resin_pocket.py
+++ b/src/wrinklefe/core/resin_pocket.py
@@ -1,4 +1,18 @@
-"""Resin-pocket material zone for wrinkled laminates (Li et al. 2024/2025).
+"""Resin-pocket material zones for wrinkled laminates.
+
+Two physically distinct resin zones share this module because they share
+the same *material* treatment (a fibre-free, isotropic, soft inclusion
+that suppresses the meaningless fibre-misalignment angle) and the same
+downstream mesh plumbing (``resin_mask`` / ``resin_blend`` +
+``resin_blend_materials``, consumed by the assembler, stress recovery and
+failure evaluator with **zero** solver changes):
+
+1. **Crest lens** (:class:`ResinPocketSpec`, :func:`compute_resin_mask`,
+   :func:`compute_resin_blend`; Li et al. 2024/2025) — a machined cosine
+   epoxy insert at the wrinkle crest, mid-thickness.
+2. **Surface resin pockets** (:class:`SurfacePocketSpec`,
+   :func:`compute_surface_resin_blend`) — the neat-resin pockets that fill
+   the wrinkle *troughs* just under a **tool-flat outer surface**.
 
 The machined cosine resin insert that creates the wrinkle in the Li
 unidirectional glass/epoxy datasets is co-cured **bulk epoxy**, so the
@@ -11,6 +25,44 @@ pocket.  This module supplies the missing zone: given a generated
 flags the hex elements whose centroids fall inside the lens so the
 assembler / stress recovery can swap in the resin material and suppress
 the (meaningless) fibre-misalignment angle there.
+
+Tool-flat surfaces and surface resin pockets
+---------------------------------------------
+Parts cured against rigid tooling (or under a caul sheet) have
+**perfectly flat outer surfaces**: the fibre undulation is confined to
+the interior and, where the outermost undulating ply dips *away* from the
+flat tool surface, the volume deficit fills with **neat resin** —
+surface-visible pockets over the wrinkle troughs, thinning to nothing
+over the crests.  WrinkleFE's default through-thickness decay already
+gets the *kinematics* right for free (the decay reaches exactly zero at
+both outer surfaces for the ``stack``/``convex``/``concave`` morphologies
+and for ``graded`` with ``decay_floor == 0`` — see
+:func:`~wrinklefe.core.morphology.WrinkleConfiguration._through_thickness_decay`),
+but the *material* is wrong: the sub-surface elements silently **stretch**
+over the troughs while keeping their stiff fibre-direction material.
+Physically that stretched volume is fibre-free isotropic resin — a
+stiffness hole and a matrix-cracking initiation site where
+fibre-misalignment failure criteria are meaningless.
+
+:func:`compute_surface_resin_blend` recovers that zone from the deformed
+mesh geometry.  For each column of elements it walks inward from the
+chosen flat surface to the first element whose deformed height ``h``
+departs from the nominal height ``h0`` (the transition element straddling
+the outermost pinned/undulating interface), and assigns a resin blend
+weight equal to the **excess-stretch fraction**::
+
+    weight = max(0, (h - h0) / h)
+
+This is exactly volume-conserving: the resin volume tagged in a column
+equals ``weight * h * area == (h - h0) * area``, i.e. the integrated
+kinematic gap ``-w(x) * decay_last`` between the flat surface and the
+outermost undulating ply.  It is automatically zero over crests and
+wherever the ply moves *toward* the tool (those elements compress; v1
+leaves them as host material — the local fibre-volume increase is treated
+as neutral).  This zone is the *complement* of the crest lens:
+surface-bonded and trough-following rather than a mid-thickness crest
+insert.  Both may be enabled together; their weights compose by
+per-element maximum.
 
 Geometry
 --------
@@ -215,4 +267,183 @@ def compute_resin_blend(mesh: MeshData, spec: ResinPocketSpec) -> np.ndarray:
     weight: np.ndarray = w_x * w_z
     weight[~within_x] = 0.0
     weight[dz > half_height] = 0.0
+    return weight
+
+
+# =======================================================================
+# Surface resin pockets (tool-flat outer surface, trough-following)
+# =======================================================================
+
+
+@dataclass(frozen=True)
+class SurfacePocketSpec:
+    """Geometry rule for surface resin pockets under a tool-flat surface.
+
+    Unlike :class:`ResinPocketSpec` (a fixed cosine lens), the surface
+    pocket is derived from the *deformed* mesh: it tags the transition
+    element in each column where the outermost undulating ply pulls away
+    from the flat surface, weighting it by the excess-stretch fraction.
+    There is therefore no explicit position/size here — only which
+    surface(s) to inspect and the flatness tolerance.
+
+    Parameters
+    ----------
+    side : {"top", "bottom", "both"}
+        Which tool-flat surface(s) to tag.  ``"top"`` is the ``+z`` face,
+        ``"bottom"`` the ``-z`` face.  ``"both"`` tags each and composes
+        the two weight fields by per-element maximum.
+    min_gap_threshold : float or None, optional
+        Absolute gap (mm) below which an element is treated as flat, so
+        numerically-flat regions do not produce resin "dust".  ``None``
+        (default) uses ``0.01 * ply_thickness`` inferred from the mesh.
+    compaction_stiffening : bool, optional
+        Reserved stretch-goal knob.  When ``False`` (default) the
+        compression side (ply moving toward the tool) stays host material;
+        no compaction stiffening is modelled in v1.  Present so the API is
+        stable when the feature lands.
+    """
+
+    side: str = "top"
+    min_gap_threshold: float | None = None
+    compaction_stiffening: bool = False
+
+    def __post_init__(self) -> None:
+        if self.side not in ("top", "bottom", "both"):
+            raise ValueError(
+                f"SurfacePocketSpec.side must be 'top', 'bottom' or 'both', "
+                f"got {self.side!r}"
+            )
+        if self.min_gap_threshold is not None and not (
+            math.isfinite(self.min_gap_threshold) and self.min_gap_threshold >= 0.0
+        ):
+            raise ValueError(
+                f"SurfacePocketSpec.min_gap_threshold must be a non-negative "
+                f"finite float or None, got {self.min_gap_threshold!r}"
+            )
+
+
+def _tag_surface_side(
+    gap: np.ndarray,
+    height: np.ndarray,
+    nonflat: np.ndarray,
+    side: str,
+    nz: int,
+    ncol: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Tag the single transition element-layer nearest one flat surface.
+
+    The surface pocket lives in exactly one horizontal element-layer: the
+    layer straddling the outermost pinned/undulating interface (the pinned
+    surface plies above it are flat, the interior below undulates).  That
+    layer is the non-flat layer with the extreme k-index toward the chosen
+    surface — fixed across all columns, so a column where the wrinkle
+    happens to cross zero (locally flat) never leaks the tag onto a deeper
+    internal ply interface.
+
+    Returns the transition-layer element indices and their blend weights
+    (0 where a column has no gap or the ply is in compression there).  When
+    no layer is non-flat (flat mesh) the returned arrays are empty.
+    """
+    layer_nonflat = nonflat.any(axis=1)
+    layers = np.flatnonzero(layer_nonflat)
+    if layers.size == 0:
+        empty = np.empty(0, dtype=np.int64)
+        return empty, np.empty(0, dtype=np.float64)
+
+    # Transition layer: closest non-flat layer to the chosen surface.
+    k = int(layers.max()) if side == "top" else int(layers.min())
+
+    cols = np.arange(ncol)
+    g = gap[k, cols]
+    h = height[k, cols]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        w = np.where((nonflat[k, cols]) & (g > 0.0), g / h, 0.0)
+    elem_idx = k * ncol + cols
+    return elem_idx, np.asarray(w, dtype=np.float64)
+
+
+def compute_surface_resin_blend(
+    mesh: MeshData,
+    wrinkle_config: object,
+    spec: SurfacePocketSpec,
+) -> np.ndarray:
+    """Per-element surface-pocket resin blend weight, in [0, 1].
+
+    Computes the neat-resin blend weight for the surface pockets that fill
+    the wrinkle troughs beneath a tool-flat outer surface.  The weight is
+    the excess-stretch fraction ``max(0, (h - h0) / h)`` of the transition
+    element in each column (the outermost element that departs from the
+    nominal height ``h0`` as it spans the gap to the flat surface).  It is
+    zero over crests and wherever the outermost undulating ply moves toward
+    the tool (compression side stays host material in v1).
+
+    The result is volume-conserving: ``weight * h == h - h0`` is exactly
+    the kinematic gap ``-w(x) * decay_last`` between the flat surface and
+    the outermost undulating ply, so the tagged resin volume equals the
+    integrated gap.  The geometry is read from the *already-deformed* mesh,
+    so multi-wrinkle configurations work for free (the gap comes from the
+    composed displacement field).
+
+    Parameters
+    ----------
+    mesh : MeshData
+        Generated (deformed) hex8 mesh with a tool-flat outer surface.
+    wrinkle_config : WrinkleConfiguration
+        The wrinkle configuration that deformed the mesh.  Accepted for API
+        symmetry with the crest-lens helpers and cross-checking; the blend
+        is derived from the deformed geometry so a ``None`` is rejected to
+        catch a mis-wired call (a surface pocket is meaningless without a
+        wrinkle).
+    spec : SurfacePocketSpec
+        Which surface(s) to tag and the flatness tolerance.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n_elements,)`` float array of blend weights in [0, 1];
+        ``0`` outside the tagged transition elements.
+    """
+    if wrinkle_config is None:
+        raise ValueError(
+            "compute_surface_resin_blend requires a wrinkle configuration; "
+            "surface resin pockets are meaningless on an undeformed mesh."
+        )
+
+    nz = int(mesh.nz)
+    ncol = int(mesh.nx) * int(mesh.ny)
+    n_elem = int(mesh.n_elements)
+
+    # Per-element deformed height from the 8 node z-coordinates.
+    ez = mesh.nodes[mesh.elements][:, :, 2]
+    height = ez.max(axis=1) - ez.min(axis=1)
+
+    z_lo = float(mesh.nodes[:, 2].min())
+    z_hi = float(mesh.nodes[:, 2].max())
+    total_thickness = z_hi - z_lo
+    # Structured mesh: every element has the same nominal height.
+    h0 = total_thickness / nz if nz > 0 else 0.0
+
+    n_plies = int(mesh.ply_ids.max()) + 1 if mesh.ply_ids.size else 1
+    ply_thickness = total_thickness / n_plies if n_plies > 0 else total_thickness
+    if spec.min_gap_threshold is not None:
+        tol = float(spec.min_gap_threshold)
+    else:
+        tol = 0.01 * ply_thickness
+
+    gap = height - h0
+    weight = np.zeros(n_elem, dtype=np.float64)
+
+    if n_elem != nz * ncol or nz == 0 or ncol == 0:
+        # Non-structured or degenerate mesh: no surface pocket to tag.
+        return weight
+
+    gap_grid = gap.reshape(nz, ncol)
+    height_grid = height.reshape(nz, ncol)
+    nonflat = np.abs(gap_grid) > tol
+
+    sides = ("top", "bottom") if spec.side == "both" else (spec.side,)
+    for side in sides:
+        elem_idx, w = _tag_surface_side(gap_grid, height_grid, nonflat, side, nz, ncol)
+        np.maximum.at(weight, elem_idx, w)
+
     return weight

--- a/tests/test_surface_resin_pockets.py
+++ b/tests/test_surface_resin_pockets.py
@@ -1,0 +1,278 @@
+"""Surface resin pockets under a tool-flat outer surface (issue #361).
+
+Covers the new :class:`SurfacePocketSpec` /
+:func:`compute_surface_resin_blend` geometry (fast, mesh-only) plus the
+``analysis.py`` config surface, validation and FE wiring (the FE-solve
+smoke test is marked ``integration``/``slow`` per issue #267).
+
+Part 0 spike findings this file pins:
+
+* **Flatness** — the default through-thickness decay leaves both outer
+  surfaces *exactly* flat (to floating point), so no ``flatten_surfaces``
+  clamp is needed; ``uniform`` and ``graded`` with ``decay_floor > 0`` are
+  the only non-flat cases and are rejected by validation instead.
+* **Volume conservation** — the tagged resin volume equals the integrated
+  kinematic gap ``-w(x)·decay_last`` between the flat surface and the
+  outermost undulating ply.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import MaterialLibrary
+from wrinklefe.core.mesh import WrinkleMesh
+from wrinklefe.core.morphology import WrinkleConfiguration, WrinklePlacement
+from wrinklefe.core.resin_pocket import (
+    SurfacePocketSpec,
+    compute_surface_resin_blend,
+)
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+PLY_T = 0.184
+N_PLIES = 8
+LX = 16.0
+LY = 4.0
+
+
+def _build_mesh(
+    *,
+    amplitude: float = 0.12,
+    interfaces: tuple[int, ...] = (3,),
+    phases: tuple[float, ...] | None = None,
+    nx: int = 120,
+    ny: int = 1,
+    nz_per_ply: int = 1,
+    decay_mode: str = "default",
+    decay_floor: float = 0.0,
+    wrinkle_z_position: float = 0.5,
+    width: float = 1.0e6,
+):
+    """Build a deformed hex mesh with one or more mid-laminate wrinkles."""
+    mat = MaterialLibrary().get("AS4_3501_6")
+    lam = Laminate.from_angles([0.0] * N_PLIES, mat, PLY_T)
+    if phases is None:
+        phases = (0.0,) * len(interfaces)
+    placements = [
+        WrinklePlacement(
+            profile=GaussianSinusoidal(
+                amplitude=amplitude, wavelength=LX, width=width, center=LX / 2.0
+            ),
+            ply_interface=k,
+            phase_offset=ph,
+        )
+        for k, ph in zip(interfaces, phases)
+    ]
+    wc = WrinkleConfiguration(
+        placements, decay_mode=decay_mode, decay_floor=decay_floor
+    )
+    wc.wrinkle_z_position = wrinkle_z_position
+    mesh = WrinkleMesh(
+        lam, wc, Lx=LX, Ly=LY, nx=nx, ny=ny, nz_per_ply=nz_per_ply
+    ).generate()
+    return mesh, wc
+
+
+def _element_geometry(mesh):
+    """Return (deformed height, nominal height, footprint area) per element."""
+    ez = mesh.nodes[mesh.elements][:, :, 2]
+    ex = mesh.nodes[mesh.elements][:, :, 0]
+    ey = mesh.nodes[mesh.elements][:, :, 1]
+    h = ez.max(axis=1) - ez.min(axis=1)
+    z_span = float(mesh.nodes[:, 2].max() - mesh.nodes[:, 2].min())
+    h0 = z_span / mesh.nz
+    area = (ex.max(axis=1) - ex.min(axis=1)) * (ey.max(axis=1) - ey.min(axis=1))
+    return h, h0, area
+
+
+def _surface_node_spread(mesh) -> tuple[float, float]:
+    """Peak-to-peak z of the top and bottom surface node layers."""
+    per_layer = (mesh.nx + 1) * (mesh.ny + 1)
+    k_idx = np.arange(mesh.n_nodes) // per_layer
+    top = mesh.nodes[k_idx == mesh.nz, 2]
+    bot = mesh.nodes[k_idx == 0, 2]
+    return float(top.max() - top.min()), float(bot.max() - bot.min())
+
+
+# ---------------------------------------------------------------------------
+# Part 0.1 — flatness invariant
+# ---------------------------------------------------------------------------
+
+
+def test_default_decay_leaves_outer_surfaces_exactly_flat():
+    """Spike 0.1: default decay pins both outer surfaces flat to fp tolerance."""
+    mesh, _ = _build_mesh()
+    top_spread, bot_spread = _surface_node_spread(mesh)
+    assert top_spread < 1e-12
+    assert bot_spread < 1e-12
+
+
+def test_flatness_holds_when_surface_pockets_tagged():
+    """Tagging pockets does not move any node — the surface stays flat."""
+    mesh, wc = _build_mesh()
+    before = mesh.nodes.copy()
+    _ = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="both"))
+    assert np.array_equal(mesh.nodes, before)
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — gap-field correctness and volume conservation
+# ---------------------------------------------------------------------------
+
+
+def test_weight_is_excess_stretch_fraction():
+    """weight == max(0, (h - h0) / h) exactly on the tagged transition layer."""
+    mesh, wc = _build_mesh()
+    h, h0, _ = _element_geometry(mesh)
+    w = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    tagged = w > 0
+    assert tagged.any()
+    np.testing.assert_allclose(w[tagged], ((h - h0) / h)[tagged], rtol=1e-9)
+    # Excess-stretch fraction is a valid blend weight.
+    assert w.min() >= 0.0 and w.max() <= 1.0
+
+
+def test_pockets_form_over_troughs_not_crests():
+    """Tagged top-surface elements sit over troughs (ply dips from the tool)."""
+    mesh, wc = _build_mesh()
+    w = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    centroids = mesh.nodes[mesh.elements].mean(axis=1)
+    xc = centroids[w > 0, 0]
+    # The single mid wrinkle (cos, centre at Lx/2) crests at x = Lx/2 and
+    # troughs at the ends: no pocket near the centre crest.
+    assert np.all(np.abs(xc - LX / 2.0) > LX / 8.0)
+
+
+def test_resin_volume_matches_integrated_kinematic_gap():
+    """Total tagged resin volume ≈ width · ∫ max(0, -w(x)·decay_last) dx."""
+    mesh, wc = _build_mesh(nx=200, ny=1)
+    h, h0, area = _element_geometry(mesh)
+    w = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    tagged = w > 0
+
+    # Excess-stretch form and kinematic-gap form of the per-element volume
+    # agree by construction (weight·h == h - h0).
+    vol_weight = float((w * h * area)[tagged].sum())
+    vol_gap = float(((h - h0) * area)[tagged].sum())
+    np.testing.assert_allclose(vol_weight, vol_gap, rtol=1e-9)
+
+    # ... and both match the analytic band integral to within mesh tolerance.
+    decay_last = float(
+        wc._through_thickness_decay(np.array([N_PLIES - 2]), 3, N_PLIES)[0]
+    )
+    prof = wc.wrinkles[0].profile
+    xs = np.linspace(0.0, LX, 8000)
+    gap_x = np.maximum(0.0, -prof.displacement(xs) * decay_last)
+    analytic = float(np.trapezoid(gap_x, xs)) * LY
+    assert vol_weight == pytest.approx(analytic, rel=0.1)
+    assert analytic > 0.0
+
+
+def test_min_gap_threshold_suppresses_resin_dust():
+    """A large min_gap_threshold zeros out shallow pockets."""
+    mesh, wc = _build_mesh(amplitude=0.05)
+    w_default = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    big = SurfacePocketSpec(side="top", min_gap_threshold=1.0)  # 1 mm >> any gap
+    w_big = compute_surface_resin_blend(mesh, wc, big)
+    assert (w_default > 0).sum() > 0
+    assert (w_big > 0).sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — side selection
+# ---------------------------------------------------------------------------
+
+
+def test_side_selection_top_bottom_both():
+    """top tags the upper band, bottom the lower, both their union."""
+    mesh, wc = _build_mesh()
+    w_top = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    w_bot = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="bottom"))
+    w_both = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="both"))
+
+    top_plies = np.unique(mesh.ply_ids[w_top > 0])
+    bot_plies = np.unique(mesh.ply_ids[w_bot > 0])
+    assert top_plies.max() >= N_PLIES - 2         # near the top surface
+    assert bot_plies.min() <= 1                     # near the bottom surface
+    assert set(top_plies).isdisjoint(set(bot_plies))
+
+    # "both" is the per-element maximum of the two single-sided fields.
+    np.testing.assert_allclose(w_both, np.maximum(w_top, w_bot))
+
+
+def test_symmetric_wrinkle_gives_symmetric_side_counts():
+    """A single mid-plane wrinkle tags equal element counts top and bottom."""
+    mesh, wc = _build_mesh(interfaces=(3,))
+    w_top = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    w_bot = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="bottom"))
+    assert int((w_top > 0).sum()) == int((w_bot > 0).sum())
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — mesh-quirk robustness and multi-wrinkle
+# ---------------------------------------------------------------------------
+
+
+def test_single_transition_layer_per_side():
+    """Only one horizontal element-layer per side is tagged (no internal slivers)."""
+    for nz_per_ply in (1, 2):
+        mesh, wc = _build_mesh(nz_per_ply=nz_per_ply, amplitude=0.08)
+        w = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+        tagged = np.flatnonzero(w > 0)
+        # All tagged elements share one nominal through-thickness band ...
+        assert len(np.unique(mesh.ply_ids[tagged])) == 1
+        # ... and one structured element-layer (k index = elem // (nx·ny)).
+        k_layer = tagged // (mesh.nx * mesh.ny)
+        assert len(np.unique(k_layer)) == 1
+
+
+def test_multi_wrinkle_uses_composed_displacement_field():
+    """Two stacked wrinkles tag pockets from the composed displacement field."""
+    single, wc_s = _build_mesh(interfaces=(3,), amplitude=0.06, nx=200)
+    multi, wc_m = _build_mesh(interfaces=(3, 4), amplitude=0.06, nx=200)
+
+    w_single = compute_surface_resin_blend(single, wc_s, SurfacePocketSpec("top"))
+    w_multi = compute_surface_resin_blend(multi, wc_m, SurfacePocketSpec("top"))
+
+    h_s, h0_s, a_s = _element_geometry(single)
+    h_m, h0_m, a_m = _element_geometry(multi)
+    vol_single = float(((h_s - h0_s) * a_s)[w_single > 0].sum())
+    vol_multi = float(((h_m - h0_m) * a_m)[w_multi > 0].sum())
+
+    assert (w_multi > 0).sum() > 0
+    # The second wrinkle deepens the composed trough, so more resin is tagged.
+    assert vol_multi > vol_single
+
+
+def test_flat_mesh_tags_nothing():
+    """A wrinkle-free mesh yields an all-zero blend field."""
+    mat = MaterialLibrary().get("AS4_3501_6")
+    lam = Laminate.from_angles([0.0] * N_PLIES, mat, PLY_T)
+    wc = WrinkleConfiguration(
+        [WrinklePlacement(
+            profile=GaussianSinusoidal(0.0, LX, 1.0e6, LX / 2.0),
+            ply_interface=3,
+            phase_offset=0.0,
+        )],
+        decay_mode="default",
+    )
+    mesh = WrinkleMesh(lam, wc, Lx=LX, Ly=LY, nx=40, ny=1, nz_per_ply=1).generate()
+    w = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="both"))
+    assert not np.any(w > 0)
+
+
+def test_spec_rejects_bad_side_and_threshold():
+    """SurfacePocketSpec validates its side and threshold at construction."""
+    with pytest.raises(ValueError, match="side"):
+        SurfacePocketSpec(side="left")
+    with pytest.raises(ValueError, match="min_gap_threshold"):
+        SurfacePocketSpec(min_gap_threshold=-1.0)
+
+
+def test_none_wrinkle_config_is_rejected():
+    """compute_surface_resin_blend refuses an undeformed (config-less) call."""
+    mesh, _ = _build_mesh()
+    with pytest.raises(ValueError, match="wrinkle"):
+        compute_surface_resin_blend(mesh, None, SurfacePocketSpec())

--- a/tests/test_surface_resin_pockets.py
+++ b/tests/test_surface_resin_pockets.py
@@ -276,3 +276,151 @@ def test_none_wrinkle_config_is_rejected():
     mesh, _ = _build_mesh()
     with pytest.raises(ValueError, match="wrinkle"):
         compute_surface_resin_blend(mesh, None, SurfacePocketSpec())
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — config validation (fast, no FE solve)
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**over):
+    from wrinklefe.analysis import AnalysisConfig
+
+    base = dict(
+        amplitude=0.354, wavelength=7.4, width=3.7, morphology="graded",
+        loading="compression",
+        material=MaterialLibrary().get("AC318_S6C10"),
+        angles=[0.0] * 15, ply_thickness=0.42,
+        nx=18, ny=3, nz_per_ply=3, domain_length=22.2, domain_width=10.0,
+        applied_strain=-0.01,
+    )
+    base.update(over)
+    return AnalysisConfig(**base)
+
+
+def test_config_accepts_flat_morphologies():
+    """stack/convex/concave and graded(decay_floor=0) are tool-flat: accepted."""
+    for morph in ("stack", "convex", "concave"):
+        _cfg(morphology=morph, enable_surface_resin_pockets=True)
+    _cfg(morphology="graded", decay_floor=0.0, enable_surface_resin_pockets=True)
+
+
+def test_config_rejects_uniform_morphology():
+    with pytest.raises(ValueError, match="uniform morphology has wavy"):
+        _cfg(morphology="uniform", enable_surface_resin_pockets=True)
+
+
+def test_config_rejects_graded_with_decay_floor():
+    with pytest.raises(ValueError, match="decay_floor"):
+        _cfg(
+            morphology="graded", decay_floor=0.2,
+            enable_surface_resin_pockets=True,
+        )
+
+
+def test_config_rejects_analytical_only():
+    with pytest.raises(ValueError, match="requires the FE path"):
+        _cfg(enable_surface_resin_pockets=True, analytical_only=True)
+
+
+def test_config_rejects_bad_side_and_gap():
+    with pytest.raises(ValueError, match="surface_pocket_side"):
+        _cfg(enable_surface_resin_pockets=True, surface_pocket_side="left")
+    with pytest.raises(ValueError, match="surface_pocket_min_gap"):
+        _cfg(enable_surface_resin_pockets=True, surface_pocket_min_gap=-1.0)
+
+
+def test_config_roundtrips_with_surface_pockets():
+    """The new fields ride the #259 dataclass-walk to_dict/from_dict."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = _cfg(
+        enable_surface_resin_pockets=True, surface_pocket_side="both",
+        surface_pocket_min_gap=0.01,
+    )
+    restored = AnalysisConfig.from_dict(cfg.to_dict())
+    assert restored.enable_surface_resin_pockets is True
+    assert restored.surface_pocket_side == "both"
+    assert restored.surface_pocket_min_gap == 0.01
+
+
+def test_disabled_by_default_is_a_noop():
+    """Off (the default) tags nothing — the mesh carries no resin fields."""
+    cfg = _cfg()
+    assert cfg.enable_surface_resin_pockets is False
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — end-to-end FE wiring (integration; the solve is marked slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_pockets_tag_elements_and_reduce_modulus():
+    """Surface pockets soften the laminate: modulus_retention_global drops."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    off = WrinkleAnalysis(_cfg()).run()
+    on = WrinkleAnalysis(
+        _cfg(enable_surface_resin_pockets=True, surface_pocket_side="both")
+    ).run()
+
+    assert off.mesh.resin_blend is None
+    assert on.mesh.resin_blend is not None
+    assert int((on.mesh.resin_blend > 0).sum()) > 0
+    assert on.mesh.resin_blend.max() <= 1.0
+    assert on.mesh.resin_material.name == "EPOXY_S6C10"
+    # The soft isotropic pockets reduce the global modulus retention.
+    assert on.modulus_retention_global < off.modulus_retention_global
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_feature_off_is_bit_identical():
+    """Enabling then disabling the flag reproduces the baseline exactly."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    a = WrinkleAnalysis(_cfg()).run()
+    b = WrinkleAnalysis(_cfg(enable_surface_resin_pockets=False)).run()
+    assert a.modulus_retention_global == b.modulus_retention_global
+    assert b.mesh.resin_blend is None and b.mesh.resin_mask is None
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_composes_with_crest_lens_no_double_blend():
+    """Crest lens + surface pockets compose by per-element maximum."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    crest = WrinkleAnalysis(_cfg(enable_resin_pocket=True)).run()
+    both = WrinkleAnalysis(
+        _cfg(
+            enable_resin_pocket=True,
+            enable_surface_resin_pockets=True, surface_pocket_side="both",
+        )
+    ).run()
+
+    cw = crest.mesh.resin_blend
+    bw = both.mesh.resin_blend
+    assert np.all(bw >= cw - 1e-12)                 # composed via maximum
+    assert int((bw > 0).sum()) >= int((cw > 0).sum())
+    # Exactly one blended material per tagged element (no double-blend).
+    assert len(both.mesh.resin_blend_materials) == int((bw > 0).sum())
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_binary_mode_tags_mask():
+    """resin_pocket_graded=False routes surface pockets through resin_mask."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    res = WrinkleAnalysis(
+        _cfg(
+            enable_surface_resin_pockets=True, surface_pocket_side="top",
+            resin_pocket_graded=False,
+        )
+    ).run()
+    assert res.mesh.resin_mask is not None
+    assert res.mesh.resin_mask.sum() > 0
+    assert res.mesh.resin_blend is None


### PR DESCRIPTION
## Linked issue

Fixes #361

## Summary

Parts cured against rigid tooling / a caul sheet keep **perfectly flat outer surfaces** while the fibres undulate internally; where the outermost undulating ply dips away from the flat surface, the gap fills with **neat resin** (surface pockets over the wrinkle troughs, thinning to nothing over the crests). Today the mesh gets the kinematics right for free (the default decay flattens the outer plies) but the material wrong — the sub-surface elements silently stretch while keeping their stiff fibre-direction material. This PR supplies the missing material zone.

**Scope: Parts 0–3 (core physics + config + tests). The app/viz (Part 4) is a deliberate follow-up PR** so it does not collide with the Analyze-tab rework.

### What changed
- **`core/resin_pocket.py`** — new `SurfacePocketSpec` and `compute_surface_resin_blend(mesh, wrinkle_config, spec)`. Per column, the transition element straddling the outermost pinned/undulating interface is tagged with a blend weight equal to the excess-stretch fraction `max(0, (h − h0) / h)`. This is exactly volume-conserving (equal to the integrated kinematic gap `−w(x)·decay_last`), zero over crests, and zero where the ply moves toward the tool (compression side stays host material in v1). Trough-following and surface-bonded — the complement of the crest lens, whose mesh plumbing (`resin_blend` / `resin_blend_materials`) it reuses, so the solver needs **zero changes**.
- **`analysis.py`** — `enable_surface_resin_pockets`, `surface_pocket_side` (`top`/`bottom`/`both`), `surface_pocket_min_gap`, reusing `resin_pocket_material` / `resin_pocket_graded`. Validation requires the FE path and a tool-flat morphology; `_attach_surface_resin_pockets` runs after `_attach_resin_pocket` and composes with the crest lens by per-element maximum (rebuilding blended materials from the combined weight — no double-blend).
- **Tests** (`tests/test_surface_resin_pockets.py`) — flatness invariant, gap-field correctness + resin-volume conservation, side selection, single-transition-layer robustness (incl. `nz_per_ply=2`), multi-wrinkle composition, all validation rejections, config round-trip, and FE smoke (integration/slow) asserting pockets reduce `modulus_retention_global`, feature-off is bit-identical, crest-lens composition, and the binary path. README subsection + CHANGELOG `### Added`.

### Part 0 spike findings
- **0.1 — Surface flatness (this changed the implementation).** The node→ply-id map in `core/mesh.py` is `min(k // nz_per_ply, n_plies − 1)`, so the top-surface nodes get ply `n_plies−1` and the bottom-surface nodes get ply `0`. In the default decay these plies evaluate to **exactly 0** (bottom `p/k → 0` at `p=0`; top `(n_plies−1−p)/denom → 0` at `p=n_plies−1`); `graded` with `decay_floor=0` is likewise exactly 0 at both surfaces. Measured surface node peak-to-peak spread is **0.0** (well under 1e-12). **So no `flatten_surfaces` clamp is needed** — the only non-flat cases are `uniform` (decay ≡ 1) and `graded` with `decay_floor > 0`, which are rejected by validation with messages naming the fix. A related quirk (interface nodes are assigned to the *upper* ply) makes the tagged transition element land in ply `n_plies−2` on the top but ply `0` on the bottom; the geometry-driven "closest non-flat element-layer to the surface" rule handles this and never leaks the tag onto a deeper internal interface.
- **0.2 — Failure path.** Confirmed: `MeshData.element_material` / `resin_angle_scale` route `resin_blend_materials` (or the binary `resin_material`) and suppress the fibre angle; the assembler (`element_material` + `resin_angle_scale`) and the failure evaluator (blended materials + `elem_fiber_angles * (1 − resin_blend)`) already consume them. Populating the same fields gives the material swap and angle suppression for free.
- **0.3 — Graded precedent.** The surface pocket emits the same fields as `_attach_resin_pocket`'s graded branch (`resin_blend` weight + `ply_mat.blend(resin, w)`), so composition is a `np.maximum` on the weight plus a rebuild of the blended-materials dict.

### Resin-volume conservation (from the tests)
The excess-stretch and kinematic-gap forms of the per-element volume agree to floating point by construction (`weight·h == h − h0`). Against the analytic band integral `width · ∫ max(0, −w(x)·decay_last) dx`, a coarse `stack` mesh gives ~1.29 vs ~1.24 mm³ (≈4%) and a refined single mid-plane wrinkle gives 2.60 vs 2.55 (≈2%), i.e. within mesh discretization; the conservation test asserts agreement to 10%.

### Non-goals (v1)
- **No analytical-path change** — the pocket's stiffness/strength effect is FE-only (`modulus_retention_global`, FPF in the isotropic resin zone). Documented limitation.
- **No compaction stiffening** on the crest side (knob reserved, default off).
- **No fabricated validation data** — a caul-plate dataset can be pinned via the existing ledger when available.
- **No viz** — Part 4 (app through-thickness cross-section) is a separate follow-up PR.

### Gates
- `ruff check .` — clean
- `mypy src/wrinklefe app.py streamlit_viz.py` — only the pre-existing `app.py:217` error (out of scope; no new errors)
- `pytest -m "not slow"` — 1561 passed, 77 deselected; the 4 slow FE integration tests run and pass
- `python scripts/validate.py` — **zero ledger drift** (all cases match pinned baselines)

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (use `-m "not slow"` to skip FE integration solves)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (no new errors)
- [x] Docs/README updated if user-facing
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_