### PR TITLE
analysis: expose WrinkleSurface3D transverse wrinkle modes via AnalysisConfig (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Analysis — **through-width (transverse) wrinkle surfaces reachable from
+  `AnalysisConfig`** (issue #300). The already-implemented, already-tested
+  `WrinkleSurface3D` transverse modes are now selectable through three new
+  config fields: `transverse_mode`
+  (`"uniform"`/`"gaussian_decay"`/`"sinusoidal_y"`/`"elliptical"`, default
+  `"uniform"`), `transverse_span` (→ `span_y`, `None` tracks
+  `domain_width`), and `transverse_width` (→ `width_y`, `None` resolves to
+  `span_y / 4` — a localized mid-width patch). With the default
+  `"uniform"` the pipeline still builds the bare x-only
+  `GaussianSinusoidal`, so results are bit-identical (regression-safe). A
+  non-uniform mode wraps the profile in a `WrinkleSurface3D` on the FE
+  single-wrinkle path so the crest amplitude varies across the specimen
+  width; at the same crest amplitude a localized wrinkle predicts a milder
+  knockdown than the uniform baseline (real manufacturing wrinkles are
+  localized, and the uniform assumption overstates the defect volume).
+  FE-only and single-wrinkle for now: analytical-only, multi-wrinkle
+  (`wrinkles`), and `enable_czm` combinations are rejected at construction
+  with actionable messages. New `examples/transverse_wrinkle_knockdown.py`
+  demonstrates localized-vs-uniform knockdown; CLI/app exposure is a
+  deliberate follow-up.
 - CLI — **wrinkle-defect capabilities on `analyze`** (issue #346). The
   new defect models shipped for the scripting API are now reachable from
   the command line: `--wrinkle-z-position Z` (off-mid-plane wrinkle,

--- a/README.md
+++ b/README.md
@@ -152,11 +152,29 @@ the docs and the dataclass cannot drift.
 | `amplitude_profile` | name | `"constant"` | Spatially varying in-plane modulation of the wrinkle amplitude `A`, applied on top of the wrinkle's own longitudinal envelope. `"constant"` (default) preserves the legacy uniform `A`; `"gaussian"` multiplies `A` by `exp(−(s/d)²)`; `"linear"` multiplies `A` by `max(0, 1 − \|s\|/d)` (clipped). `s` is the coordinate from the wrinkle centre along `amplitude_profile_axis` and `d` is `amplitude_profile_decay_length`. | one of `constant`, `gaussian`, `linear` |
 | `amplitude_profile_decay_length` | mm | `None` | Decay length `d` (mm) for the Gaussian sigma or linear-decay extent. `None` falls back to the wrinkle profile's own `width`. Ignored when `amplitude_profile == "constant"`. | finite and > 0 when set |
 | `amplitude_profile_axis` | axis | `"x"` | In-plane axis along which the amplitude modulation runs. Pick `"y"` for an independent transverse tapering of `A` that does not stack with the existing longitudinal envelope on `x`. | one of `x`, `y` |
+| `transverse_mode` | name | `"uniform"` | Through-width (transverse, y-direction) wrinkle-surface envelope `f(y)`. `"uniform"` (default) builds the bare x-only wrinkle exactly as before (bit-identical). The non-uniform modes wrap the profile in a `WrinkleSurface3D` so the crest amplitude varies across the specimen width: `"gaussian_decay"` decays it toward the edges (localized mid-width defect), `"sinusoidal_y"` ripples it across the width, and `"elliptical"` confines it to a mid-width patch. **FE-only** — a non-uniform mode requires `analytical_only=False` and is not yet combinable with multi-wrinkle (`wrinkles`) or `enable_czm` (both rejected at construction). | one of `uniform`, `gaussian_decay`, `sinusoidal_y`, `elliptical` |
+| `transverse_span` | mm | `None` | Specimen width `span_y` seen by the transverse envelope. `None` tracks `domain_width` so the envelope always spans the meshed y-extent. Ignored when `transverse_mode == "uniform"`. | finite and > 0 when set |
+| `transverse_width` | mm | `None` | Transverse localization half-width `width_y`: the Gaussian 1/e length for `"gaussian_decay"` and the ellipse half-width for `"elliptical"` (ignored by `"uniform"`/`"sinusoidal_y"`). `None` resolves to `span_y / 4` — a localized mid-width patch whose amplitude has fallen to `exp(−4) ≈ 0.018` of the crest at the edges (`gaussian_decay`) or that occupies the central half of the width (`elliptical`). | finite and > 0 when set |
 
 Peak fibre misalignment: `θ_max ≈ arctan(2πA/λ)` (exact for a pure
 cosine; dimensionless because A and λ share the mm length unit). See the
 `WrinkleProfile` class docstring in `src/wrinklefe/core/wrinkle.py` for
 the full per-profile geometric definitions.
+
+#### Through-width (transverse) variation
+
+By default a wrinkle is treated as uniform across the full specimen width
+(`transverse_mode="uniform"`). Real manufacturing wrinkles are usually
+*localized* — high amplitude mid-width, fading toward the edges — so a
+uniform-width assumption overstates the defect volume and biases the
+knockdown conservative. Set `transverse_mode` to `"gaussian_decay"`,
+`"sinusoidal_y"`, or `"elliptical"` to run the FE path with a full
+`z(x, y)` wrinkle surface (`transverse_span` and `transverse_width` tune
+the width envelope). At the same crest amplitude a localized wrinkle
+predicts a *milder* knockdown than the uniform baseline. This is FE-only
+and single-wrinkle for now (analytical-only, multi-wrinkle, and CZM runs
+are rejected at construction); the CLI/app knobs are a follow-up. See
+`examples/transverse_wrinkle_knockdown.py` for a runnable comparison.
 
 ### Tension analysis
 

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -68,6 +68,8 @@ from wrinklefe.core.penetration_gate import (
 from wrinklefe.core.transforms import rotate_stiffness_3d
 from wrinklefe.core.wrinkle import (
     GaussianSinusoidal,
+    WrinkleProfile,
+    WrinkleSurface3D,
 )
 from wrinklefe.elements.cohesive8 import (
     Cohesive8Element,
@@ -1027,6 +1029,28 @@ class AnalysisConfig:
         Default ``"x"``.  Pick ``"y"`` (transverse axis) for an
         independent in-plane tapering of *A* that does not stack with
         the existing longitudinal envelope on *x*.
+    transverse_mode : {"uniform", "gaussian_decay", "sinusoidal_y", "elliptical"}
+        Through-width (transverse *y*) wrinkle-surface envelope (#300).
+        Default ``"uniform"`` builds the bare x-only wrinkle exactly as
+        before (bit-identical). The non-uniform modes wrap the profile in
+        a :class:`~wrinklefe.core.wrinkle.WrinkleSurface3D` so the
+        amplitude varies across the specimen width: ``"gaussian_decay"``
+        decays it toward the edges, ``"sinusoidal_y"`` ripples it across
+        the width, and ``"elliptical"`` confines it to a mid-width patch.
+        FE-only — a non-uniform mode requires ``analytical_only=False`` and
+        is not combinable with ``wrinkles`` (multi-wrinkle) or
+        ``enable_czm`` (both rejected at construction).
+    transverse_span : float or None
+        Specimen width ``span_y`` (mm) seen by the transverse envelope.
+        ``None`` (default) tracks ``domain_width`` so the envelope always
+        spans the meshed y-extent. Must be > 0 when set. Ignored when
+        ``transverse_mode == "uniform"``.
+    transverse_width : float or None
+        Transverse localization half-width ``width_y`` (mm): the Gaussian
+        1/e length for ``"gaussian_decay"`` and the ellipse half-width for
+        ``"elliptical"`` (ignored by ``"uniform"``/``"sinusoidal_y"``).
+        ``None`` (default) resolves to ``span_y / 4`` — a localized
+        mid-width patch. Must be > 0 when set.
     loading : str
         Loading mode: ``'compression'`` or ``'tension'``.
         Default is ``'compression'``.
@@ -1102,6 +1126,34 @@ class AnalysisConfig:
     amplitude_profile: str = "constant"
     amplitude_profile_decay_length: float | None = None
     amplitude_profile_axis: str = "x"
+
+    # Through-width (transverse / y-direction) wrinkle surface (#300).
+    # Selects a WrinkleSurface3D transverse envelope f(y) so the wrinkle
+    # amplitude can vary across the specimen width instead of being uniform
+    # across it (the default). ``"uniform"`` builds the bare, x-only
+    # GaussianSinusoidal exactly as before (bit-identical), so the default
+    # path is untouched. The non-uniform modes decay the amplitude toward
+    # the edges (``"gaussian_decay"``), ripple it across the width
+    # (``"sinusoidal_y"``), or confine it to a mid-width elliptical patch
+    # (``"elliptical"``) — matching real, localized manufacturing wrinkles.
+    # FE-only: the transverse variation only manifests in the mesh, so a
+    # non-uniform mode requires the FE path (analytical_only=False) and is
+    # not yet combinable with multi-wrinkle (``wrinkles``) or ``enable_czm``
+    # (rejected at validation; see __post_init__). CLI/app exposure is a
+    # deliberate follow-up.
+    transverse_mode: str = "uniform"
+    # Total specimen width span_y (mm) seen by the transverse envelope.
+    # ``None`` (default) tracks the mesh width ``domain_width`` so the
+    # envelope always spans the meshed y-extent. Must be > 0 when set.
+    transverse_span: float | None = None
+    # Transverse localization half-width width_y (mm): the Gaussian 1/e
+    # length scale for ``"gaussian_decay"`` and the ellipse half-width for
+    # ``"elliptical"`` (ignored by ``"uniform"`` / ``"sinusoidal_y"``).
+    # ``None`` (default) resolves to ``span_y / 4`` — a localized mid-width
+    # patch whose amplitude has fallen to exp(-4) ≈ 0.018 of the crest at the
+    # edges (gaussian_decay) or that occupies the central half of the width
+    # (elliptical). Must be > 0 when set.
+    transverse_width: float | None = None
 
     # Loading
     loading: str = "compression"
@@ -1466,6 +1518,65 @@ class AnalysisConfig:
                 f"a finite positive float when set, "
                 f"got {self.amplitude_profile_decay_length}"
             )
+
+        # --- Through-width (transverse) wrinkle surface (#300) --------
+        # Reuse WrinkleSurface3D's own mode set so the two never drift.
+        if (
+            not isinstance(self.transverse_mode, str)
+            or self.transverse_mode not in WrinkleSurface3D._VALID_MODES
+        ):
+            raise ValueError(
+                f"AnalysisConfig.transverse_mode must be one of "
+                f"{sorted(WrinkleSurface3D._VALID_MODES)}, "
+                f"got {self.transverse_mode!r}"
+            )
+        # span_y / width_y overrides must be positive and finite when set;
+        # ``None`` resolves to domain_width and span_y/4 at build time and is
+        # therefore always valid.
+        if self.transverse_span is not None and not (
+            self.transverse_span > 0.0 and math.isfinite(self.transverse_span)
+        ):
+            raise ValueError(
+                f"AnalysisConfig.transverse_span must be a finite positive "
+                f"float when set, got {self.transverse_span}"
+            )
+        if self.transverse_width is not None and not (
+            self.transverse_width > 0.0 and math.isfinite(self.transverse_width)
+        ):
+            raise ValueError(
+                f"AnalysisConfig.transverse_width must be a finite positive "
+                f"float when set, got {self.transverse_width}"
+            )
+        if self.transverse_mode != "uniform":
+            # The transverse envelope only manifests in the FE mesh, so it is
+            # meaningless on the x-only analytical path — fail fast instead of
+            # silently ignoring the requested surface.
+            if self.analytical_only:
+                raise ValueError(
+                    "AnalysisConfig.transverse_mode="
+                    f"{self.transverse_mode!r} requires the FE path but "
+                    "analytical_only=True. The transverse surface only "
+                    "manifests in the mesh; set analytical_only=False or "
+                    "transverse_mode='uniform'."
+                )
+            # Multi-wrinkle FE and CZM composition with a 3-D surface are out
+            # of scope for this first cut — reject the combination up front
+            # (issue #300) rather than surprising the user mid-solve.
+            if self.wrinkles is not None:
+                raise NotImplementedError(
+                    "AnalysisConfig.transverse_mode="
+                    f"{self.transverse_mode!r} is not yet supported together "
+                    "with a multi-wrinkle 'wrinkles' list. Use a single-"
+                    "wrinkle config (wrinkles=None) or transverse_mode="
+                    "'uniform'."
+                )
+            if self.enable_czm:
+                raise NotImplementedError(
+                    "AnalysisConfig.transverse_mode="
+                    f"{self.transverse_mode!r} is not yet supported together "
+                    "with enable_czm=True. Disable CZM or use "
+                    "transverse_mode='uniform'."
+                )
 
         # --- Loading --------------------------------------------------
         valid_loadings = ("compression", "tension")
@@ -2399,6 +2510,18 @@ class WrinkleAnalysis:
         if analytical_only is None:
             analytical_only = cfg.analytical_only
 
+        # A transverse surface only exists in the FE mesh, so a run-time
+        # analytical_only override must be rejected too (the construction-time
+        # _validate only sees cfg.analytical_only). Fail fast rather than
+        # silently dropping the requested through-width variation (#300).
+        if analytical_only and cfg.transverse_mode != "uniform":
+            raise ValueError(
+                "AnalysisConfig.transverse_mode="
+                f"{cfg.transverse_mode!r} requires the FE path but this run "
+                "was invoked with analytical_only=True. Run with "
+                "analytical_only=False or set transverse_mode='uniform'."
+            )
+
         # Multi-wrinkle FE solve (issue #252): overlapping and
         # non-overlapping layouts run through the linear FE path, and
         # (issue #283) through the CZM path — cohesive layers are
@@ -2470,11 +2593,23 @@ class WrinkleAnalysis:
             )
             results.wrinkle_config = wrinkle_config
         else:
-            profile = GaussianSinusoidal(
+            base_profile = GaussianSinusoidal(
                 amplitude=cfg.amplitude,
                 wavelength=cfg.wavelength,
                 width=cfg.width,
                 center=wrinkle_center,
+            )
+            # Through-width variation (#300): wrap the x-only profile in a
+            # 3-D transverse surface only when a non-uniform mode is
+            # requested. ``"uniform"`` leaves the bare GaussianSinusoidal
+            # untouched, so the default path stays bit-identical. The
+            # morphology layer already consumes WrinkleSurface3D end-to-end
+            # (node deformation + fibre-angle fields); multi-wrinkle/CZM
+            # combinations are rejected earlier in _validate.
+            profile: WrinkleProfile | WrinkleSurface3D = (
+                self._wrap_transverse_surface(base_profile)
+                if cfg.transverse_mode != "uniform"
+                else base_profile
             )
             if cfg.phase is not None and (
                 cfg.morphology.lower().strip() not in SINGLE_WRINKLE_MODES
@@ -3332,6 +3467,35 @@ class WrinkleAnalysis:
             stiffness_3d=mat.stiffness_matrix,
             ply_thickness=ply_thickness,
             E_x0=laminate.Ex,
+        )
+
+    def _wrap_transverse_surface(
+        self, profile: WrinkleProfile
+    ) -> WrinkleSurface3D:
+        """Wrap *profile* in a through-width :class:`WrinkleSurface3D` (#300).
+
+        Resolves the transverse span and localization half-width from the
+        config, defaulting ``span_y`` to the meshed ``domain_width`` and
+        ``width_y`` to ``span_y / 4`` (a localized mid-width patch). Only
+        called for a non-uniform ``transverse_mode``; validation has already
+        rejected the analytical-only, multi-wrinkle, and CZM combinations.
+        """
+        cfg = self.config
+        span_y = (
+            cfg.transverse_span
+            if cfg.transverse_span is not None
+            else cfg.domain_width
+        )
+        width_y = (
+            cfg.transverse_width
+            if cfg.transverse_width is not None
+            else span_y / 4.0
+        )
+        return WrinkleSurface3D(
+            profile,
+            transverse_mode=cfg.transverse_mode,
+            width_y=width_y,
+            span_y=span_y,
         )
 
     def _compute_analytical(

--- a/tests/test_param_docs_match.py
+++ b/tests/test_param_docs_match.py
@@ -29,6 +29,9 @@ EXPECTED_DEFAULTS: dict[str, object] = {
     "amplitude_profile": "constant",          # one of constant/gaussian/linear
     "amplitude_profile_decay_length": None,    # mm, None -> wrinkle width
     "amplitude_profile_axis": "x",             # one of x/y
+    "transverse_mode": "uniform",              # uniform/gaussian_decay/sinusoidal_y/elliptical
+    "transverse_span": None,                   # mm, None -> domain_width
+    "transverse_width": None,                  # mm, None -> span_y / 4
 }
 
 

--- a/tests/test_transverse_wrinkle.py
+++ b/tests/test_transverse_wrinkle.py
@@ -1,0 +1,214 @@
+"""Through-width (transverse) wrinkle surfaces via ``AnalysisConfig`` (#300).
+
+The ``WrinkleSurface3D`` transverse modes are wired to three new config
+fields (``transverse_mode`` / ``transverse_span`` / ``transverse_width``).
+These tests pin the contract:
+
+* the default (``"uniform"``) path is bit-identical — it builds the bare,
+  x-only ``GaussianSinusoidal`` and never a ``WrinkleSurface3D``;
+* a localized mode (``"gaussian_decay"``) gives a *milder* FE knockdown
+  than uniform at the same crest amplitude (the headline behaviour);
+* invalid modes and the out-of-scope combinations (analytical-only,
+  multi-wrinkle, CZM) fail fast at construction with actionable messages;
+* the new fields round-trip through ``to_dict`` / ``from_dict`` (#259).
+
+FE-solve tests carry the ``slow`` marker (#267).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wrinklefe.analysis import (
+    AnalysisConfig,
+    WrinkleAnalysis,
+    WrinkleSpec,
+)
+from wrinklefe.core.wrinkle import GaussianSinusoidal, WrinkleSurface3D
+
+# --------------------------------------------------------------------------- #
+# Defaults / regression
+# --------------------------------------------------------------------------- #
+
+def test_default_transverse_fields() -> None:
+    """The new fields default to the uniform, auto-resolved contract."""
+    cfg = AnalysisConfig()
+    assert cfg.transverse_mode == "uniform"
+    assert cfg.transverse_span is None
+    assert cfg.transverse_width is None
+
+
+def test_uniform_builds_bare_profile_not_wrapped() -> None:
+    """Default uniform mode must build a bare GaussianSinusoidal (#300).
+
+    Wrapping even in "uniform" mode would risk numerical drift; the
+    contract is that the default path is left completely untouched.
+    """
+    cfg = AnalysisConfig()
+    result = WrinkleAnalysis(cfg).run(analytical_only=True)
+    profile = result.wrinkle_config.wrinkles[0].profile
+    assert isinstance(profile, GaussianSinusoidal)
+    assert not isinstance(profile, WrinkleSurface3D)
+
+
+def test_non_uniform_wraps_in_surface3d() -> None:
+    """A non-uniform mode wraps the profile in a WrinkleSurface3D."""
+    cfg = AnalysisConfig(transverse_mode="gaussian_decay")
+    result = WrinkleAnalysis(cfg).run(analytical_only=False)
+    profile = result.wrinkle_config.wrinkles[0].profile
+    assert isinstance(profile, WrinkleSurface3D)
+    assert profile.transverse_mode == "gaussian_decay"
+    # span_y tracks the mesh width; width_y defaults to span_y / 4.
+    assert profile.span_y == pytest.approx(cfg.domain_width)
+    assert profile.width_y == pytest.approx(cfg.domain_width / 4.0)
+
+
+def test_explicit_span_and_width_forwarded() -> None:
+    """Explicit transverse_span / transverse_width reach the surface."""
+    cfg = AnalysisConfig(
+        transverse_mode="elliptical",
+        transverse_span=18.0,
+        transverse_width=4.0,
+    )
+    result = WrinkleAnalysis(cfg).run(analytical_only=False)
+    profile = result.wrinkle_config.wrinkles[0].profile
+    assert isinstance(profile, WrinkleSurface3D)
+    assert profile.span_y == pytest.approx(18.0)
+    assert profile.width_y == pytest.approx(4.0)
+
+
+# --------------------------------------------------------------------------- #
+# Directional acceptance: localized => milder knockdown
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.slow
+def test_gaussian_decay_is_milder_than_uniform() -> None:
+    """Same crest amplitude, localized surface => milder FE knockdown (#300).
+
+    The crest fibre angle at the mid-width centreline is identical (both
+    surfaces are full-amplitude there), so ``mesh_max_angle_rad`` matches;
+    the width-averaged FE knockdown is milder for the localized wrinkle,
+    i.e. it retains more stiffness and strength.
+    """
+    def solve(mode: str):
+        cfg = AnalysisConfig(
+            amplitude=0.366,
+            wavelength=16.0,
+            width=12.0,
+            morphology="stack",
+            loading="compression",
+            transverse_mode=mode,
+        )
+        return WrinkleAnalysis(cfg).run(analytical_only=False)
+
+    uniform = solve("uniform")
+    localized = solve("gaussian_decay")
+
+    # Crest angle unchanged (the centreline geometry is identical).
+    assert localized.mesh_max_angle_rad == pytest.approx(
+        uniform.mesh_max_angle_rad, rel=1e-9
+    )
+
+    # Milder stiffness knockdown: higher retention.
+    assert localized.modulus_retention_global > uniform.modulus_retention_global
+
+    # Milder strength knockdown: higher weakest-criterion retention.
+    u_str = min(uniform.retention_factors.values())
+    l_str = min(localized.retention_factors.values())
+    assert l_str > u_str
+
+
+# --------------------------------------------------------------------------- #
+# Validation / scope
+# --------------------------------------------------------------------------- #
+
+def test_invalid_mode_names_valid_set() -> None:
+    with pytest.raises(ValueError) as exc:
+        AnalysisConfig(transverse_mode="banana")
+    msg = str(exc.value)
+    assert "transverse_mode" in msg
+    # The valid set is reused from WrinkleSurface3D so the two never drift.
+    for mode in WrinkleSurface3D._VALID_MODES:
+        assert mode in msg
+
+
+def test_analytical_only_rejects_transverse_mode() -> None:
+    with pytest.raises(ValueError) as exc:
+        AnalysisConfig(transverse_mode="gaussian_decay", analytical_only=True)
+    msg = str(exc.value)
+    assert "analytical_only" in msg
+    assert "FE" in msg
+
+
+def test_run_time_analytical_override_rejected() -> None:
+    """A run(analytical_only=True) override is rejected too (not silent)."""
+    cfg = AnalysisConfig(transverse_mode="gaussian_decay")  # cfg default FE
+    with pytest.raises(ValueError):
+        WrinkleAnalysis(cfg).run(analytical_only=True)
+
+
+def test_multi_wrinkle_combination_rejected() -> None:
+    with pytest.raises(NotImplementedError) as exc:
+        AnalysisConfig(
+            transverse_mode="elliptical",
+            wrinkles=[
+                WrinkleSpec(
+                    amplitude=0.3, wavelength=16.0, width=12.0, ply_interface=11
+                )
+            ],
+        )
+    assert "wrinkles" in str(exc.value)
+
+
+def test_czm_combination_rejected() -> None:
+    with pytest.raises(NotImplementedError) as exc:
+        AnalysisConfig(transverse_mode="gaussian_decay", enable_czm=True)
+    assert "enable_czm" in str(exc.value)
+
+
+@pytest.mark.parametrize("field", ["transverse_span", "transverse_width"])
+@pytest.mark.parametrize("bad", [-1.0, 0.0, float("nan"), float("inf")])
+def test_non_positive_span_width_rejected(field: str, bad: float) -> None:
+    with pytest.raises(ValueError) as exc:
+        AnalysisConfig(transverse_mode="gaussian_decay", **{field: bad})
+    assert field in str(exc.value)
+
+
+def test_uniform_ignores_span_width_overrides() -> None:
+    """Uniform mode is unaffected by span/width and never wraps."""
+    cfg = AnalysisConfig(
+        transverse_mode="uniform", transverse_span=8.0, transverse_width=2.0
+    )
+    result = WrinkleAnalysis(cfg).run(analytical_only=True)
+    assert not isinstance(
+        result.wrinkle_config.wrinkles[0].profile, WrinkleSurface3D
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Serialisation round-trip (#259)
+# --------------------------------------------------------------------------- #
+
+def test_transverse_fields_round_trip() -> None:
+    cfg = AnalysisConfig(
+        transverse_mode="gaussian_decay",
+        transverse_span=18.0,
+        transverse_width=4.0,
+    )
+    payload = cfg.to_dict()
+    assert payload["transverse_mode"] == "gaussian_decay"
+    assert payload["transverse_span"] == 18.0
+    assert payload["transverse_width"] == 4.0
+
+    restored = AnalysisConfig.from_dict(payload)
+    assert restored.transverse_mode == "gaussian_decay"
+    assert restored.transverse_span == pytest.approx(18.0)
+    assert restored.transverse_width == pytest.approx(4.0)
+
+
+def test_default_transverse_fields_round_trip() -> None:
+    cfg = AnalysisConfig()
+    restored = AnalysisConfig.from_dict(cfg.to_dict())
+    assert restored.transverse_mode == "uniform"
+    assert restored.transverse_span is None
+    assert restored.transverse_width is None


### PR DESCRIPTION
## Linked issue

Fixes #300

## Summary

The `WrinkleSurface3D` transverse/localized wrinkle representation was fully implemented and unit-tested in the morphology layer, but unreachable: the pipeline only ever built an x-only `GaussianSinusoidal`, so every analysis assumed the wrinkle was uniform across the full specimen width. This PR is config plumbing only — no new physics — to reach the existing capability.

### What changed

Three new `AnalysisConfig` fields:

- `transverse_mode: str = "uniform"` — `"uniform"` (default) | `"gaussian_decay"` | `"sinusoidal_y"` | `"elliptical"`, validated against `WrinkleSurface3D._VALID_MODES` (the set is **reused**, not duplicated).
- `transverse_span: float | None = None` → `span_y`; `None` tracks `domain_width` so the envelope spans the meshed y-extent.
- `transverse_width: float | None = None` → `width_y`; `None` resolves at build time (see below).

At the single-wrinkle construction site the bare `GaussianSinusoidal` is wrapped in a `WrinkleSurface3D` **only** when `transverse_mode != "uniform"`. With the default `"uniform"` the bare profile is built exactly as before, so results are **bit-identical** (regression-safe — `scripts/validate.py` shows zero drift). The morphology layer already consumes `WrinkleSurface3D` end-to-end (node deformation + fibre-angle fields, including the `stack`/`dual_wrinkle` → `_profile_at_half_amplitude` default path).

### `width_y` default choice

`transverse_width=None` resolves to **`span_y / 4`**. Reading how `width_y` is used per mode (`wrinkle.py`): for `gaussian_decay` it is the Gaussian 1/e length scale, so `span_y/4` puts the edges at 2·`width_y` from centre → amplitude `exp(-4) ≈ 0.018` of the crest (a well-localized mid-width defect that isn't so tight it under-resolves on the default `ny=6` mesh); for `elliptical` it is the ellipse half-width, so `span_y/4` occupies the central half of the width. `sinusoidal_y`/`uniform` ignore `width_y`. This is documented in the field comment, the docstring, and the README table.

### Multi-wrinkle / CZM scope decision

Rejected at construction (fail fast, not mid-solve), per the issue's option 3:

- **Multi-wrinkle** (`wrinkles=[...]`) + non-uniform → `NotImplementedError`. The config exposes a single global transverse envelope, whereas a multi-wrinkle layout has per-wrinkle placements; the FE multi-wrinkle path is also already out of scope in the code. Composing one global surface across all wrinkles is a design decision left as a follow-up.
- **CZM** (`enable_czm=True`) + non-uniform → `NotImplementedError`. The cohesive path's interaction with a through-width-varying wrinkle is unverified.
- **Analytical-only** + non-uniform → `ValueError`. A transverse surface only manifests in the FE mesh, so it is rejected under `analytical_only=True` **and** under a run-time `run(analytical_only=True)` override (not silently ignored).

Default single-wrinkle + FE is fully supported.

### Milder-knockdown result (headline)

Same crest amplitude (`A=0.366`, `λ=16`, `w=12`, stack, compression), FE path, uniform vs `gaussian_decay`:

| metric | uniform | gaussian_decay |
|---|---|---|
| mesh max fibre angle (deg) | 7.329 | 7.329 (unchanged — centreline crest identical) |
| global modulus retention | 0.9832 | **0.9947** |
| strength retention (weakest, LaRC05) | 0.7547 | **0.8251** |

The localized wrinkle predicts a **milder** knockdown — the width-averaged defect volume drops while the crest centreline is unchanged.

### Docs / examples / tests

- README "Wrinkle geometry parameters" table + `AnalysisConfig` docstring updated in lockstep (`tests/test_param_docs_match.py` pins the defaults), plus a "Through-width (transverse) variation" note.
- `CHANGELOG.md` `### Added`.
- `examples/transverse_wrinkle_knockdown.py` — matplotlib-only, runs in the no-extras examples CI job; prints and plots localized-vs-uniform knockdown.
- `tests/test_transverse_wrinkle.py` — bit-identical default (bare profile), milder-knockdown acceptance (`slow`, #267), invalid-mode + analytical-only + multi-wrinkle + CZM rejections, and `to_dict`/`from_dict` round-trip (#259).

CLI (`--transverse-mode`, `--transverse-span`) and Streamlit exposure are a deliberate follow-up (issue option 4), out of scope here.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (`-m "not slow"`: 1611 passed; the new `slow` FE test passes)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (only the pre-existing `app.py:226` error remains)
- [x] Docs/README updated
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `python scripts/validate.py` shows no validation-ledger drift (all cases match pinned baselines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_