### PR TITLE
cli: surface wrinkle-defect capabilities on analyze/sweep (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- CLI — **wrinkle-defect capabilities on `analyze`** (issue #346). The
+  new defect models shipped for the scripting API are now reachable from
+  the command line: `--wrinkle-z-position Z` (off-mid-plane wrinkle,
+  validated to `[0, 1]`), `--gate {li2024-moulded,li2025-vacbag}` (the
+  two-parameter (θ, D/T) penetration gate, selecting a calibrated
+  `GateParameters` preset), `--resin-pocket` (crest resin lens),
+  `--surface-resin-pockets` / `--surface-pocket-side {top,bottom,both}`
+  (tool-flat surface pockets), and `--progressive` / `--increments N`
+  (load-stepping ultimate strength). The flags inherit the #259
+  config-file precedence, so any flag left off keeps the `--config`
+  value and any flag passed overrides it (and is written by
+  `--save-config`); the FE-only features force the FE path with the same
+  precedence as `--enable-czm` rather than silently no-op'ing under
+  `--analytical-only`. The result summary now prints the progressive
+  knockdown when a progressive run happened. `sweep --parameter
+  wrinkle_z_position` works end-to-end over a `--config` base. The
+  surface-resin-pocket flags (issue #361, newer than #346) are included
+  as part of the same CLI-reachability story. Buckling was **deferred**:
+  the linearized microbuckling solver is standalone diagnostic
+  infrastructure with no `AnalysisConfig` knob and is documented as not a
+  usable knockdown predictor, so there is no clean field to surface.
 - Streamlit app — **surface resin pockets in the through-thickness
   cross-section** (issue #361, Part 4 follow-up). The Analyze-tab
   cross-section now shades the neat-resin pockets that fill the wrinkle

--- a/README.md
+++ b/README.md
@@ -413,6 +413,46 @@ wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
     --no-analytical-only --parallel 4
 ```
 
+#### Wrinkle-defect capabilities
+
+`analyze` also exposes the newer defect models. The FE-only features
+(`--resin-pocket`, `--surface-resin-pockets`, `--progressive`) force the
+full FE solve, so they take precedence over `--analytical-only` / `--no-fe`:
+
+```bash
+# Two-parameter (theta, D/T) penetration gate — the best UD predictor —
+# selecting a calibrated preset (UD-scoped; not for multidirectional laminates)
+wrinklefe analyze --gate li2025-vacbag --morphology uniform \
+    --angles 0,0,0,0,0,0,0,0 --interface-1 3 --interface-2 4 --amplitude 0.5
+
+# Off-mid-plane wrinkle position (fraction of thickness, in [0, 1])
+wrinklefe analyze --morphology graded --wrinkle-z-position 0.7
+
+# Crest resin pocket + progressive-damage ultimate strength (FE)
+wrinklefe analyze --resin-pocket --progressive --increments 15
+
+# Surface resin pockets under a tool-flat surface (FE)
+wrinklefe analyze --surface-resin-pockets --surface-pocket-side both
+```
+
+| Flag | Config field | Notes |
+| --- | --- | --- |
+| `--wrinkle-z-position Z` | `wrinkle_z_position` | Fraction of thickness in `[0, 1]` (0.5 = midplane); graded morphology |
+| `--gate {li2024-moulded,li2025-vacbag}` | `penetration_gate` | Calibrated `GateParameters` preset; UD-scoped |
+| `--resin-pocket` | `enable_resin_pocket` | Crest resin lens (FE-only) |
+| `--surface-resin-pockets` / `--surface-pocket-side {top,bottom,both}` | `enable_surface_resin_pockets` / `surface_pocket_side` | Tool-flat surface pockets (FE-only) |
+| `--progressive` / `--increments N` | `enable_progressive_damage` / `progressive_n_increments` | Load-stepping ultimate strength (FE-only) |
+
+The long tail of finer knobs (custom `GateParameters`, resin-pocket
+geometry scales, progressive load-ramp targets) stays reachable through
+`--config` (see below). `sweep` sweeps any numeric `AnalysisConfig` field,
+including `wrinkle_z_position`, over its `--config` base setup:
+
+```bash
+wrinklefe sweep --parameter wrinkle_z_position --min 0.2 --max 0.8 \
+    --steps 4 --morphology graded
+```
+
 ### Saving and reusing a configuration
 
 `analyze` can persist and reload a full `AnalysisConfig`. `--save-config`

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -2258,6 +2258,16 @@ class AnalysisResults:
                 f"{self.modulus_retention_global:.4f}",
             ])
 
+        if self.progressive_history is not None:
+            lines.extend([
+                "",
+                "  Progressive Damage (ultimate strength):",
+                f"    Wrinkled strength:  {self.progressive_strength_MPa:.1f} MPa",
+                f"    Pristine strength:  "
+                f"{self.progressive_pristine_strength_MPa:.1f} MPa",
+                f"    Strength knockdown: {self.progressive_knockdown:.4f}",
+            ])
+
         if self.czm_damage is not None:
             max_d = float(np.max(self.czm_damage)) if self.czm_damage.size else 0.0
             mean_d = float(np.mean(self.czm_damage)) if self.czm_damage.size else 0.0

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -305,6 +305,89 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # ------------------------------------------------------------------ #
+    # Wrinkle-defect capabilities (issue #346): surface the AnalysisConfig
+    # fields shipped by the resin-pocket / progressive-damage / penetration-
+    # gate / off-mid-plane-wrinkle work so ``analyze`` (and, via --config,
+    # ``sweep``) can express them. Added BEFORE the SUPPRESS loop below so
+    # they inherit the config-file precedence for free (a flag left off keeps
+    # the --config value; a flag passed overrides it). The long tail of finer
+    # knobs stays reachable through --config.
+    # ------------------------------------------------------------------ #
+    p_analyze.add_argument(
+        "--wrinkle-z-position", type=float, default=None,
+        dest="wrinkle_z_position",
+        help=(
+            "Through-thickness position of the single-wrinkle decay centre "
+            "as a fraction of the laminate thickness T: 0.0 = bottom "
+            "surface, 0.5 = midplane (default), 1.0 = top surface. Must be "
+            "in [0, 1]. Consulted by the graded morphology path; ignored "
+            "for stack/convex/concave/uniform."
+        ),
+    )
+    p_analyze.add_argument(
+        "--gate", type=str, default=None, dest="gate",
+        choices=["li2024-moulded", "li2025-vacbag"],
+        help=(
+            "Use the two-parameter (theta, D/T) penetration-gate knockdown "
+            "instead of the Budiansky-Fleck kink-band path, selecting a "
+            "calibrated preset: 'li2024-moulded' (AC318/S6C10 moulded, "
+            "Dataset E) or 'li2025-vacbag' (AC318/S6C10 vacuum-bag, Dataset "
+            "F). UD-scoped -- do not use for multidirectional/blocked "
+            "laminates. For a custom GateParameters, use --config."
+        ),
+    )
+    p_analyze.add_argument(
+        "--resin-pocket", action="store_true", default=False,
+        dest="resin_pocket",
+        help=(
+            "Enable the crest resin-pocket material zone (FE-only). Tags the "
+            "hex elements inside the cosine resin lens at the wrinkle crest "
+            "and blends in an isotropic epoxy card, capturing the soft, "
+            "fibre-free inclusion the machined insert leaves. Forces the FE "
+            "path; no effect on the analytical path."
+        ),
+    )
+    p_analyze.add_argument(
+        "--surface-resin-pockets", action="store_true", default=False,
+        dest="surface_resin_pockets",
+        help=(
+            "Enable surface resin pockets for a tool-flat outer surface "
+            "(FE-only). Tags the transition elements that span the gap "
+            "between the flat surface and the outermost undulating ply and "
+            "blends in the resin card. Requires a tool-flat morphology "
+            "(stack/convex/concave, or graded with decay_floor=0). Forces "
+            "the FE path."
+        ),
+    )
+    p_analyze.add_argument(
+        "--surface-pocket-side", type=str, default="top",
+        dest="surface_pocket_side", choices=["top", "bottom", "both"],
+        help=(
+            "Which tool-flat surface(s) receive surface resin pockets: "
+            "'top' (+z, default), 'bottom' (-z), or 'both'. Only consulted "
+            "when --surface-resin-pockets is set."
+        ),
+    )
+    p_analyze.add_argument(
+        "--progressive", action="store_true", default=False,
+        dest="progressive",
+        help=(
+            "Run the progressive-damage load-stepping solve to an ultimate "
+            "compressive strength (FE-only). Populates the progressive "
+            "strength/knockdown fields; this is the only path that carries "
+            "UD compression past first-ply failure. Forces the FE path; not "
+            "combinable with --enable-czm."
+        ),
+    )
+    p_analyze.add_argument(
+        "--increments", type=int, default=15, dest="increments",
+        help=(
+            "Number of load increments for the --progressive solve "
+            "(default: 15). Only consulted when --progressive is set."
+        ),
+    )
+
     # Config-file precedence (issue #259): give every analyze option a
     # SUPPRESS default so ``vars(args)`` contains only the flags the user
     # actually passed. ``_cmd_analyze`` starts from the --config file (or
@@ -731,10 +814,39 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     if given("czm_load_increments"):
         overrides["czm_n_load_increments"] = args.czm_load_increments
 
+    # Wrinkle-defect capabilities (issue #346). Each maps onto its
+    # AnalysisConfig field and composes with --config / --save-config.
+    if given("wrinkle_z_position"):
+        overrides["wrinkle_z_position"] = args.wrinkle_z_position
+    if given("gate"):
+        from wrinklefe.core.penetration_gate import (
+            GATE_LI2024_MOULDED,
+            GATE_LI2025_VACBAG,
+        )
+        gate_map = {
+            "li2024-moulded": GATE_LI2024_MOULDED,
+            "li2025-vacbag": GATE_LI2025_VACBAG,
+        }
+        overrides["penetration_gate"] = gate_map[args.gate]
+    if given("resin_pocket"):
+        overrides["enable_resin_pocket"] = True
+    if given("surface_resin_pockets"):
+        overrides["enable_surface_resin_pockets"] = True
+    if given("surface_pocket_side"):
+        overrides["surface_pocket_side"] = args.surface_pocket_side
+    if given("progressive"):
+        overrides["enable_progressive_damage"] = True
+    if given("increments"):
+        overrides["progressive_n_increments"] = args.increments
+
     # Resolve analytical-only vs. full FE intent.
     #
     # Precedence (highest first):
-    #   1. --enable-czm (or a config with CZM on) -> force FE (CZM needs NR)
+    #   1. --enable-czm, --resin-pocket, --surface-resin-pockets, or
+    #      --progressive (or a config with any of them on) -> force FE.
+    #      These are FE-only features that would silently no-op under
+    #      analytical_only, so they take precedence over --analytical-only
+    #      / --no-fe just as CZM does (issue #346).
     #   2. --analytical-only                       -> skip FE
     #   3. --fe / --no-fe                          -> FE / analytical-only
     #   4. --config file's analytical_only value   -> inherit
@@ -742,7 +854,19 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     enable_czm_eff = overrides.get("enable_czm", False) or (
         base is not None and base.enable_czm
     )
-    if enable_czm_eff:
+    fe_feature_eff = enable_czm_eff or (
+        overrides.get("enable_resin_pocket", False)
+        or overrides.get("enable_surface_resin_pockets", False)
+        or overrides.get("enable_progressive_damage", False)
+        or (
+            base is not None and (
+                base.enable_resin_pocket
+                or base.enable_surface_resin_pockets
+                or base.enable_progressive_damage
+            )
+        )
+    )
+    if fe_feature_eff:
         analytical_only = False
     elif given("analytical_only"):
         analytical_only = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -604,3 +604,189 @@ def test_sweep_negative_parallel_rejected(capsys):
     assert exc.value.code == 2
     err = capsys.readouterr().err
     assert "--parallel" in err and "Traceback" not in err
+
+
+# --------------------------------------------------------------------------- #
+# analyze: wrinkle-defect capabilities (issue #346)
+# --------------------------------------------------------------------------- #
+
+_UD_LAYUP = "0,0,0,0,0,0,0,0"
+
+
+def test_analyze_wrinkle_z_position_maps_to_config():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--analytical-only", "--wrinkle-z-position", "0.7"])
+    assert captured["config"].wrinkle_z_position == pytest.approx(0.7)
+
+
+def test_analyze_wrinkle_z_position_out_of_range_rejected(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["analyze", "--analytical-only", "--wrinkle-z-position", "1.5"])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "wrinkle_z_position" in err and "[0, 1]" in err
+    assert "Traceback" not in err
+
+
+def test_analyze_gate_maps_to_preset_object():
+    from wrinklefe.core.penetration_gate import GATE_LI2025_VACBAG
+
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--analytical-only", "--morphology", "uniform",
+            "--angles", _UD_LAYUP, "--interface-1", "3", "--interface-2", "4",
+            "--gate", "li2025-vacbag",
+        ])
+    assert captured["config"].penetration_gate is GATE_LI2025_VACBAG
+
+
+def test_analyze_gate_moulded_maps_to_preset_object():
+    from wrinklefe.core.penetration_gate import GATE_LI2024_MOULDED
+
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--analytical-only", "--morphology", "uniform",
+            "--angles", _UD_LAYUP, "--interface-1", "3", "--interface-2", "4",
+            "--gate", "li2024-moulded",
+        ])
+    assert captured["config"].penetration_gate is GATE_LI2024_MOULDED
+
+
+def test_analyze_resin_pocket_maps_and_forces_fe():
+    """--resin-pocket enables the FE-only zone and overrides --analytical-only."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--analytical-only", "--resin-pocket"])
+    cfg = captured["config"]
+    assert cfg.enable_resin_pocket is True
+    # FE-only feature must force the FE path despite --analytical-only.
+    assert cfg.analytical_only is False
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_surface_resin_pockets_maps_side():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--surface-resin-pockets",
+            "--surface-pocket-side", "both",
+        ])
+    cfg = captured["config"]
+    assert cfg.enable_surface_resin_pockets is True
+    assert cfg.surface_pocket_side == "both"
+    assert cfg.analytical_only is False
+
+
+def test_analyze_progressive_maps_increments_and_forces_fe():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--analytical-only",
+            "--progressive", "--increments", "7",
+        ])
+    cfg = captured["config"]
+    assert cfg.enable_progressive_damage is True
+    assert cfg.progressive_n_increments == 7
+    assert cfg.analytical_only is False
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_gate_overrides_config_file(tmp_path):
+    """A --gate flag overrides the penetration_gate from a --config file."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.penetration_gate import (
+        GATE_LI2024_MOULDED,
+        GATE_LI2025_VACBAG,
+    )
+
+    base = AnalysisConfig(
+        morphology="uniform",
+        angles=[0.0] * 8,
+        interface_1=3,
+        interface_2=4,
+        penetration_gate=GATE_LI2024_MOULDED,
+        analytical_only=True,
+    )
+    path = tmp_path / "case.json"
+    base.save_json(path)
+
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--config", str(path), "--gate", "li2025-vacbag",
+        ])
+    # The flag wins; other file values are preserved.
+    assert captured["config"].penetration_gate is GATE_LI2025_VACBAG
+    assert captured["config"].morphology == "uniform"
+
+
+def test_analyze_gate_reproduces_api_penetration_gate_kd():
+    """`analyze --gate li2025-vacbag` reproduces the API gate KD (UD)."""
+    import math
+
+    from wrinklefe.analysis import WrinkleAnalysis
+    from wrinklefe.core.penetration_gate import (
+        GATE_LI2025_VACBAG,
+        penetration_gate_kd,
+    )
+
+    amplitude, wavelength = 0.5, 16.0
+    angles = [0.0] * 8
+
+    # Capture the config the CLI builds from --gate, then run it, so the
+    # flag→config mapping (not just a hand-built config) is under test.
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--analytical-only", "--morphology", "uniform",
+            "--angles", ",".join("0" for _ in angles),
+            "--interface-1", "3", "--interface-2", "4",
+            "--amplitude", str(amplitude), "--wavelength", str(wavelength),
+            "--gate", "li2025-vacbag",
+        ])
+    cfg = captured["config"]
+    assert cfg.penetration_gate is GATE_LI2025_VACBAG
+    kd_cli = WrinkleAnalysis(cfg).run(analytical_only=True).analytical_knockdown
+
+    theta_deg = math.degrees(math.atan(2 * math.pi * amplitude / wavelength))
+    dt = amplitude / (cfg.ply_thickness * len(angles))
+    kd_api = penetration_gate_kd(
+        theta_deg, dt, GATE_LI2025_VACBAG, z_position=0.5
+    )
+    assert kd_cli == pytest.approx(kd_api)
+
+
+@pytest.mark.slow
+def test_analyze_progressive_reports_knockdown(capsys):
+    """`analyze --progressive` completes a real FE solve and reports KD."""
+    cli_main([
+        "analyze", "--progressive", "--increments", "3",
+        "--morphology", "stack", "--angles", _UD_LAYUP,
+        "--interface-1", "3", "--interface-2", "4",
+        "--amplitude", "0.3", "--wavelength", "16",
+        "--nx", "4", "--ny", "2",
+    ])
+    out = capsys.readouterr().out
+    assert "Progressive Damage" in out
+    assert "Strength knockdown:" in out
+
+
+# --------------------------------------------------------------------------- #
+# sweep: new base-config parameters (issue #346)
+# --------------------------------------------------------------------------- #
+
+
+def test_sweep_wrinkle_z_position_end_to_end(capsys):
+    """`sweep --parameter wrinkle_z_position` runs and yields distinct KDs."""
+    cli_main([
+        "sweep", "--parameter", "wrinkle_z_position",
+        "--min", "0.2", "--max", "0.8", "--steps", "3",
+        "--morphology", "graded",
+    ])
+    out = capsys.readouterr().out
+    assert "wrinkle_z_position" in out
+    # Three data rows should be present between the header rules.
+    assert out.count("\n") > 5


### PR DESCRIPTION
## Linked issue

Fixes #346

## Summary

The resin-pocket / progressive-damage / penetration-gate / off-mid-plane-wrinkle models were reachable from the scripting API but not from the CLI. This surfaces the existing `AnalysisConfig` fields through `wrinklefe analyze` (and, via `--config`, `sweep`) — no solver or analysis-logic change.

New `analyze` flags:

| Flag | Config field | Notes |
| --- | --- | --- |
| `--wrinkle-z-position Z` | `wrinkle_z_position` | Fraction of thickness in `[0, 1]` (0.5 = midplane); graded morphology |
| `--gate {li2024-moulded,li2025-vacbag}` | `penetration_gate` | Maps to the calibrated `GateParameters` **object**; UD-scoped |
| `--resin-pocket` | `enable_resin_pocket` | Crest resin lens (FE-only) |
| `--surface-resin-pockets` / `--surface-pocket-side {top,bottom,both}` | `enable_surface_resin_pockets` / `surface_pocket_side` | Tool-flat surface pockets (FE-only) |
| `--progressive` / `--increments N` | `enable_progressive_damage` / `progressive_n_increments` | Load-stepping ultimate strength (FE-only) |

Design notes:

- Flags are declared **before** the #259 `SUPPRESS`-default loop, so they inherit the config-file precedence for free: a flag left off keeps the `--config` value, a flag passed overrides it and is written by `--save-config` (the gate round-trips by preset name — verified).
- The **FE-only features** (resin pocket, surface pockets, progressive) force the FE path with the same precedence as `--enable-czm`, so they don't silently no-op under `--analytical-only` / `--no-fe`.
- The result summary now prints the **progressive knockdown** when a progressive run happened (`analytical_modulus_knockdown` was already shown; the JSON export already carried both).
- `sweep --parameter wrinkle_z_position` works end-to-end over a `--config` base (verified by a new test) — no code change needed on `sweep`; `--config` is the base-setup carrier for the long tail of knobs.

**Surface resin pockets included:** `--surface-resin-pockets` / `--surface-pocket-side` are newer than #346 (issue #361) but part of the same CLI-reachability story, so they're included here.

**Buckling deferred:** the issue title mentions buckling, but there is no `AnalysisConfig` knob for it — the linearized microbuckling solver (`solver/buckling.py`) is standalone diagnostic infrastructure whose own module docstring states it is *not a usable knockdown predictor*. Surfacing it would mean inventing a new analysis path, out of scope for this reachability PR. Left unchecked below; can be revisited if a genuine structural-buckling config field is added.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (1589 passed with `-m "not slow"`; new slow CLI progressive test passes)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (only the pre-existing `app.py:226` error remains)
- [x] Docs/README updated if user-facing
- [x] `CHANGELOG.md` `[Unreleased]` updated (surfacing existing capability; no **Numerical results** entry)
- [x] `python scripts/validate.py` shows no validation-ledger drift
- [ ] Buckling flag (deferred — no clean config knob; see summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_