### PR TITLE
tests: enable doctests in CI and triage docstring examples to green (#296)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,33 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  doctests:
+    # Executes the `>>>` docstring examples across src/wrinklefe so a drift
+    # between the documented output and real behaviour fails CI. Kept as a
+    # dedicated job (not folded into `test`) so a doc example can never block
+    # the core unit-test suite — `--doctest-modules` is deliberately absent
+    # from the default addopts. Examples that need a heavy object (generated
+    # mesh, full FE solve) are marked `# doctest: +SKIP`; see CONTRIBUTING.md.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Run doctests
+        run: pytest --doctest-modules src/wrinklefe -q
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,15 @@ version produced a given file.
 - `provenance` block on JSON exports and the NCR summary recording the
   installed version, numerics stack, platform, and timestamp.
 - GitHub issue forms, pull-request template, and this changelog.
+- Docstring examples are now executed in CI (issue #296). A dedicated
+  `doctests` job runs `pytest --doctest-modules src/wrinklefe`, and
+  `doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"` is set. The
+  runnable `>>>` examples were made exact (real expected output,
+  NumPy-version-stable reprs) so they act as regression guards; examples
+  that need a generated mesh or a full FE solve are marked
+  `# doctest: +SKIP`. Kept out of the default `addopts` so a doc example
+  cannot block the core suite. Docstring-only change — no numeric
+  results shift.
 
 ### Fixed
 - Results-export schema drift (issue #345): the structured JSON export

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,39 @@ benchmark"`) once and owns the coverage upload. Run the full suite
 locally (`pytest`) before opening a PR when your change touches the FE,
 CZM, or analysis paths.
 
+### Doctests
+
+The `>>>` examples in the source docstrings are executed as tests so a
+drift between the documented output and real behaviour is caught. They
+run via a dedicated invocation (and a matching `doctests` CI job), kept
+**out** of the default `addopts` so a doc example can never block the
+core suite:
+
+```bash
+pytest --doctest-modules src/wrinklefe -q
+```
+
+`doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"` (in
+`pyproject.toml`) is applied, so `...` may stand in for volatile float
+digits and array/line-wrap whitespace is tolerated.
+
+When you add or edit a docstring example, triage it into one of:
+
+- **Make it exact** — include the setup lines and the *real* expected
+  output (run the snippet and paste the actual repr; never guess). This
+  is preferred for scalar/short-array/pure-function examples, which then
+  act as regression guards. Wrap NumPy scalar results in `bool(...)` /
+  `float(...)` so the repr is stable across NumPy versions.
+- **Mark `# doctest: +SKIP`** when a faithful example would need a heavy
+  object (a generated mesh, a full FE solve, a fitted result) or be
+  slow. An illustrative snippet is fine, but it **must** be explicitly
+  `+SKIP` — non-runnable examples are marked, never silently unrun.
+- **Convert to a plain code block** (strip the `>>>`) only if it was
+  never meant as an executable transcript.
+
+Keep the doctests fast (target < ~1 min); never let a "make exact"
+example trigger a real FE solve.
+
 ### Benchmarks
 
 Performance micro-benchmarks for the hot kernels live in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,12 @@ testpaths = ["tests"]
 # fast by excluding the pytest-benchmark performance suite; pass an
 # explicit -m on the CLI (e.g. -m benchmark) to override it.
 addopts = "-v --tb=short --strict-markers -m 'not benchmark'"
+# Docstring examples are executed via a dedicated `pytest --doctest-modules
+# src/wrinklefe` invocation (its own `doctests` CI job), NOT as part of the
+# default suite — a doc example must never be able to block the core tests.
+# These flags apply when that invocation runs: NORMALIZE_WHITESPACE tolerates
+# array/line-wrap formatting and ELLIPSIS allows `...` for volatile floats.
+doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 markers = [
     "slow: FE/CZM solves taking more than ~5s per test",
     "integration: end-to-end pipeline tests",

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -24,8 +24,8 @@ Minimal compression analysis::
     ...     morphology="concave", loading="compression",
     ... )
     >>> analysis = WrinkleAnalysis(config)
-    >>> result = analysis.run()
-    >>> print(result.summary())
+    >>> result = analysis.run()  # doctest: +SKIP
+    >>> print(result.summary())  # doctest: +SKIP
 
 References
 ----------
@@ -2450,8 +2450,8 @@ class WrinkleAnalysis:
     --------
     >>> config = AnalysisConfig(morphology="concave", amplitude=0.366)
     >>> analysis = WrinkleAnalysis(config)
-    >>> result = analysis.run()
-    >>> print(f"Strength = {result.analytical_strength_MPa:.1f} MPa")
+    >>> result = analysis.run()  # doctest: +SKIP
+    >>> print(f"Strength = {result.analytical_strength_MPa:.1f} MPa")  # doctest: +SKIP
     """
 
     def __init__(self, config: AnalysisConfig) -> None:

--- a/src/wrinklefe/core/laminate.py
+++ b/src/wrinklefe/core/laminate.py
@@ -226,10 +226,12 @@ class Laminate:
 
     Examples
     --------
+    >>> from wrinklefe.core.material import OrthotropicMaterial
+    >>> mat = OrthotropicMaterial()
     >>> lam = Laminate.from_angles([0, 45, -45, 90, 90, -45, 45, 0],
     ...                            material=mat, ply_thickness=0.183)
-    >>> lam.total_thickness
-    1.464
+    >>> lam.total_thickness  # doctest: +ELLIPSIS
+    1.464...
     >>> lam.is_symmetric
     True
     """

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -258,7 +258,7 @@ class WrinkleConfiguration:
         >>> config.n_wrinkles()
         2
         >>> config.aggregate_morphology_factor("compression")  # doctest: +ELLIPSIS
-        1.336...
+        1.333...
 
     References
     ----------
@@ -1071,6 +1071,8 @@ class WrinkleConfiguration:
         Create a convex dual-wrinkle at interfaces 11 and 12::
 
             >>> import numpy as np
+            >>> from wrinklefe.core.wrinkle import GaussianSinusoidal
+            >>> profile = GaussianSinusoidal(amplitude=0.366, wavelength=16.0, width=12.0)
             >>> config = WrinkleConfiguration.dual_wrinkle(
             ...     profile, interface1=11, interface2=12, phase=np.pi/2
             ... )
@@ -1148,9 +1150,13 @@ class WrinkleConfiguration:
         --------
         ::
 
+            >>> from wrinklefe.core.wrinkle import GaussianSinusoidal
+            >>> profile = GaussianSinusoidal(amplitude=0.366, wavelength=16.0, width=12.0)
             >>> config = WrinkleConfiguration.from_morphology_name(
             ...     "concave", profile, interface1=11, interface2=12
             ... )
+            >>> config.n_wrinkles()
+            2
         """
         key = name.lower().strip()
 

--- a/src/wrinklefe/elements/gauss.py
+++ b/src/wrinklefe/elements/gauss.py
@@ -45,8 +45,10 @@ def gauss_points_1d(n: int) -> tuple[np.ndarray, np.ndarray]:
     Examples
     --------
     >>> pts, wts = gauss_points_1d(2)
-    >>> pts  # array([-1/sqrt(3), 1/sqrt(3)])
-    >>> wts  # array([1.0, 1.0])
+    >>> pts  # +/- 1/sqrt(3)
+    array([-0.57735027,  0.57735027])
+    >>> wts
+    array([1., 1.])
     """
     if n == 1:
         points = np.array([0.0])
@@ -100,7 +102,7 @@ def gauss_points_hex(order: int = 2) -> tuple[np.ndarray, np.ndarray]:
     (8, 3)
     >>> wts.shape
     (8,)
-    >>> np.isclose(wts.sum(), 8.0)  # volume of reference cube
+    >>> bool(np.isclose(wts.sum(), 8.0))  # volume of reference cube
     True
     """
     pts_1d, wts_1d = gauss_points_1d(order)

--- a/src/wrinklefe/failure/evaluator.py
+++ b/src/wrinklefe/failure/evaluator.py
@@ -12,8 +12,8 @@ Typical Usage
 -------------
 >>> from wrinklefe.failure.evaluator import FailureEvaluator
 >>> evaluator = FailureEvaluator.default_criteria()
->>> report = evaluator.evaluate_laminate(laminate, load)
->>> print(report.summary())
+>>> report = evaluator.evaluate_laminate(laminate, load)  # doctest: +SKIP
+>>> print(report.summary())  # doctest: +SKIP
 
 References
 ----------
@@ -164,10 +164,16 @@ class FailureEvaluator:
 
     Examples
     --------
+    >>> import numpy as np
     >>> from wrinklefe.failure.max_stress import MaxStressCriterion
     >>> from wrinklefe.failure.hashin import HashinCriterion
+    >>> from wrinklefe.core.material import OrthotropicMaterial
     >>> evaluator = FailureEvaluator([MaxStressCriterion(), HashinCriterion()])
+    >>> stress = np.array([-800.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    >>> material = OrthotropicMaterial()
     >>> results = evaluator.evaluate_point(stress, material)
+    >>> sorted(results)
+    ['hashin', 'max_stress']
     """
 
     def __init__(self, criteria: list[FailureCriterion]):
@@ -274,10 +280,10 @@ class FailureEvaluator:
 
         >>> ply_contexts = [
         ...     {"misalignment_angle": phi_k} for phi_k in misalignments
-        ... ]
+        ... ]  # doctest: +SKIP
         >>> report = evaluator.evaluate_laminate(
         ...     laminate, load, ply_contexts=ply_contexts
-        ... )
+        ... )  # doctest: +SKIP
         """
         n_plies = laminate.n_plies
 

--- a/src/wrinklefe/failure/hashin.py
+++ b/src/wrinklefe/failure/hashin.py
@@ -72,12 +72,12 @@ class HashinCriterion(FailureCriterion):
     >>> mat = OrthotropicMaterial()
     >>> criterion = HashinCriterion()
     >>> import numpy as np
-    >>> # Pure fibre compression at 50% of Xc
+    >>> # Pure fibre compression at 62.5% of Xc (Xc = 1200 MPa)
     >>> stress = np.array([-750.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     >>> result = criterion.evaluate(stress, mat)
     >>> result.mode
     'fiber_compression'
-    >>> abs(result.index - 0.5) < 1e-10
+    >>> bool(abs(result.index - 0.625) < 1e-10)
     True
     """
 

--- a/src/wrinklefe/failure/kinkband.py
+++ b/src/wrinklefe/failure/kinkband.py
@@ -337,6 +337,7 @@ class InterlaminarDamage:
     >>> dmg = InterlaminarDamage()
     >>> D = dmg.damage_index(amplitude=0.366, theta=0.15, morphology_factor=1.0)
     >>> dmg.damage_to_strength(D)  # returns (1-D)^1.5
+    0.36646076482133927
     """
 
     def __init__(

--- a/src/wrinklefe/failure/max_stress.py
+++ b/src/wrinklefe/failure/max_stress.py
@@ -80,8 +80,8 @@ class MaxStressCriterion(FailureCriterion):
     >>> result = criterion.evaluate(stress, mat)
     >>> result.mode
     'fiber_compression'
-    >>> result.index  # 800 / 1500
-    0.533...
+    >>> float(result.index)  # 800 / 1200 (Xc = 1200 MPa)
+    0.6666666666666666
     """
 
     name: str = "max_stress"

--- a/src/wrinklefe/failure/progressive.py
+++ b/src/wrinklefe/failure/progressive.py
@@ -108,10 +108,16 @@ class PlyDiscount(ProgressiveDamageModel):
 
     Examples
     --------
+    >>> import numpy as np
+    >>> from wrinklefe.core.material import OrthotropicMaterial
+    >>> from wrinklefe.failure.max_stress import MaxStressCriterion
+    >>> material = OrthotropicMaterial()
+    >>> stress = np.array([-1500.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # beyond Xc -> fibre failure
+    >>> failure_result = MaxStressCriterion().evaluate(stress, material)
     >>> model = PlyDiscount(residual_factor=0.01)
     >>> degraded = model.degrade(material, failure_result)
-    >>> degraded.E1  # E1 reduced if fibre failure
-    1610.0
+    >>> degraded.E1  # E1 reduced to 1% on fibre failure
+    1714.2
     """
 
     def __init__(self, residual_factor: float = 0.01):
@@ -248,6 +254,12 @@ class ContinuumDamage(ProgressiveDamageModel):
 
     Examples
     --------
+    >>> import numpy as np
+    >>> from wrinklefe.core.material import OrthotropicMaterial
+    >>> from wrinklefe.failure.max_stress import MaxStressCriterion
+    >>> material = OrthotropicMaterial()
+    >>> stress = np.array([-1500.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # beyond Xc -> fibre failure
+    >>> failure_result = MaxStressCriterion().evaluate(stress, material)
     >>> cdm = ContinuumDamage()
     >>> cdm.update_damage(failure_result)
     >>> degraded_mat = cdm.degrade(material, failure_result)

--- a/src/wrinklefe/failure/tsai_wu.py
+++ b/src/wrinklefe/failure/tsai_wu.py
@@ -104,10 +104,10 @@ class TsaiWuCriterion(FailureCriterion):
     >>> mat = OrthotropicMaterial()
     >>> criterion = TsaiWuCriterion(f12_star=-0.5)
     >>> import numpy as np
-    >>> # Pure fibre compression at Xc should give FI = 1.0
-    >>> stress = np.array([-1500.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    >>> # Pure fibre compression at Xc (=1200 MPa) should give FI = 1.0
+    >>> stress = np.array([-1200.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     >>> result = criterion.evaluate(stress, mat)
-    >>> abs(result.index - 1.0) < 1e-10
+    >>> bool(abs(result.index - 1.0) < 1e-10)
     True
     """
 

--- a/src/wrinklefe/solver/assembler.py
+++ b/src/wrinklefe/solver/assembler.py
@@ -69,10 +69,13 @@ class GlobalAssembler:
 
     Examples
     --------
-    >>> assembler = GlobalAssembler(mesh, laminate)
-    >>> K = assembler.assemble_stiffness()
-    >>> dofs = assembler.element_dof_indices(0)
-    >>> dofs.shape
+    Illustrative usage (needs a generated ``mesh`` and ``laminate``, so the
+    snippet is skipped under ``--doctest-modules``)::
+
+    >>> assembler = GlobalAssembler(mesh, laminate)  # doctest: +SKIP
+    >>> K = assembler.assemble_stiffness()  # doctest: +SKIP
+    >>> dofs = assembler.element_dof_indices(0)  # doctest: +SKIP
+    >>> dofs.shape  # doctest: +SKIP
     (24,)
     """
 

--- a/src/wrinklefe/solver/assembler.py
+++ b/src/wrinklefe/solver/assembler.py
@@ -70,7 +70,7 @@ class GlobalAssembler:
     Examples
     --------
     Illustrative usage (needs a generated ``mesh`` and ``laminate``, so the
-    snippet is skipped under ``--doctest-modules``)::
+    snippet is skipped under ``--doctest-modules``).
 
     >>> assembler = GlobalAssembler(mesh, laminate)  # doctest: +SKIP
     >>> K = assembler.assemble_stiffness()  # doctest: +SKIP

--- a/src/wrinklefe/solver/boundary.py
+++ b/src/wrinklefe/solver/boundary.py
@@ -308,11 +308,14 @@ class BoundaryHandler:
 
     Examples
     --------
-    >>> handler = BoundaryHandler(mesh)
-    >>> bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.01)
-    >>> constrained = handler.get_constrained_dofs(bcs)
-    >>> F = handler.get_force_dofs(bcs)
-    >>> K_mod, F_mod = handler.apply_penalty(K, F, constrained)
+    Illustrative usage (needs a generated ``mesh``, so the snippet is skipped
+    under ``--doctest-modules``)::
+
+    >>> handler = BoundaryHandler(mesh)  # doctest: +SKIP
+    >>> bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.01)  # doctest: +SKIP
+    >>> constrained = handler.get_constrained_dofs(bcs)  # doctest: +SKIP
+    >>> F = handler.get_force_dofs(bcs)  # doctest: +SKIP
+    >>> K_mod, F_mod = handler.apply_penalty(K, F, constrained)  # doctest: +SKIP
     """
 
     def __init__(self, mesh: MeshData) -> None:
@@ -817,9 +820,12 @@ class BoundaryHandler:
 
         Examples
         --------
-        >>> bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.005)
-        >>> handler = BoundaryHandler(mesh)
-        >>> constrained = handler.get_constrained_dofs(bcs)
+        Illustrative usage (needs a generated ``mesh``, so the snippet is
+        skipped under ``--doctest-modules``)::
+
+        >>> bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.005)  # doctest: +SKIP
+        >>> handler = BoundaryHandler(mesh)  # doctest: +SKIP
+        >>> constrained = handler.get_constrained_dofs(bcs)  # doctest: +SKIP
         """
         Lx = mesh.domain_size[0]
         prescribed_disp = applied_strain * Lx

--- a/src/wrinklefe/solver/boundary.py
+++ b/src/wrinklefe/solver/boundary.py
@@ -309,7 +309,7 @@ class BoundaryHandler:
     Examples
     --------
     Illustrative usage (needs a generated ``mesh``, so the snippet is skipped
-    under ``--doctest-modules``)::
+    under ``--doctest-modules``).
 
     >>> handler = BoundaryHandler(mesh)  # doctest: +SKIP
     >>> bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.01)  # doctest: +SKIP
@@ -821,7 +821,7 @@ class BoundaryHandler:
         Examples
         --------
         Illustrative usage (needs a generated ``mesh``, so the snippet is
-        skipped under ``--doctest-modules``)::
+        skipped under ``--doctest-modules``).
 
         >>> bcs = BoundaryHandler.compression_bcs(mesh, applied_strain=-0.005)  # doctest: +SKIP
         >>> handler = BoundaryHandler(mesh)  # doctest: +SKIP


### PR DESCRIPTION
## Linked issue

Fixes #296

## Summary

The package ships ~105 `>>>` docstring examples that were never executed. This
wires them into CI and triages the failing set to green.

**Config + CI**
- `pyproject.toml`: add `doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"`.
  `--doctest-modules` is deliberately **not** added to the default `addopts`, so
  a doc example can never block the core unit-test suite.
- `.github/workflows/ci.yml`: new dedicated `doctests` job (ubuntu-latest,
  Python 3.12, `pip install -e ".[all,dev]"`, `pytest --doctest-modules
  src/wrinklefe -q`), mirroring the shape of the existing docs/benchmarks jobs.
  Existing jobs are untouched.
- `CONTRIBUTING.md`: document the doctest command and the make-exact / `+SKIP`
  convention. `CHANGELOG.md` `[Unreleased]` entry added.

**Docstring triage (no source-logic change)**
- **Before:** `pytest --doctest-modules src/wrinklefe` → **20 failed, 7 passed**.
- **After:** **0 failed** — 23 passed, 4 skipped, runs in ~1s.

Triage tally (per the issue's guidance — bias toward make-exact, `+SKIP` only
where a faithful example would need a generated mesh / full FE solve):

- **Made exact (13 examples)** — added the missing setup, ran the snippet, and
  pasted the real repr as regression guards: `core/laminate.py`,
  `core/morphology.py` (×3), `elements/gauss.py` (×2),
  `failure/evaluator.py::FailureEvaluator.evaluate_point`, `failure/hashin.py`,
  `failure/max_stress.py`, `failure/tsai_wu.py`, `failure/kinkband.py`,
  `failure/progressive.py` (×2). NumPy scalar results are wrapped in
  `bool(...)` / `float(...)` for version-stable reprs, and a few drifted
  expected values were corrected to the true output (e.g. the default material
  `Xc` is 1200 MPa, not 1500).
- **Marked `# doctest: +SKIP` (7 examples)** — illustrative snippets needing a
  generated mesh or a full FE solve (kept fast setup lines runnable where
  possible): `analysis.py` (×2, the `.run()` solve lines), `failure/evaluator.py`
  (module "Typical Usage" + `evaluate_laminate`), `solver/assembler.py`,
  `solver/boundary.py` (×2).
- **Converted to plain code block:** 0.

No numeric-results change: `python scripts/validate.py` reports zero drift.

## Checklist

- [x] Tests added or updated for the change (doctests are now executed; runnable examples made exact)
- [x] `pytest` green (`-m "not slow"`: 1611 passed, 79 deselected)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (only the pre-existing `app.py:226` error remains)
- [x] Docs/README updated if user-facing (CONTRIBUTING.md doctest section)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_