### PR TITLE
Visualize surface resin pockets in the Analyze cross-section (#361 Part 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Streamlit app — **surface resin pockets in the through-thickness
+  cross-section** (issue #361, Part 4 follow-up). The Analyze-tab
+  cross-section now shades the neat-resin pockets that fill the wrinkle
+  troughs under a tool-flat surface, and an expert-mode sidebar toggle
+  (*Surface resin pockets*, with a top/bottom/both side selector) drives
+  both the preview and the FE run so a solve models exactly what the
+  picture shows. The zone is rendered *analytically* — the amber fill
+  between the flat tool line and the deformed outermost undulating ply —
+  rather than by deforming an FE mesh at render time, so the preview
+  stays responsive; a fidelity test cross-checks that rendered gap area
+  against the resin volume `compute_surface_resin_blend` tags on a coarse
+  mesh (agree within ~4%, well inside #361's 10% conservation tolerance).
+  Shown only for tool-flat morphologies (`stack`/`convex`/`concave`, or
+  `graded` with `decay_floor=0`); an incompatible morphology (`uniform`,
+  or `graded` with a non-zero floor) is withheld from the config and
+  flagged with a sidebar note, so a run can never build an invalid
+  config. Opt-in and off by default (feature-off preview unchanged).
 - Tool-flat surfaces with surface resin pockets (issue #361).
   Parts cured against rigid tooling / a caul sheet keep perfectly flat
   outer surfaces while the fibres undulate internally; the wrinkle

--- a/app.py
+++ b/app.py
@@ -169,6 +169,12 @@ DEFAULT_CZM_GIIC = (
 DEFAULT_CZM_SIGMA_MAX = float(_default_mat_for_czm.sigma_max)
 DEFAULT_CZM_TAU_MAX = float(_default_mat_for_czm.tau_max)
 
+# Surface resin pockets (issue #361). Mirror ``AnalysisConfig`` so the UI
+# default cannot drift from the analysis contract; both are exposed via the
+# expert-mode sidebar and the Reset button.
+DEFAULT_ENABLE_SURFACE_POCKETS = _CFG_DEFAULTS.enable_surface_resin_pockets
+DEFAULT_SURFACE_POCKET_SIDE = _CFG_DEFAULTS.surface_pocket_side
+
 # Single source of truth used by the "Reset to defaults" button: maps each
 # sidebar widget ``key=`` argument to the value it should hold after a reset.
 # Keep this aligned with the ``key=`` strings on the widgets below.
@@ -201,6 +207,9 @@ DEFAULTS: dict[str, object] = {
     "sb_czm_GIIc": DEFAULT_CZM_GIIC,
     "sb_czm_sigma_max": DEFAULT_CZM_SIGMA_MAX,
     "sb_czm_tau_max": DEFAULT_CZM_TAU_MAX,
+    # Surface resin pockets (issue #361)
+    "sb_enable_surface_pockets": DEFAULT_ENABLE_SURFACE_POCKETS,
+    "sb_surface_pocket_side": DEFAULT_SURFACE_POCKET_SIDE,
 }
 
 
@@ -402,6 +411,24 @@ def _morphology_schematic(
     return buf.getvalue()
 
 
+def _is_tool_flat_morphology(morphology: str, decay_floor: float) -> bool:
+    """True when the morphology cures against flat tooling on both faces.
+
+    Surface resin pockets (issue #361) only exist where the
+    through-thickness decay reaches exactly zero at the outer surface, so
+    the outermost ply is pinned flat and the wrinkle troughs open a gap
+    under it.  That holds for the dual-wrinkle modes
+    (``stack``/``convex``/``concave``) and for ``graded`` with
+    ``decay_floor == 0``; ``uniform`` (no decay) and ``graded`` with a
+    non-zero floor leave wavy surfaces.  Mirrors the ``AnalysisConfig``
+    validation so the preview never shows a zone an FE run would reject.
+    """
+    m = (morphology or "").lower().strip()
+    if m in ("stack", "convex", "concave"):
+        return True
+    return m == "graded" and abs(float(decay_floor)) < 1e-12
+
+
 def _through_thickness_cross_section(
     *,
     morphology: str,
@@ -414,6 +441,8 @@ def _through_thickness_cross_section(
     amplitude_profile: str,
     amplitude_profile_decay_length: float | None,
     amplitude_profile_axis: str,
+    enable_surface_resin_pockets: bool = False,
+    surface_pocket_side: str = "top",
 ) -> Figure:
     """Deformed through-thickness (x–z) cross-section of the wrinkled stack.
 
@@ -433,6 +462,20 @@ def _through_thickness_cross_section(
     :class:`~wrinklefe.analysis.AnalysisConfig` resolves them
     (``mid = n_plies // 2``), so the picture matches what an analysis run
     with these inputs would build.
+
+    When ``enable_surface_resin_pockets`` is set and the morphology is
+    tool-flat (:func:`_is_tool_flat_morphology`), the wrinkle troughs just
+    under the chosen flat surface(s) are shaded amber: the neat-resin
+    pockets of issue #361.  They are rendered analytically as the fill
+    between the flat tool line and the deformed outermost *undulating* ply
+    — the same kinematic gap ``-w(x)·decay`` that
+    :func:`~wrinklefe.core.resin_pocket.compute_surface_resin_blend` tags
+    on an FE mesh — so the preview stays responsive (no mesh deform) yet
+    faithful (cross-checked against the FE volume in the tests).  The
+    total gap area per unit width, per rendered side, is attached to the
+    returned figure as ``surface_pocket_gap_area`` (a ``{side: mm²}``
+    dict, empty when nothing is drawn) so the caller can caption it; the
+    return type is unchanged for backward compatibility.
     """
     n_plies = len(angles)
     prof = GaussianSinusoidal(
@@ -496,6 +539,62 @@ def _through_thickness_cross_section(
         for p in (i1, i2):
             ax.plot(x, z_def[p] + t / 2, color="#d62728", linewidth=1.1)
             ax.plot(x, z_def[p] - t / 2, color="#d62728", linewidth=1.1)
+
+    # --- Surface resin pockets (issue #361, Part 4 follow-up) ----------
+    # Shade the neat-resin zones filling the wrinkle troughs under a
+    # tool-flat surface.  For a tool-flat morphology the decay reaches
+    # exactly zero at the outer surface, so the outermost ply is flat and
+    # the first ply inward (``p_outer``) is the transition zone whose
+    # trough pulls away from the flat cap.  The amber wedge is the analytic
+    # kinematic gap between that ply's deformed outer edge and the flat
+    # nominal edge — identical to the gap
+    # ``compute_surface_resin_blend`` integrates on an FE mesh (bound by
+    # ``test_preview_gap_matches_fe_tagged_volume``), drawn here without a
+    # mesh deform.  Rendered in the bands' own (mm) data coordinates so it
+    # lines up with the exaggerated vertical scale.
+    gap_areas: dict[str, float] = {}
+    if enable_surface_resin_pockets and _is_tool_flat_morphology(
+        morphology, decay_floor
+    ):
+        dz_field = z_def - z0[:, None]
+        max_disp = float(np.abs(dz_field).max())
+        tol = 1.0e-6 * max_disp
+        sides = (
+            ("top", "bottom")
+            if surface_pocket_side == "both"
+            else (surface_pocket_side,)
+        )
+        for side in sides:
+            p_seq = (
+                range(n_plies - 1, -1, -1) if side == "top" else range(n_plies)
+            )
+            p_outer: int | None = next(
+                (p for p in p_seq if float(np.abs(dz_field[p]).max()) > tol),
+                None,
+            )
+            if p_outer is None:
+                continue
+            if side == "top":
+                flat_z = float(z0[p_outer] + t / 2.0)
+                deformed_edge = z_def[p_outer] + t / 2.0
+                gap = flat_z - deformed_edge
+                lower, upper = deformed_edge, np.full_like(x, flat_z)
+            else:
+                flat_z = float(z0[p_outer] - t / 2.0)
+                deformed_edge = z_def[p_outer] - t / 2.0
+                gap = deformed_edge - flat_z
+                lower, upper = np.full_like(x, flat_z), deformed_edge
+            poly = ax.fill_between(
+                x, lower, upper, where=gap > tol,
+                facecolor="#e8a33d", alpha=0.55, hatch="xxx",
+                edgecolor="#9c6a12", linewidth=0.0, zorder=3,
+                label="surface resin pocket" if side == sides[0] else "",
+            )
+            poly.set_gid(f"surface_resin_{side}")
+            gap_areas[side] = float(np.trapezoid(np.maximum(0.0, gap), x))
+    # Expose the per-side gap area (mm² per unit width) for the caller's
+    # caption without changing the return type (backward compatible).
+    setattr(fig, "surface_pocket_gap_area", gap_areas)
 
     ax.set_xlim(-x_half, x_half)
     ax.set_xlabel("x [mm]")
@@ -1097,6 +1196,76 @@ with st.sidebar:
         czm_load_increments = DEFAULT_CZM_LOAD_INCREMENTS
         czm_newton_tol = DEFAULT_CZM_NEWTON_TOL
 
+    # ------------------------------------------------------------------
+    # Surface resin pockets (tool-flat outer surface; issue #361). Expert
+    # only, like CZM: it is an FE-only material effect (the neat-resin
+    # zones filling the wrinkle troughs under a flat tool surface) and the
+    # FE solve it needs is itself expert-gated. When enabled for a
+    # tool-flat morphology, the Analyze-tab cross-section shades the zones
+    # and the FE run tags them; incompatible morphologies (uniform, or
+    # graded with a non-zero decay floor) leave wavy surfaces, so the flag
+    # is withheld from the run and a note explains why — the preview and
+    # the run never diverge.
+    # ------------------------------------------------------------------
+    if expert_mode:
+        with st.expander("Surface resin pockets (tool-flat surface)", expanded=False):
+            enable_surface_pockets = st.checkbox(
+                "Model surface resin pockets",
+                value=DEFAULT_ENABLE_SURFACE_POCKETS,
+                key="sb_enable_surface_pockets",
+                help=(
+                    "Parts cured against rigid tooling / a caul sheet keep "
+                    "perfectly flat outer surfaces while the fibres undulate "
+                    "internally; the wrinkle troughs fill with neat resin "
+                    "just under the flat surface. When enabled, the "
+                    "through-thickness cross-section shades these zones and "
+                    "the FE solve blends in the soft isotropic resin card "
+                    "(fibre-free, misalignment suppressed). Requires a "
+                    "tool-flat morphology (stack/convex/concave, or graded "
+                    "with decay floor 0) and the full FE solve (untick "
+                    "*Analytical only*; it is forced off when this is on)."
+                ),
+            )
+            surface_pocket_side = st.selectbox(
+                "Tool-flat surface(s)",
+                ["top", "bottom", "both"],
+                index=["top", "bottom", "both"].index(
+                    DEFAULT_SURFACE_POCKET_SIDE
+                ),
+                key="sb_surface_pocket_side",
+                help=(
+                    "Which flat face(s) to tag: *top* (+z), *bottom* (-z), "
+                    "or *both*. A part flat on one face only (e.g. a caul on "
+                    "top, bag on the bottom) uses a single side."
+                ),
+            )
+            if enable_surface_pockets and not _is_tool_flat_morphology(
+                morphology, decay_floor
+            ):
+                st.warning(
+                    "Surface resin pockets need a tool-flat morphology — "
+                    "stack/convex/concave, or graded with decay floor 0. The "
+                    f"current morphology (**{morphology}**"
+                    + (
+                        f", decay floor {decay_floor:g}"
+                        if morphology == "graded" else ""
+                    )
+                    + ") leaves wavy outer surfaces, so pockets are disabled "
+                    "for this run and not drawn in the cross-section."
+                )
+    else:
+        # Novice path: surface pockets depend on the expert-only FE solve.
+        enable_surface_pockets = False
+        surface_pocket_side = DEFAULT_SURFACE_POCKET_SIDE
+
+    # Surface pockets are only wired into the run when both requested and
+    # compatible, so an incompatible morphology can never build an invalid
+    # AnalysisConfig (which would raise in ``_validate``).
+    _surface_pockets_active = bool(
+        enable_surface_pockets
+        and _is_tool_flat_morphology(morphology, decay_floor)
+    )
+
     run_disabled = bool(mesh_diag is not None and mesh_diag.will_invert)
     run_clicked = st.button(
         "Run analysis",
@@ -1174,6 +1343,16 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             czm_newton_tol=float(cfg_dict.get("czm_newton_tol", 1.0e-4)),
         )
 
+    # Surface resin pockets (issue #361) — only threaded in when the run
+    # handler flagged them active (requested + tool-flat morphology), so an
+    # incompatible morphology never reaches AnalysisConfig validation.
+    surface_pocket_kwargs: dict = {}
+    if cfg_dict.get("enable_surface_resin_pockets", False):
+        surface_pocket_kwargs = dict(
+            enable_surface_resin_pockets=True,
+            surface_pocket_side=cfg_dict.get("surface_pocket_side", "top"),
+        )
+
     cfg = AnalysisConfig(
         amplitude=cfg_dict["amplitude"],
         wavelength=cfg_dict["wavelength"],
@@ -1195,6 +1374,7 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         nz_per_ply=cfg_dict.get("nz_per_ply", 1),
         analytical_only=cfg_dict["analytical_only"],
         **czm_kwargs,
+        **surface_pocket_kwargs,
     )
     result = WrinkleAnalysis(cfg).run(
         analytical_only=cfg_dict["analytical_only"],
@@ -1533,11 +1713,16 @@ if run_clicked or _demo_pending:
             st.error(f"Invalid custom material: {e}")
             st.stop()
 
-        # CZM requires the Newton-Raphson FE path; force analytical_only
-        # off when CZM is enabled regardless of the *Analytical only*
-        # checkbox so the user can't accidentally request an analytical
-        # CZM run (which would silently drop the cohesive solve).
-        _effective_analytical_only = bool(analytical_only) and not bool(enable_czm)
+        # CZM and surface resin pockets are both FE-only material effects;
+        # force analytical_only off when either is enabled regardless of the
+        # *Analytical only* checkbox so the user can't accidentally request
+        # a run that would silently drop (CZM) or reject in validation
+        # (surface pockets) the feature.
+        _effective_analytical_only = (
+            bool(analytical_only)
+            and not bool(enable_czm)
+            and not _surface_pockets_active
+        )
 
         cfg_items: dict = {
             "amplitude": amplitude,
@@ -1573,6 +1758,12 @@ if run_clicked or _demo_pending:
             cfg_items["czm_tau_max"] = float(czm_tau_max)
             cfg_items["czm_n_load_increments"] = int(czm_load_increments)
             cfg_items["czm_newton_tol"] = float(czm_newton_tol)
+        # Surface resin pockets — only added when requested AND the
+        # morphology is tool-flat, so the config never sees the flag with an
+        # incompatible morphology (bit-identical cache key when off).
+        if _surface_pockets_active:
+            cfg_items["enable_surface_resin_pockets"] = True
+            cfg_items["surface_pocket_side"] = surface_pocket_side
         cfg_payload = tuple(sorted(cfg_items.items()))
 
     with st.status("Running analysis…", expanded=True) as status:
@@ -1696,7 +1887,10 @@ with tab_analyze:
                     amplitude_profile=amplitude_profile,
                     amplitude_profile_decay_length=amplitude_profile_decay_length,
                     amplitude_profile_axis=amplitude_profile_axis,
+                    enable_surface_resin_pockets=enable_surface_pockets,
+                    surface_pocket_side=surface_pocket_side,
                 )
+                _gap_areas = getattr(fig_tt, "surface_pocket_gap_area", {})
                 st.pyplot(fig_tt, clear_figure=True)
                 _total_t = len(_tt_angles) * ply_thickness
                 st.caption(
@@ -1710,6 +1904,16 @@ with tab_analyze:
                     f"{_total_t:.2f} mm · θ_max = {theta_max_deg:.2f}°. "
                     "Vertical scale is exaggerated relative to x for visibility."
                 )
+                if _gap_areas:
+                    _total_gap = sum(_gap_areas.values())
+                    _sides_txt = " + ".join(sorted(_gap_areas))
+                    st.caption(
+                        "Amber hatching marks the surface resin pockets "
+                        f"filling the wrinkle troughs under the tool-flat "
+                        f"surface ({_sides_txt}) — total gap "
+                        f"≈ {_total_gap:.3f} mm² per unit width. The FE run "
+                        "models this same zone as a soft isotropic resin blend."
+                    )
 
         if morphology == "graded":
             with st.expander("Through-thickness amplitude profile", expanded=False):

--- a/tests/test_app_cross_section.py
+++ b/tests/test_app_cross_section.py
@@ -171,3 +171,218 @@ def test_handles_small_and_odd_ply_counts(app_module):
         )
         assert len(fig.axes) == 1
         plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Surface resin pockets (issue #361, Part 4 follow-up)
+# ---------------------------------------------------------------------------
+#
+# The Analyze-tab cross-section shades the neat-resin pockets that fill the
+# wrinkle troughs under a tool-flat surface.  They are drawn *analytically*
+# (the fill between the flat tool line and the deformed outermost undulating
+# ply) rather than by deforming an FE mesh at render time — so the preview
+# stays responsive.  ``test_preview_gap_matches_fe_tagged_volume`` is the
+# load-bearing test: it cross-checks that analytic gap against the resin
+# volume ``compute_surface_resin_blend`` tags on a real (coarse) mesh, so the
+# cheap render is provably the same geometry the FE run models.
+
+
+def _resin_polys(fig, side):
+    """Return the resin ``PolyCollection`` for one side (or None)."""
+    ax = fig.axes[0]
+    gid = f"surface_resin_{side}"
+    for c in ax.collections:
+        if c.get_gid() == gid:
+            return c
+    return None
+
+
+def _covered_x_intervals(poly):
+    """(x_min, x_max) of each filled polygon in a fill_between collection."""
+    intervals = []
+    for path in poly.get_paths():
+        v = path.vertices
+        if len(v):
+            intervals.append((float(v[:, 0].min()), float(v[:, 0].max())))
+    return intervals
+
+
+def test_is_tool_flat_morphology_predicate(app_module):
+    """The gate matches ``AnalysisConfig`` validation: flat vs wavy."""
+    f = app_module._is_tool_flat_morphology
+    assert f("stack", 0.3) and f("convex", 0.0) and f("concave", 1.0)
+    assert f("graded", 0.0)              # graded with zero floor IS tool-flat
+    assert not f("graded", 0.2)          # a residual floor leaves waviness
+    assert not f("uniform", 0.0)         # never decays
+
+
+def test_surface_pockets_off_by_default_adds_nothing(app_module):
+    """Default (feature off) draws no resin patches — backward compatible."""
+    import matplotlib.pyplot as plt
+
+    fig = _call(app_module, "stack", decay_floor=0.0)
+    try:
+        assert getattr(fig, "surface_pocket_gap_area", None) == {}
+        assert _resin_polys(fig, "top") is None
+        assert _resin_polys(fig, "bottom") is None
+    finally:
+        plt.close(fig)
+
+
+def test_surface_pockets_render_over_troughs_not_crest(app_module):
+    """stack + toggle on tags amber patches over the troughs, none at the
+    central crest (x = 0, where the wrinkle peaks toward the top tool)."""
+    import matplotlib.pyplot as plt
+
+    fig = _call(
+        app_module, "stack", decay_floor=0.0,
+        enable_surface_resin_pockets=True, surface_pocket_side="top",
+    )
+    try:
+        poly = _resin_polys(fig, "top")
+        assert poly is not None, "expected a top surface-resin patch"
+        areas = fig.surface_pocket_gap_area
+        assert areas.get("top", 0.0) > 0.0
+        # The crest at x = 0 pokes toward the tool: no top pocket spans it.
+        intervals = _covered_x_intervals(poly)
+        assert intervals, "resin patch has no filled region"
+        assert not any(lo <= 0.0 <= hi for lo, hi in intervals), (
+            f"top resin should avoid the x=0 crest; covered {intervals}"
+        )
+    finally:
+        plt.close(fig)
+
+
+def test_surface_pockets_both_sides_and_crest_on_bottom(app_module):
+    """side='both' adds patches on both faces; at the top crest (x=0) the
+    *bottom* face troughs, so the bottom patch does span x=0."""
+    import matplotlib.pyplot as plt
+
+    fig = _call(
+        app_module, "stack", decay_floor=0.0,
+        enable_surface_resin_pockets=True, surface_pocket_side="both",
+    )
+    try:
+        top = _resin_polys(fig, "top")
+        bot = _resin_polys(fig, "bottom")
+        assert top is not None and bot is not None
+        areas = fig.surface_pocket_gap_area
+        assert areas.get("top", 0.0) > 0.0 and areas.get("bottom", 0.0) > 0.0
+        bot_intervals = _covered_x_intervals(bot)
+        assert any(lo <= 0.0 <= hi for lo, hi in bot_intervals), (
+            "bottom face should have a pocket at the x=0 crest"
+        )
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "morphology,decay_floor",
+    [("uniform", 0.0), ("graded", 0.3)],
+)
+def test_surface_pockets_skipped_for_wavy_morphologies(
+    app_module, morphology, decay_floor
+):
+    """Wavy morphologies (uniform, graded+floor) render nothing even when the
+    toggle is on — matching what the FE run would (refuse to) do."""
+    import matplotlib.pyplot as plt
+
+    fig = _call(
+        app_module, morphology, decay_floor=decay_floor,
+        enable_surface_resin_pockets=True, surface_pocket_side="both",
+    )
+    try:
+        assert fig.surface_pocket_gap_area == {}
+        assert _resin_polys(fig, "top") is None
+        assert _resin_polys(fig, "bottom") is None
+    finally:
+        plt.close(fig)
+
+
+def test_graded_zero_floor_is_a_valid_surface_pocket_morphology(app_module):
+    """graded with decay_floor==0 is tool-flat: the toggle DOES render."""
+    import matplotlib.pyplot as plt
+
+    fig = _call(
+        app_module, "graded", decay_floor=0.0,
+        enable_surface_resin_pockets=True, surface_pocket_side="top",
+    )
+    try:
+        assert fig.surface_pocket_gap_area.get("top", 0.0) > 0.0
+        assert _resin_polys(fig, "top") is not None
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize("morphology", ["stack", "convex", "concave", "graded"])
+def test_preview_gap_matches_fe_tagged_volume(app_module, morphology):
+    """FIDELITY CROSS-CHECK — the important one.
+
+    The analytic gap area the preview shades must equal the neat-resin
+    volume ``compute_surface_resin_blend`` tags on a real deformed mesh
+    (per unit width), to within the coarse-mesh tolerance #361's own
+    conservation test uses (~10%).  This binds the cheap analytic render to
+    the shared FE function's geometry: they are the same kinematic gap
+    ``-w(x)·decay``, not two independently-derived shapes.
+    """
+    import matplotlib.pyplot as plt
+
+    from wrinklefe.core.laminate import Laminate
+    from wrinklefe.core.material import MaterialLibrary
+    from wrinklefe.core.mesh import WrinkleMesh
+    from wrinklefe.core.morphology import WrinkleConfiguration
+    from wrinklefe.core.resin_pocket import (
+        SurfacePocketSpec,
+        compute_surface_resin_blend,
+    )
+    from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+    amplitude, wavelength, width, ply_t = 0.4, 16.0, 8.0, 0.183
+    angles = list(_ANGLES_12)
+    n = len(angles)
+    decay_floor = 0.0
+
+    # 1) Preview: the analytic gap area (mm² per unit width) it returns.
+    fig = _call(
+        app_module, morphology,
+        amplitude=amplitude, wavelength=wavelength, width=width,
+        ply_thickness=ply_t, decay_floor=decay_floor,
+        enable_surface_resin_pockets=True, surface_pocket_side="top",
+    )
+    preview_area = fig.surface_pocket_gap_area["top"]
+    plt.close(fig)
+    assert preview_area > 0.0
+
+    # 2) FE: build a coarse structured mesh from the SAME morphology field
+    #    the preview uses (from_morphology_name, mid = n // 2 interfaces),
+    #    tag the surface pockets, and integrate weight·height·footprint.
+    mid = n // 2
+    i1, i2 = max(0, mid - 1), min(n - 1, mid)
+    Lx, Ly = 6.0 * width, 4.0
+    prof = GaussianSinusoidal(
+        amplitude=amplitude, wavelength=wavelength, width=width, center=Lx / 2.0
+    )
+    wc = WrinkleConfiguration.from_morphology_name(
+        morphology, prof, interface1=i1, interface2=i2, decay_floor=decay_floor
+    )
+    lam = Laminate.from_angles(angles, MaterialLibrary().get("IM7_8552"), ply_t)
+    mesh = WrinkleMesh(
+        lam, wc, Lx=Lx, Ly=Ly, nx=240, ny=1, nz_per_ply=1
+    ).generate()
+    weight = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+
+    ez = mesh.nodes[mesh.elements][:, :, 2]
+    ex = mesh.nodes[mesh.elements][:, :, 0]
+    ey = mesh.nodes[mesh.elements][:, :, 1]
+    height = ez.max(axis=1) - ez.min(axis=1)
+    footprint = (ex.max(axis=1) - ex.min(axis=1)) * (ey.max(axis=1) - ey.min(axis=1))
+    tagged = weight > 0
+    assert tagged.any(), "FE mesh tagged no surface resin — bad fixture"
+    fe_volume = float((weight * height * footprint)[tagged].sum())
+    fe_area_per_width = fe_volume / Ly
+
+    # The two independent computations of the same kinematic gap agree.
+    assert preview_area == pytest.approx(fe_area_per_width, rel=0.10), (
+        f"{morphology}: preview gap {preview_area:.5f} vs FE/width "
+        f"{fe_area_per_width:.5f} (ratio {preview_area / fe_area_per_width:.4f})"
+    )

--- a/tests/test_app_surface_pockets.py
+++ b/tests/test_app_surface_pockets.py
@@ -1,0 +1,161 @@
+"""Smoke tests for the Streamlit app's Surface resin pocket controls.
+
+The Streamlit ``app.py`` exposes a collapsed *Surface resin pockets*
+expander in the sidebar — visible only in **Expert mode**, because the
+pockets are an FE-only material effect and the FE solve is itself
+expert-only (issue #361, Part 4 follow-up). These tests use
+``streamlit.testing.v1.AppTest`` to drive the page without a browser and
+verify:
+
+1. In the default (novice) sidebar the toggle is *hidden*; turning on
+   ``session_state['expert_mode']`` surfaces it with
+   ``key='sb_enable_surface_pockets'`` (unchecked) plus the side
+   selectbox ``key='sb_surface_pocket_side'``.
+2. The defaults are exposed via ``DEFAULTS`` so *Reset to defaults*
+   restores them, and mirror ``AnalysisConfig``.
+3. Toggling the feature on with a *compatible* (tool-flat) morphology
+   renders without raising — the Analyze-tab cross-section shades the
+   pockets.
+4. Toggling it on with an *incompatible* morphology (uniform / graded
+   with a decay floor) does not raise and surfaces the explanatory
+   sidebar note, so a run can never build an invalid config.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.viz
+
+# ``app.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+pytest.importorskip(
+    "streamlit.testing.v1", reason="Streamlit testing API not available."
+)
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    import app as app_module  # noqa: WPS433 - test-time import.
+    return app_module
+
+
+def _app_path() -> str:
+    return str(_REPO_ROOT / "app.py")
+
+
+# ----------------------------------------------------------------------
+# 1. DEFAULTS round-trip
+# ----------------------------------------------------------------------
+
+
+def test_defaults_include_surface_pocket_entries(app_module):
+    """``DEFAULTS`` must hold both widget keys so Reset works."""
+    d = app_module.DEFAULTS
+    assert "sb_enable_surface_pockets" in d
+    assert d["sb_enable_surface_pockets"] is False
+    assert "sb_surface_pocket_side" in d
+    assert d["sb_surface_pocket_side"] in ("top", "bottom", "both")
+
+
+def test_surface_pocket_defaults_match_analysis_config(app_module):
+    """UI defaults must mirror ``AnalysisConfig`` so they cannot drift."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig()
+    assert (
+        app_module.DEFAULT_ENABLE_SURFACE_POCKETS
+        == cfg.enable_surface_resin_pockets
+    )
+    assert app_module.DEFAULT_SURFACE_POCKET_SIDE == cfg.surface_pocket_side
+
+
+# ----------------------------------------------------------------------
+# 2. AppTest-driven UI smoke tests
+# ----------------------------------------------------------------------
+
+
+def test_novice_mode_hides_surface_pocket_controls():
+    """Default (novice) load: the surface-pocket toggle is hidden."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    cbs = {cb.key for cb in at.checkbox if cb.key is not None}
+    assert "sb_enable_surface_pockets" not in cbs, (
+        f"surface-pocket toggle leaked into novice UI; saw {sorted(cbs)}"
+    )
+    sbs = {sb.key for sb in at.selectbox if sb.key is not None}
+    assert "sb_surface_pocket_side" not in sbs
+
+
+def test_expert_mode_shows_surface_pocket_toggle_unchecked():
+    """Expert mode surfaces the toggle (unchecked) and the side selectbox."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    cbs = {cb.key: cb for cb in at.checkbox if cb.key is not None}
+    assert "sb_enable_surface_pockets" in cbs, (
+        f"toggle missing in Expert mode; saw {sorted(cbs)}"
+    )
+    assert cbs["sb_enable_surface_pockets"].value is False
+    sbs = {sb.key for sb in at.selectbox if sb.key is not None}
+    assert "sb_surface_pocket_side" in sbs
+
+
+def test_enabling_on_compatible_morphology_does_not_raise():
+    """Toggling on with a tool-flat morphology (stack) renders cleanly and
+    shades the cross-section — no exception, no sidebar warning."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.session_state["sb_morphology"] = "stack"
+    at.session_state["sb_enable_surface_pockets"] = True
+    at.session_state["sb_surface_pocket_side"] = "both"
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    # A compatible morphology raises no tool-flat warning.
+    warnings = [w.value for w in at.warning]
+    assert not any("tool-flat morphology" in w for w in warnings), (
+        f"unexpected incompatibility warning for stack: {warnings}"
+    )
+
+
+@pytest.mark.parametrize(
+    "morphology,decay_floor", [("uniform", 0.0), ("graded", 0.4)]
+)
+def test_enabling_on_incompatible_morphology_warns_not_raises(
+    morphology, decay_floor
+):
+    """Toggling on with a wavy morphology must not raise; it surfaces the
+    explanatory note so the run cannot build an invalid config."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.session_state["sb_morphology"] = morphology
+    if morphology == "graded":
+        at.session_state["sb_decay_floor"] = decay_floor
+    at.session_state["sb_enable_surface_pockets"] = True
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    warnings = [w.value for w in at.warning]
+    assert any("tool-flat morphology" in w for w in warnings), (
+        f"missing tool-flat note for {morphology}; saw {warnings}"
+    )


### PR DESCRIPTION
## Linked issue

Refs #361 (Part 4 follow-up — #361 is already closed; this is the visualization/UI layer on top of the surface-pocket model it shipped).

## Summary

Surface resin pockets (the neat-resin zones filling wrinkle troughs under a tool-flat outer surface, modelled by `compute_surface_resin_blend` in #361) are now **visible in the Streamlit Analyze-tab through-thickness cross-section**, driven by a new expert-mode sidebar toggle that also feeds the FE run so a solve models exactly what the preview shows.

**Key design decision — analytic render + fidelity cross-check.** The preview does *not* build or deform an FE mesh at render time (that would kill its responsiveness). Instead the resin zone is drawn analytically as the amber fill between the flat tool line and the deformed outermost *undulating* ply — the **same** kinematic gap `-w(x)·decay` that `compute_surface_resin_blend` tags on a mesh, not a re-derived geometry. A fidelity test binds the two: it cross-checks the rendered gap area against the FE-tagged resin volume on a coarse mesh and they agree within **~4%** (well inside #361's own 10% conservation tolerance), across stack/convex/concave and graded-with-zero-floor.

What changed:
- `_through_thickness_cross_section` gains backward-compatible kwargs `enable_surface_resin_pockets=False` / `surface_pocket_side="top"`. When on **and** the morphology is tool-flat (`stack`/`convex`/`concave`, or `graded` with `decay_floor==0`) it shades the trough resin zones (hatched amber, per side for `both`) in the bands' own exaggerated data coordinates, and exposes the per-side gap area on the returned figure for captioning (return type unchanged).
- Expert-mode sidebar (guarded exactly like the CZM controls): a *Surface resin pockets* checkbox + a top/bottom/both side selector. Both keys are registered in `DEFAULTS` (Reset support) and mirror `AnalysisConfig`. The two kwargs are threaded from sidebar state into the preview call site, the caption, and the `AnalysisConfig` the run handler builds — so preview and run never diverge.
- **Incompatible-morphology handling (no run can crash).** `AnalysisConfig._validate()` raises for the toggle + `uniform` / `graded`+`decay_floor>0`. When the toggle is on and the morphology is incompatible, the sidebar shows an explanatory note **and** the flags are withheld from the constructed config (so an invalid config is never built), and the preview renders nothing extra. The FE path is forced on when pockets are active (they are FE-only), mirroring CZM.

No solver/analysis-logic change (the config fields already exist from #361); feature is opt-in and off by default, so feature-off behaviour is unchanged.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (use `-m "not slow"` to skip FE integration solves) — 1579 passed, 77 deselected
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (only the pre-existing `app.py` `str | int` note, no new errors)
- [x] Docs/README updated if user-facing — `CHANGELOG.md` `### Added`
- [x] `CHANGELOG.md` `[Unreleased]` updated if the change is user-visible (no **Numerical results** entry: visualization + opt-in preview, feature-off unchanged)
- [x] `python scripts/validate.py` shows no validation-ledger drift

## Tests

- **Fidelity cross-check** (`test_preview_gap_matches_fe_tagged_volume`, parametrized over the four tool-flat morphologies): rendered gap area vs `compute_surface_resin_blend` volume per unit width — agree within ~4%.
- Rendering: off → no patches; stack+on → amber patches over troughs and none at the crest; `both` → patches on both faces (and the bottom pocket spans the top crest); `uniform`/`graded`+floor → nothing even with the toggle on; `graded`+zero-floor → rendered.
- Sidebar `AppTest` smoke (`test_app_surface_pockets.py`): toggle hidden in novice / present unchecked in expert with its side selector; `DEFAULTS` carries both keys and mirrors `AnalysisConfig`; enabling on a compatible morphology renders cleanly; enabling on an incompatible one surfaces the note without raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_