### PR TITLE
packaging: move pyvista/VTK to an optional vtk extra (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,14 @@ version produced a given file.
   access in `max_angle` / `fiber_angles_at_nodes`.
 
 ### Changed
+- Packaging — **PyVista/VTK moved to an optional `vtk` extra** (issue
+  #302). Plain `pip install wrinklefe` no longer pulls in VTK (~150 MB
+  lighter) and stays headless-safe; the 3D cohesive-zone plots
+  (`plot_interface_damage_3d` / `plot_crack_front_3d`) now require
+  `pip install "wrinklefe[vtk]"` (also included in `[all]`). PyVista was
+  already imported lazily, so `import wrinklefe`, the CLI, the Streamlit
+  app, and the docs build are unaffected when it is absent; the
+  `_require_pyvista` error message now names the `wrinklefe[vtk]` extra.
 - Streamlit app — acknowledgment gate and intro reworded to a
   professional-tool framing (issue #333): the gate leads with what
   WrinkleFE computes rather than "free academic software", and the

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ cd wrinklefe
 pip install -e ".[all]"
 ```
 
+The 3D cohesive-zone renders (`plot_interface_damage_3d` /
+`plot_crack_front_3d`) use PyVista, which pulls in VTK (~150 MB). It is an
+optional dependency, so plain `pip install wrinklefe` stays lean and
+headless-safe; install `pip install "wrinklefe[vtk]"` when you need those
+plots (it is already included in `[all]`).
+
 Verify the install:
 
 ```bash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,10 @@ extensions = [
     "myst_parser",
 ]
 
-# The 3-D viz module imports pyvista at module scope; mock it so the
-# docs build does not require VTK.
+# PyVista is an optional dependency (the `vtk` extra) imported lazily
+# inside the 3-D CZM plot helpers, so the docs build never needs VTK
+# installed. This mock is kept defensively: if the 3-D viz module is ever
+# autodoc'd, the mock lets the build succeed without pulling in VTK.
 autodoc_mock_imports = ["pyvista"]
 
 autosummary_generate = True

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,10 +5,14 @@
 ```bash
 pip install wrinklefe            # core: analytical + FE pipeline
 pip install "wrinklefe[streamlit]"  # + the Streamlit web app
+pip install "wrinklefe[vtk]"        # + 3D cohesive-zone PyVista plots (pulls in VTK)
 ```
 
+The `vtk` extra is optional — plain `pip install wrinklefe` stays lean and
+headless-safe (no VTK); add it only for the 3D cohesive-zone renders.
+
 From a clone, `pip install -e ".[all]"` installs everything including
-the dev tooling.
+the dev tooling (and the `vtk` extra).
 
 ## A five-minute analysis
 

--- a/docs/internal/ARCHITECTURE.md
+++ b/docs/internal/ARCHITECTURE.md
@@ -82,7 +82,7 @@ from wrinklefe.failure.evaluator import FailureEvaluator
 | `failure/larc05.py` | LaRC05 composite failure criterion implementation |
 | `failure/evaluator.py` | `FailureEvaluator` applies criteria across all elements; `LaminateFailureReport` |
 | `viz/plots_2d.py` | 2D matplotlib plots (wrinkle profiles, knockdown curves, distributions) |
-| `viz/plots_3d.py` | 3D PyVista plots (mesh, damage contours) |
+| `viz/plots_3d.py` | 3D plots: matplotlib mesh/contour/mode-shape renders, plus optional PyVista cohesive-interface damage and crack-front plots (the `vtk` extra) |
 | `viz/style.py` | Publication styling constants and helpers |
 | `sweep/parametric_sweep.py` | Parametric sweep over amplitude/wavelength/morphology; CSV output |
 | `analysis.py` | Top-level orchestrator: `WrinkleAnalysis`, `AnalysisConfig`, `compare_morphologies`, `parametric_sweep` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "numpy>=1.24",
     "scipy>=1.10",
     "matplotlib>=3.7",
-    "pyvista>=0.42",
 ]
 
 # Note: wrinklefe is Streamlit-first / CLI-only and has no desktop GUI code.
@@ -53,7 +52,15 @@ docs = [
     "myst-parser>=4.0",
     "furo>=2024.8",
 ]
-all = ["wrinklefe[streamlit,dev,docs]"]
+# 3D cohesive-zone plots (plot_interface_damage_3d / plot_crack_front_3d)
+# render via PyVista, which pulls in VTK (~150 MB). It is imported lazily,
+# so `pip install wrinklefe` stays headless-safe and VTK-free; install this
+# extra only when you need the 3D CZM renders. (pyvistaqt/PyQt6 stay
+# excluded per the note above — this extra is pyvista-only.)
+vtk = [
+    "pyvista>=0.42",
+]
+all = ["wrinklefe[streamlit,vtk,dev,docs]"]
 
 [project.scripts]
 wrinklefe = "wrinklefe.cli:main"

--- a/src/wrinklefe/viz/plots_3d.py
+++ b/src/wrinklefe/viz/plots_3d.py
@@ -775,7 +775,7 @@ def _require_pyvista():
     except ImportError as exc:  # pragma: no cover - exercised in sparse envs
         raise ImportError(
             "PyVista is required for 3D cohesive-zone visualizations. "
-            "Install it with `pip install pyvista`."
+            'Install it with `pip install "wrinklefe[vtk]"`.'
         ) from exc
     return pv
 

--- a/tests/test_viz_czm.py
+++ b/tests/test_viz_czm.py
@@ -17,6 +17,8 @@ up the new ``czm_element_centroids`` field correctly.
 
 from __future__ import annotations
 
+import sys
+
 import matplotlib
 
 matplotlib.use("Agg")  # headless; no display required
@@ -292,3 +294,28 @@ def test_plot_crack_front_3d_runs():
     plotter = plot_crack_front_3d(nodes, conn, damage, threshold=0.5)
     assert plotter is not None
     plotter.close()
+
+
+# ----------------------------------------------------------------------
+# PyVista absent — the 3D plots must raise an actionable ImportError that
+# names the `wrinklefe[vtk]` extra.  Runs on every CI job (with or without
+# PyVista installed) because it forces the import to fail deterministically
+# by planting a ``None`` sentinel in ``sys.modules`` (issue #302).
+# ----------------------------------------------------------------------
+
+
+def test_require_pyvista_raises_actionable_error_without_pyvista(monkeypatch):
+    from wrinklefe.viz.plots_3d import _require_pyvista
+
+    # A ``None`` entry makes ``import pyvista`` raise ImportError, regardless
+    # of whether PyVista is actually installed in this environment.
+    monkeypatch.setitem(sys.modules, "pyvista", None)
+    with pytest.raises(ImportError, match=r"wrinklefe\[vtk\]"):
+        _require_pyvista()
+
+
+def test_plot_interface_damage_3d_raises_without_pyvista(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyvista", None)
+    nodes, conn, damage = _make_synthetic_interface_quads()
+    with pytest.raises(ImportError, match=r"wrinklefe\[vtk\]"):
+        plot_interface_damage_3d(nodes, conn, damage)


### PR DESCRIPTION
## Linked issue

Fixes #302

## Summary

PyVista (which pulls in VTK, ~150 MB) was a **core** dependency even though it is only used by the two 3D cohesive-zone plot helpers (`plot_interface_damage_3d` / `plot_crack_front_3d`) and is already imported **lazily** inside `_require_pyvista()`. This moves it to an optional `vtk` extra so plain `pip install wrinklefe` is lean and headless-safe, with no import-time behavior change.

Because the only PyVista import in `src/` is lazy (inside `_require_pyvista`), `import wrinklefe`, the CLI, the Streamlit app, and the docs build never touch it — so this is a metadata + message + docs + test change, **no import-guard refactor was needed**.

Changes:
- **`pyproject.toml`** — dropped `pyvista>=0.42` from core `dependencies`; added a pyvista-only `vtk` extra; updated the aggregate to `all = ["wrinklefe[streamlit,vtk,dev,docs]"]` so the test / test-full / benchmark jobs still install PyVista (and the two `importorskip` CZM 3D tests keep running rather than becoming permanent skips). `pyvistaqt`/PyQt6 stay excluded per the existing headless-safe note. `requirements.txt` untouched.
- **`_require_pyvista()`** — the `ImportError` now names the extra: `pip install "wrinklefe[vtk]"`.
- **Docs** — README + `docs/getting_started.md` document the `vtk` extra; `docs/conf.py` keeps `autodoc_mock_imports=["pyvista"]` (defensive) with its stale "module scope" comment corrected to note the import is lazy; `docs/internal/ARCHITECTURE.md` precision fix (mesh/contour plots are matplotlib; only the interface-damage and crack-front plots are PyVista).
- **Tests** — new tests in `tests/test_viz_czm.py` assert both `_require_pyvista()` and `plot_interface_damage_3d(...)` raise an actionable `ImportError` matching `wrinklefe\[vtk\]` when PyVista is unavailable. They force the failure deterministically via `monkeypatch.setitem(sys.modules, "pyvista", None)`, so they run and pass on **every** CI job regardless of whether PyVista is installed (acceptance criterion 3).
- **`CHANGELOG.md`** — `### Changed` entry. No `### Numerical results` entry: nothing numeric changes and `scripts/validate.py` shows zero drift.

No behavior change to numeric outputs.

## CI covers both paths (no new job needed)

- **With PyVista** — `test` (matrix), `test-full`, `benchmarks` install `.[all,dev]`, which now resolves the `vtk` token in `all`, so PyVista is present and the two `importorskip` CZM 3D tests run.
- **Without PyVista** — `docs` (`.[docs]`), `examples` (`.`, no extras), `lint` (`.[dev]`) install no VTK, proving `import wrinklefe` / CLI / docs build work absent PyVista; and the new monkeypatch tests prove the actionable `ImportError` message on every job. So acceptance criterion 4 (CI exercises both the with- and without-PyVista paths) is met without adding a CI job.

## examples/ check

Confirmed **no** script under `examples/` calls `plot_interface_damage_3d`, `plot_crack_front_3d`, or `_build_interface_polydata` (grep: none). The `examples` CI job (`pip install -e .`, no extras) therefore stays green with PyVista absent.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (`-m "not slow"`: 1591 passed, 78 deselected)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (only the pre-existing unrelated `app.py:226` error)
- [x] Docs/README updated (user-facing)
- [x] `CHANGELOG.md` `[Unreleased]` updated (`### Changed`)
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_