### PR TITLE
tool_flat morphology with significant surface resin pockets (Part A of #371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Analysis — **`tool_flat` morphology with significant surface resin
+  pockets** (issue #371, Part A). A new through-thickness decay mode /
+  morphology (`morphology="tool_flat"`) models a wrinkle cured against
+  rigid tooling: a uniform-amplitude core, a short linear transition over
+  `surface_transition_plies` plies (new config field, default 2), and an
+  **exactly-flat pinned surface** on `surface_pocket_side`
+  (`"top"`/`"bottom"`/`"both"`). This fixes the root cause of the reported
+  bug that surface pockets were invisible and mechanically negligible: the
+  linear-decay morphologies (`stack`/`convex`/`concave`, `graded` with
+  `decay_floor=0`) spread the wave across the whole thickness, so at the
+  24-ply defaults (t=0.183 mm, A=0.5 mm) the outermost undulating ply moved
+  only ~0.045 mm — a trough gap of **~0.25 of one ply thickness**. Under
+  `tool_flat` the mismatch collects at the flat surface, so the trough
+  pocket is ≈ the full amplitude (**~2.7 ply thicknesses** at defaults).
+  Surface pockets **auto-enable** for `tool_flat` (they are its defining
+  physics; skipped only for `analytical_only`), and the analytical path
+  equals `uniform` (M_f = 1.0; the pocket effect is FE-only). Toggling the
+  pockets now moves `modulus_retention_global` by a clearly significant
+  margin (measured **~3.1–3.4 %** at A=0.5–0.55 mm, `surface_transition_plies=4`,
+  side `both`) versus a negligible **~0.3 %** for the legacy `stack`
+  morphology — a ~10× larger effect, the original complaint resolved.
+  `compute_surface_resin_blend` tags **all** stretched layers in the
+  multi-ply transition zone (volume-conserving), and its height metric is
+  now the tilt-invariant vertical stretch (top-face minus bottom-face
+  mean-z) so a realistically-localized wrinkle's in-plane slope no longer
+  corrupts the gap. A verified element-inversion bound (`amplitude ≤ 0.8 ·
+  surface_transition_plies · ply_thickness / nz_per_ply`) is enforced at
+  construction with a message naming both remedies; multi-wrinkle / CZM /
+  transverse combinations raise `NotImplementedError`. App/UX exposure of
+  the new morphology is a deliberate follow-up (Part B).
 - Analysis — **through-width (transverse) wrinkle surfaces reachable from
   `AnalysisConfig`** (issue #300). The already-implemented, already-tested
   `WrinkleSurface3D` transverse modes are now selectable through three new

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ the docs and the dataclass cannot drift.
 | `transverse_mode` | name | `"uniform"` | Through-width (transverse, y-direction) wrinkle-surface envelope `f(y)`. `"uniform"` (default) builds the bare x-only wrinkle exactly as before (bit-identical). The non-uniform modes wrap the profile in a `WrinkleSurface3D` so the crest amplitude varies across the specimen width: `"gaussian_decay"` decays it toward the edges (localized mid-width defect), `"sinusoidal_y"` ripples it across the width, and `"elliptical"` confines it to a mid-width patch. **FE-only** — a non-uniform mode requires `analytical_only=False` and is not yet combinable with multi-wrinkle (`wrinkles`) or `enable_czm` (both rejected at construction). | one of `uniform`, `gaussian_decay`, `sinusoidal_y`, `elliptical` |
 | `transverse_span` | mm | `None` | Specimen width `span_y` seen by the transverse envelope. `None` tracks `domain_width` so the envelope always spans the meshed y-extent. Ignored when `transverse_mode == "uniform"`. | finite and > 0 when set |
 | `transverse_width` | mm | `None` | Transverse localization half-width `width_y`: the Gaussian 1/e length for `"gaussian_decay"` and the ellipse half-width for `"elliptical"` (ignored by `"uniform"`/`"sinusoidal_y"`). `None` resolves to `span_y / 4` — a localized mid-width patch whose amplitude has fallen to `exp(−4) ≈ 0.018` of the crest at the edges (`gaussian_decay`) or that occupies the central half of the width (`elliptical`). | finite and > 0 when set |
+| `surface_transition_plies` | count | `2` | `tool_flat` morphology only: number of plies over which the amplitude ramps linearly from the full-amplitude core to zero at the pinned (tool-flat) surface. A short transition concentrates the full-amplitude trough mismatch into a thin surface band (significant resin pockets), but the crest-side transition elements compress by `amplitude / surface_transition_plies`, so the amplitude is bounded: `amplitude ≤ 0.8 · surface_transition_plies · ply_thickness / nz_per_ply` (enforced at construction; exceed it and the message names both remedies). | integer ≥ 1 |
 
 Peak fibre misalignment: `θ_max ≈ arctan(2πA/λ)` (exact for a pure
 cosine; dimensionless because A and λ share the mm length unit). See the
@@ -259,6 +260,45 @@ zones **compose** (per-element maximum) when both are enabled. This is an
 angles only. A `uniform` morphology (never flat) or `graded` with
 `decay_floor > 0` (wavy surface) is rejected with a message naming the
 fix.
+
+#### The `tool_flat` morphology (significant pockets)
+
+Under the smooth-decay morphologies above (`stack`/`convex`/`concave`,
+or `graded` with `decay_floor=0`) the amplitude tapers **linearly** across
+the whole thickness, so the outermost undulating ply barely moves — at the
+24-ply defaults the trough gap is only ~0.25 of a *single* ply thickness,
+invisible in the preview and mechanically negligible. Those morphologies
+model a co-cured *gradual* wrinkle, not a tooling-dominated one.
+
+`morphology="tool_flat"` models the tooling-dominated case directly: a
+uniform-amplitude core (like `uniform`), a short linear transition over
+`surface_transition_plies` (default 2), and an **exactly-flat pinned
+surface** on `surface_pocket_side` (`"top"`/`"bottom"`/`"both"`). The
+kinematic mismatch across the transition equals the *full* amplitude, so
+the trough pocket is ≈ `amplitude` deep (≈2.7 ply thicknesses at
+defaults) — significant and visible. Surface pockets **auto-enable** for
+`tool_flat` (they are its defining physics), and the analytical path
+equals `uniform` (M_f = 1.0; the pocket effect is FE-only).
+
+```python
+config = AnalysisConfig(
+    morphology="tool_flat", amplitude=0.35, wavelength=16.0, width=12.0,
+    surface_pocket_side="both",       # tool-flat face(s), also the pocket side
+    surface_transition_plies=3,       # amplitude ramp width (>= 1)
+    material=lib.get("IM7_8552"), angles=[0.0] * 24, ply_thickness=0.183,
+)
+result = WrinkleAnalysis(config).run()   # pockets auto-enabled
+print(result.modulus_retention_global)
+```
+
+On the crest side the `surface_transition_plies` transition elements
+*compress* by `amplitude / surface_transition_plies`, so the amplitude is
+bounded — `amplitude ≤ 0.8 · surface_transition_plies · ply_thickness /
+nz_per_ply`; beyond it the elements would invert and construction fails
+with a message naming both remedies (more transition plies, or a smaller
+amplitude). The symmetric-profile limitation under rigid tooling (crests
+physically compact rather than penetrate the tool) is a documented
+follow-up.
 
 ### Penetration gate (θ, D/T, z) — UD, zero FE cost
 

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -1280,11 +1280,22 @@ class AnalysisConfig:
     # wavy surfaces and are rejected.
     enable_surface_resin_pockets: bool = False
     # Which tool-flat surface(s) to tag: "top" (+z), "bottom" (-z), "both".
+    # For the ``tool_flat`` morphology this doubles as ``tool_side`` — the
+    # surface(s) pinned exactly flat by the tooling.
     surface_pocket_side: str = "top"
     # Absolute gap (mm) below which an element is treated as flat, so
     # numerically-flat regions do not produce resin "dust".  ``None`` uses
     # the ply-thickness-scaled default (0.01 * ply_thickness).
     surface_pocket_min_gap: float | None = None
+    # ``tool_flat`` morphology only: number of plies over which the wrinkle
+    # amplitude ramps linearly from the full-amplitude core to zero at the
+    # pinned surface.  A short transition concentrates the full-amplitude
+    # trough mismatch into a thin surface band (significant pockets), but the
+    # crest-side transition elements compress by ``amplitude /
+    # surface_transition_plies`` — so the amplitude is bounded (see
+    # ``_validate``): ``A <= 0.8 * surface_transition_plies * ply_thickness /
+    # nz_per_ply``.  Must be >= 1.  Default 2.
+    surface_transition_plies: int = 2
 
     # ------------------------------------------------------------------
     # Progressive-damage FE path (load-stepping ply-discount to ultimate
@@ -1384,6 +1395,29 @@ class AnalysisConfig:
                 self.interface_1 = max(0, mid - 1)
             if self.interface_2 is None:
                 self.interface_2 = min(n_plies - 1, mid)
+
+        # Surface resin pockets ARE the physics of the ``tool_flat``
+        # morphology (the flat pinned surface would otherwise silently
+        # stretch the fibre elements over the troughs — the old #371 bug).
+        # Auto-enable them on the FE path.  Skipped for analytical_only,
+        # where the pocket has no effect and the run equals ``uniform``.
+        morph_name = (
+            self.morphology.lower().strip()
+            if isinstance(self.morphology, str)
+            else self.morphology
+        )
+        if (
+            morph_name == "tool_flat"
+            and not self.analytical_only
+            and not self.enable_surface_resin_pockets
+        ):
+            logger.warning(
+                "Surface resin pockets auto-enabled for the 'tool_flat' "
+                "morphology (they are its defining physics: the flat pinned "
+                "surface fills the wrinkle troughs with neat resin). Set "
+                "enable_surface_resin_pockets=True to silence this message."
+            )
+            self.enable_surface_resin_pockets = True
 
         self._validate()
 
@@ -1748,6 +1782,75 @@ class AnalysisConfig:
                     "(the floor is a residual surface amplitude); surface "
                     "resin pockets require a tool-flat surface. Set "
                     "decay_floor=0 (or use 'stack'/'convex'/'concave')."
+                )
+
+        # --- tool_flat morphology (issue #371) ------------------------
+        # ``surface_transition_plies`` is validated for every config (it is a
+        # dataclass field), then the tool_flat-specific geometry bound and
+        # combination rules are enforced only when the morphology is selected.
+        if (
+            not isinstance(self.surface_transition_plies, int)
+            or isinstance(self.surface_transition_plies, bool)
+            or self.surface_transition_plies < 1
+        ):
+            raise ValueError(
+                f"AnalysisConfig.surface_transition_plies must be an int "
+                f">= 1, got {self.surface_transition_plies!r}"
+            )
+        morph = (
+            self.morphology.lower().strip()
+            if isinstance(self.morphology, str)
+            else self.morphology
+        )
+        if morph == "tool_flat":
+            # Element-inversion bound (verified in the #371 spike): on the
+            # crest side each of the ``surface_transition_plies`` transition
+            # elements compresses by ``amplitude / surface_transition_plies``
+            # over an element height ``ply_thickness / nz_per_ply``, so it
+            # inverts once ``amplitude >= surface_transition_plies *
+            # ply_thickness / nz_per_ply``.  Reject above a safe 0.8 fraction,
+            # naming BOTH remedies.
+            a_safe = (
+                0.8
+                * self.surface_transition_plies
+                * self.ply_thickness
+                / self.nz_per_ply
+            )
+            if self.amplitude > a_safe:
+                raise ValueError(
+                    "AnalysisConfig: tool_flat amplitude "
+                    f"{self.amplitude:.4g} mm exceeds the safe bound "
+                    f"{a_safe:.4g} mm — the crest-side transition elements "
+                    "would invert (negative Jacobian). Either increase "
+                    "surface_transition_plies to >= "
+                    f"{math.ceil(self.amplitude * self.nz_per_ply / (0.8 * self.ply_thickness))} "
+                    f"or reduce amplitude below {a_safe:.4g} mm "
+                    "(the bound is 0.8 * surface_transition_plies * "
+                    "ply_thickness / nz_per_ply)."
+                )
+            # tool_flat is a single-wrinkle FE morphology whose pockets and
+            # decay are not verified in combination with the multi-wrinkle,
+            # CZM, or through-width paths — reject rather than silently drop
+            # the tool-flat decay (which would revert to the old linear taper).
+            if self.wrinkles is not None:
+                raise NotImplementedError(
+                    "AnalysisConfig: tool_flat morphology is single-wrinkle; "
+                    "it is not yet combinable with the multi-wrinkle "
+                    "'wrinkles' override (which would ignore the tool-flat "
+                    "decay). Use a single wrinkle or a different morphology."
+                )
+            if self.enable_czm:
+                raise NotImplementedError(
+                    "AnalysisConfig: tool_flat morphology is not yet "
+                    "combinable with enable_czm (the surface-pocket resin "
+                    "zone and cohesive elements are unverified together)."
+                )
+            if self.transverse_mode != "uniform":
+                raise NotImplementedError(
+                    "AnalysisConfig: tool_flat morphology is not yet "
+                    "combinable with a non-uniform transverse_mode "
+                    f"({self.transverse_mode!r}); the tool-flat decay is "
+                    "verified for the x-only wrinkle only."
                 )
 
         # --- Progressive-damage path ----------------------------------
@@ -2635,6 +2738,13 @@ class WrinkleAnalysis:
                     amplitude_profile=amp_profile,
                     amplitude_profile_decay_length=cfg.amplitude_profile_decay_length,
                     amplitude_profile_axis=amp_axis,
+                    # tool_flat: the tool-flat surface(s) reuse the
+                    # surface-pocket side, and the transition-zone width
+                    # controls the pocket depth / inversion margin.
+                    tool_side=cast(
+                        Literal["top", "bottom", "both"], cfg.surface_pocket_side
+                    ),
+                    surface_transition_plies=cfg.surface_transition_plies,
                 )
             results.wrinkle_config = wrinkle_config
 

--- a/src/wrinklefe/core/morphology.py
+++ b/src/wrinklefe/core/morphology.py
@@ -50,7 +50,7 @@ MORPHOLOGY_PHASES: dict[str, float] = {
 }
 
 # Single-wrinkle morphology types (not phase-based)
-SINGLE_WRINKLE_MODES = {"uniform", "graded"}
+SINGLE_WRINKLE_MODES = {"uniform", "graded", "tool_flat"}
 """Canonical dual-wrinkle morphology phase offsets (radians).
 
 - ``'stack'``: phi = 0 -- peaks and troughs aligned vertically.
@@ -182,6 +182,14 @@ class WrinkleConfiguration:
       through-thickness envelope even though both have M_f = 1.0.
     - ``"graded"``: single wrinkle, ``decay_mode="graded"`` (linear
       decay from mid-ply to surfaces, modulated by ``decay_floor``).
+    - ``"tool_flat"``: single wrinkle, ``decay_mode="tool_flat"``
+      (uniform-amplitude core, a linear transition over
+      ``surface_transition_plies`` plies, and an exactly-flat pinned
+      surface on the ``tool_side`` face(s)).  The interior carries the
+      full amplitude like ``"uniform"`` — so it shares uniform's
+      M_f = 1.0 and analytical knockdown — but the pinned flat surface
+      makes the trough gap ≈ the full amplitude, producing *significant*
+      surface resin pockets (issue #371).
 
     The aggregate morphology factor for N wrinkles uses the geometric-mean
     normalisation from the N-wrinkle extension (Eq. 12)::
@@ -198,8 +206,19 @@ class WrinkleConfiguration:
     decay_mode : str, optional
         Through-thickness amplitude distribution. ``"default"`` (linear
         decay from the wrinkle interface to the laminate surfaces),
-        ``"uniform"`` (full amplitude at every ply), or ``"graded"``
-        (linear decay from mid-ply to surfaces). Default ``"default"``.
+        ``"uniform"`` (full amplitude at every ply), ``"graded"``
+        (linear decay from mid-ply to surfaces), or ``"tool_flat"``
+        (uniform-amplitude core with a linear transition over
+        ``surface_transition_plies`` plies to an exactly-flat pinned
+        surface on the ``tool_side`` face(s)). Default ``"default"``.
+    tool_side : {"top", "bottom", "both"}, optional
+        ``"tool_flat"`` mode only: which outer surface(s) are pinned
+        exactly flat (cured against rigid tooling / a caul sheet).
+        Default ``"top"``.
+    surface_transition_plies : int, optional
+        ``"tool_flat"`` mode only: number of plies over which the
+        amplitude ramps linearly from the full-amplitude core to zero at
+        the pinned surface. Must be >= 1. Default 2.
     decay_floor : float, optional
         Dimensionless fraction in ``[0, 1]`` used only by the ``"graded"``
         decay mode: the minimum fraction of the wrinkle amplitude retained
@@ -277,6 +296,8 @@ class WrinkleConfiguration:
         amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant",
         amplitude_profile_decay_length: float | None = None,
         amplitude_profile_axis: Literal["x", "y"] = "x",
+        tool_side: Literal["top", "bottom", "both"] = "top",
+        surface_transition_plies: int = 2,
     ) -> None:
         if not wrinkles:
             raise ValueError("At least one WrinklePlacement is required.")
@@ -285,10 +306,33 @@ class WrinkleConfiguration:
             wrinkles, key=lambda w: w.ply_interface
         )
         # Decay mode for through-thickness amplitude distribution:
-        #   "default"  — standard linear decay from wrinkle interface
-        #   "uniform"  — full amplitude at all plies (no decay)
-        #   "graded"   — linear decay from mid-ply to surfaces
+        #   "default"   — standard linear decay from wrinkle interface
+        #   "uniform"   — full amplitude at all plies (no decay)
+        #   "graded"    — linear decay from mid-ply to surfaces
+        #   "tool_flat" — uniform-amplitude core, a short linear transition
+        #                 over ``surface_transition_plies`` plies, and an
+        #                 exactly-flat pinned surface (decay = 0) on the
+        #                 ``tool_side`` face(s).  Reproduces a wrinkle cured
+        #                 against rigid tooling: the wave is confined to the
+        #                 interior and the mismatch collects as surface resin
+        #                 pockets over the troughs (issue #371).
         self.decay_mode: str = decay_mode
+        # Tool-flat parameters (consulted only by decay_mode == "tool_flat").
+        # ``tool_side`` selects which surface(s) are pinned flat;
+        # ``surface_transition_plies`` (>= 1) is the number of plies over
+        # which the amplitude ramps linearly from the full-amplitude core to
+        # zero at the pinned surface.
+        if surface_transition_plies < 1:
+            raise ValueError(
+                "surface_transition_plies must be >= 1, got "
+                f"{surface_transition_plies}"
+            )
+        if tool_side not in ("top", "bottom", "both"):
+            raise ValueError(
+                f"tool_side must be 'top', 'bottom' or 'both', got {tool_side!r}"
+            )
+        self.tool_side: str = tool_side
+        self.surface_transition_plies: int = int(surface_transition_plies)
         # Decay floor for graded mode: minimum fraction of amplitude at
         # surface plies (0.0 = full decay to zero, 1.0 = uniform).
         # Physically: surface plies retain some waviness even far from
@@ -800,6 +844,33 @@ class WrinkleConfiguration:
         if self.decay_mode == "uniform":
             return np.ones(p.shape, dtype=np.float64)
 
+        if self.decay_mode == "tool_flat":
+            # Uniform-amplitude core (decay = 1), a linear ramp over the
+            # ``surface_transition_plies`` transition plies, and an exactly
+            # flat pinned surface (decay = 0) on the chosen ``tool_side``.
+            # The trough gap between the flat surface and the outermost
+            # undulating (core) ply is therefore the full amplitude, so the
+            # surface resin pockets are significant (issue #371) — unlike the
+            # sub-quarter-ply gap the linear-decay modes leave.
+            if n_plies <= 1:
+                return np.ones(p.shape, dtype=np.float64)
+            s_trans = float(self.surface_transition_plies)
+            pf = p.astype(np.float64)
+            top_ply = float(n_plies - 1)
+            if self.tool_side in ("top", "both"):
+                # decay = 0 at the top surface ply, ramping to 1 across the
+                # top ``s_trans`` plies (and clipped to 1 in the core).
+                top = np.clip((top_ply - pf) / s_trans, 0.0, 1.0)
+            else:
+                top = np.ones_like(pf)
+            if self.tool_side in ("bottom", "both"):
+                bot = np.clip(pf / s_trans, 0.0, 1.0)
+            else:
+                bot = np.ones_like(pf)
+            # "both" pins each surface; the min keeps the core at 1 while
+            # each face ramps to 0 independently.
+            return np.asarray(np.minimum(top, bot))
+
         if self.decay_mode == "graded":
             if n_plies <= 1:
                 return np.ones(p.shape, dtype=np.float64)
@@ -1117,6 +1188,8 @@ class WrinkleConfiguration:
         amplitude_profile: Literal["constant", "gaussian", "linear"] = "constant",
         amplitude_profile_decay_length: float | None = None,
         amplitude_profile_axis: Literal["x", "y"] = "x",
+        tool_side: Literal["top", "bottom", "both"] = "top",
+        surface_transition_plies: int = 2,
     ) -> WrinkleConfiguration:
         """Create a dual-wrinkle configuration from a morphology name.
 
@@ -1127,8 +1200,12 @@ class WrinkleConfiguration:
         Parameters
         ----------
         name : str
-            Morphology name: ``'stack'``, ``'convex'``, or ``'concave'``.
-            Case-insensitive.
+            Morphology name: ``'stack'``, ``'convex'``, ``'concave'``,
+            ``'uniform'``, ``'graded'``, or ``'tool_flat'``.
+            Case-insensitive.  The single-wrinkle modes (``'uniform'``,
+            ``'graded'``, ``'tool_flat'``) place one wrinkle at the mid
+            interface; ``'tool_flat'`` additionally consults ``tool_side``
+            and ``surface_transition_plies``.
         profile : WrinkleProfile or WrinkleSurface3D
             Wrinkle geometry (shared by both wrinkles).
         interface1 : int
@@ -1175,6 +1252,8 @@ class WrinkleConfiguration:
                 amplitude_profile=amplitude_profile,
                 amplitude_profile_decay_length=amplitude_profile_decay_length,
                 amplitude_profile_axis=amplitude_profile_axis,
+                tool_side=tool_side,
+                surface_transition_plies=surface_transition_plies,
             )
 
         # Dual-wrinkle morphologies: phase-offset pair

--- a/src/wrinklefe/core/resin_pocket.py
+++ b/src/wrinklefe/core/resin_pocket.py
@@ -420,18 +420,35 @@ def compute_surface_resin_blend(
     ncol = int(mesh.nx) * int(mesh.ny)
     n_elem = int(mesh.n_elements)
 
-    # Per-element deformed height from the 8 node z-coordinates.
+    # Per-element deformed height as the *vertical* (through-thickness)
+    # stretch: the mean-z of the top face minus the mean-z of the bottom
+    # face.  This is tilt-invariant — unlike a ``z.max - z.min`` bounding
+    # box, a rigidly translated/sheared element (an interior ply riding the
+    # wrinkle at full amplitude) keeps its nominal height, so only genuine
+    # through-thickness stretch (the resin gap) registers.  Bounding-box
+    # height instead conflates the wrinkle's in-plane slope with the gap,
+    # which for a realistically-localized wrinkle swamps the true stretch
+    # and, for a one-sided tool-flat surface, tags the whole interior.
     ez = mesh.nodes[mesh.elements][:, :, 2]
-    height = ez.max(axis=1) - ez.min(axis=1)
+    # hex8 node order: 0-3 bottom face (k), 4-7 top face (k+1).
+    height = ez[:, 4:8].mean(axis=1) - ez[:, 0:4].mean(axis=1)
 
-    z_lo = float(mesh.nodes[:, 2].min())
-    z_hi = float(mesh.nodes[:, 2].max())
-    total_thickness = z_hi - z_lo
+    # Nominal (undeformed) element height.  Taken from the laminate when
+    # available so a wavy (non-tool-flat) outer surface does not inflate the
+    # reference; falls back to the deformed bounding box for the bare
+    # hand-built fixtures that carry no laminate.
+    if mesh.laminate is not None:
+        zc = np.asarray(mesh.laminate.z_coords(), dtype=np.float64)
+        nominal_thickness = float(zc[-1] - zc[0])
+    else:
+        nominal_thickness = float(mesh.nodes[:, 2].max() - mesh.nodes[:, 2].min())
     # Structured mesh: every element has the same nominal height.
-    h0 = total_thickness / nz if nz > 0 else 0.0
+    h0 = nominal_thickness / nz if nz > 0 else 0.0
 
     n_plies = int(mesh.ply_ids.max()) + 1 if mesh.ply_ids.size else 1
-    ply_thickness = total_thickness / n_plies if n_plies > 0 else total_thickness
+    ply_thickness = (
+        nominal_thickness / n_plies if n_plies > 0 else nominal_thickness
+    )
     if spec.min_gap_threshold is not None:
         tol = float(spec.min_gap_threshold)
     else:

--- a/src/wrinklefe/core/resin_pocket.py
+++ b/src/wrinklefe/core/resin_pocket.py
@@ -327,22 +327,25 @@ def _tag_surface_side(
     height: np.ndarray,
     nonflat: np.ndarray,
     side: str,
-    nz: int,
     ncol: int,
+    n_layers: int = 1,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Tag the single transition element-layer nearest one flat surface.
+    """Tag the ``n_layers`` transition element-layers nearest one flat surface.
 
-    The surface pocket lives in exactly one horizontal element-layer: the
-    layer straddling the outermost pinned/undulating interface (the pinned
-    surface plies above it are flat, the interior below undulates).  That
-    layer is the non-flat layer with the extreme k-index toward the chosen
-    surface — fixed across all columns, so a column where the wrinkle
-    happens to cross zero (locally flat) never leaks the tag onto a deeper
-    internal ply interface.
+    For the smooth-decay morphologies the surface pocket lives in exactly
+    ONE horizontal element-layer (``n_layers == 1``): the layer straddling
+    the outermost pinned/undulating interface.  The ``tool_flat`` morphology
+    (issue #371) spreads the full-amplitude mismatch over its
+    ``surface_transition_plies`` transition plies, so several stacked
+    element-layers stretch — ``n_layers`` selects the non-flat layers
+    closest to the chosen surface (fixed across all columns, so a locally
+    flat column never leaks the tag onto a deeper internal ply interface,
+    and — for ``side="both"`` — the top pass never reaches the bottom
+    transition band or vice versa).
 
-    Returns the transition-layer element indices and their blend weights
-    (0 where a column has no gap or the ply is in compression there).  When
-    no layer is non-flat (flat mesh) the returned arrays are empty.
+    Returns the tagged element indices and their blend weights (0 where a
+    column has no gap or the ply is in compression there).  When no layer is
+    non-flat (flat mesh) the returned arrays are empty.
     """
     layer_nonflat = nonflat.any(axis=1)
     layers = np.flatnonzero(layer_nonflat)
@@ -350,16 +353,20 @@ def _tag_surface_side(
         empty = np.empty(0, dtype=np.int64)
         return empty, np.empty(0, dtype=np.float64)
 
-    # Transition layer: closest non-flat layer to the chosen surface.
-    k = int(layers.max()) if side == "top" else int(layers.min())
+    # The ``n_layers`` non-flat layers closest to the chosen surface.
+    sel = layers[-n_layers:] if side == "top" else layers[:n_layers]
 
     cols = np.arange(ncol)
-    g = gap[k, cols]
-    h = height[k, cols]
-    with np.errstate(invalid="ignore", divide="ignore"):
-        w = np.where((nonflat[k, cols]) & (g > 0.0), g / h, 0.0)
-    elem_idx = k * ncol + cols
-    return elem_idx, np.asarray(w, dtype=np.float64)
+    idx_parts: list[np.ndarray] = []
+    w_parts: list[np.ndarray] = []
+    for k in (int(kk) for kk in sel):
+        g = gap[k, cols]
+        h = height[k, cols]
+        with np.errstate(invalid="ignore", divide="ignore"):
+            w = np.where((nonflat[k, cols]) & (g > 0.0), g / h, 0.0)
+        idx_parts.append(k * ncol + cols)
+        w_parts.append(np.asarray(w, dtype=np.float64))
+    return np.concatenate(idx_parts), np.concatenate(w_parts)
 
 
 def compute_surface_resin_blend(
@@ -441,9 +448,19 @@ def compute_surface_resin_blend(
     height_grid = height.reshape(nz, ncol)
     nonflat = np.abs(gap_grid) > tol
 
+    # The ``tool_flat`` morphology (issue #371) confines the full-amplitude
+    # mismatch to a multi-ply transition band, so every stretched layer in
+    # that band is tagged (not just the single outermost one).  All other
+    # morphologies keep the single-transition-layer behaviour.
+    n_layers = 1
+    if getattr(wrinkle_config, "decay_mode", None) == "tool_flat":
+        n_layers = int(getattr(wrinkle_config, "surface_transition_plies", 1))
+
     sides = ("top", "bottom") if spec.side == "both" else (spec.side,)
     for side in sides:
-        elem_idx, w = _tag_surface_side(gap_grid, height_grid, nonflat, side, nz, ncol)
+        elem_idx, w = _tag_surface_side(
+            gap_grid, height_grid, nonflat, side, ncol, n_layers
+        )
         np.maximum.at(weight, elem_idx, w)
 
     return weight

--- a/tests/test_param_docs_match.py
+++ b/tests/test_param_docs_match.py
@@ -32,6 +32,7 @@ EXPECTED_DEFAULTS: dict[str, object] = {
     "transverse_mode": "uniform",              # uniform/gaussian_decay/sinusoidal_y/elliptical
     "transverse_span": None,                   # mm, None -> domain_width
     "transverse_width": None,                  # mm, None -> span_y / 4
+    "surface_transition_plies": 2,             # count, tool_flat morphology (>= 1)
 }
 
 

--- a/tests/test_surface_resin_pockets.py
+++ b/tests/test_surface_resin_pockets.py
@@ -76,13 +76,23 @@ def _build_mesh(
 
 
 def _element_geometry(mesh):
-    """Return (deformed height, nominal height, footprint area) per element."""
+    """Return (deformed height, nominal height, footprint area) per element.
+
+    Height is the tilt-invariant vertical stretch (top-face mean-z minus
+    bottom-face mean-z), matching ``compute_surface_resin_blend``; the
+    nominal height comes from the undeformed laminate.
+    """
     ez = mesh.nodes[mesh.elements][:, :, 2]
     ex = mesh.nodes[mesh.elements][:, :, 0]
     ey = mesh.nodes[mesh.elements][:, :, 1]
-    h = ez.max(axis=1) - ez.min(axis=1)
-    z_span = float(mesh.nodes[:, 2].max() - mesh.nodes[:, 2].min())
-    h0 = z_span / mesh.nz
+    # hex8 node order: 0-3 bottom face, 4-7 top face.
+    h = ez[:, 4:8].mean(axis=1) - ez[:, 0:4].mean(axis=1)
+    if mesh.laminate is not None:
+        zc = np.asarray(mesh.laminate.z_coords(), dtype=float)
+        nominal = float(zc[-1] - zc[0])
+    else:
+        nominal = float(mesh.nodes[:, 2].max() - mesh.nodes[:, 2].min())
+    h0 = nominal / mesh.nz
     area = (ex.max(axis=1) - ex.min(axis=1)) * (ey.max(axis=1) - ey.min(axis=1))
     return h, h0, area
 

--- a/tests/test_toolflat_morphology.py
+++ b/tests/test_toolflat_morphology.py
@@ -1,0 +1,305 @@
+"""Acceptance tests for the ``tool_flat`` morphology (issue #371, Part A).
+
+These encode the user's complaint and the fix's guarantees:
+
+(a) **Significance** — toggling the surface pockets on/off moves
+    ``modulus_retention_global`` by a clearly significant margin for
+    ``tool_flat`` (>= 3 %), versus a negligible move for the legacy
+    ``stack`` morphology (the original bug).
+(b) **Preview-gap magnitude** — the trough pocket depth is >= ~1 ply
+    thickness (vs ~0.25 for the linear-decay morphologies).
+(c) **Flatness invariant** — the pinned surface(s) are exactly flat.
+(d) **Positive Jacobians** at the validated amplitude bound; amplitudes
+    beyond it are rejected at construction.
+(e) **Analytical path equals uniform** (M_f = 1.0); zero drift for the
+    existing morphologies is covered by the validation ledger.
+
+The FE-solve cases are marked ``integration``/``slow`` per issue #267;
+the geometry/validation cases run fast (no solve).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import MaterialLibrary
+from wrinklefe.core.mesh import WrinkleMesh
+from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+PLY_T = 0.183
+N_PLIES = 24
+
+
+def _common(**over):
+    base = dict(
+        material=MaterialLibrary().get("IM7_8552"),
+        angles=[0.0] * N_PLIES,
+        ply_thickness=PLY_T,
+        wavelength=16.0,
+        width=12.0,
+        nx=36,
+        ny=3,
+        nz_per_ply=1,
+        loading="compression",
+    )
+    base.update(over)
+    return base
+
+
+def _toolflat_mesh(amplitude, *, side="both", s_trans=3, nz_per_ply=1, nx=36):
+    """Deformed tool_flat mesh only (no FE solve) — fast."""
+    mat = MaterialLibrary().get("IM7_8552")
+    lam = Laminate.from_angles([0.0] * N_PLIES, mat, PLY_T)
+    Lx = 3.0 * 16.0
+    prof = GaussianSinusoidal(
+        amplitude=amplitude, wavelength=16.0, width=12.0, center=Lx / 2.0
+    )
+    wc = WrinkleConfiguration.from_morphology_name(
+        "tool_flat", prof, interface1=11, interface2=12,
+        tool_side=side, surface_transition_plies=s_trans,
+    )
+    mesh = WrinkleMesh(
+        lam, wc, Lx=Lx, Ly=20.0, nx=nx, ny=3, nz_per_ply=nz_per_ply
+    ).generate()
+    return mesh, wc
+
+
+# ---------------------------------------------------------------------------
+# (e) Morphology / analytical path
+# ---------------------------------------------------------------------------
+
+
+def test_toolflat_is_single_wrinkle_mf_one():
+    """tool_flat is a single mid-interface wrinkle with M_f = 1.0."""
+    prof = GaussianSinusoidal(0.25, 16.0, 12.0, center=24.0)
+    wc = WrinkleConfiguration.from_morphology_name(
+        "tool_flat", prof, interface1=11, interface2=12
+    )
+    assert wc.n_wrinkles() == 1
+    assert wc.decay_mode == "tool_flat"
+    assert wc.aggregate_morphology_factor("compression") == 1.0
+
+
+def test_toolflat_decay_core_full_surface_pinned():
+    """Decay is 1 in the core, ramps over S plies, and 0 at the surface."""
+    prof = GaussianSinusoidal(0.25, 16.0, 12.0, center=24.0)
+    wc = WrinkleConfiguration.from_morphology_name(
+        "tool_flat", prof, interface1=11, interface2=12,
+        tool_side="both", surface_transition_plies=2,
+    )
+    ply = np.minimum(np.arange(N_PLIES + 1), N_PLIES - 1)
+    decay = wc._through_thickness_decay(ply, 11, N_PLIES)
+    assert decay[0] == 0.0 and decay[N_PLIES - 1] == 0.0  # both surfaces pinned
+    assert decay[N_PLIES // 2] == 1.0                     # full-amplitude core
+    assert decay[1] == pytest.approx(0.5)                 # linear ramp (S=2)
+
+
+def test_toolflat_analytical_equals_uniform():
+    """The closed-form knockdown equals uniform's (same full-amplitude core)."""
+    tf = WrinkleAnalysis(
+        AnalysisConfig(morphology="tool_flat", amplitude=0.25, analytical_only=True,
+                       material=MaterialLibrary().get("IM7_8552"),
+                       angles=[0.0] * N_PLIES, ply_thickness=PLY_T)
+    ).run()
+    uni = WrinkleAnalysis(
+        AnalysisConfig(morphology="uniform", amplitude=0.25, analytical_only=True,
+                       material=MaterialLibrary().get("IM7_8552"),
+                       angles=[0.0] * N_PLIES, ply_thickness=PLY_T)
+    ).run()
+    assert tf.analytical_knockdown == pytest.approx(uni.analytical_knockdown)
+
+
+# ---------------------------------------------------------------------------
+# (b, c, d) geometry: gap magnitude, flatness, positive Jacobians
+# ---------------------------------------------------------------------------
+
+
+def test_pocket_gap_is_at_least_one_ply_thickness():
+    """The trough pocket depth is >= ~1 ply thickness (vs ~0.25 for linear)."""
+    A = 0.35
+    mesh, _ = _toolflat_mesh(A, side="top", s_trans=3)
+    # Pocket depth = the deepest the core plies pull away from the flat
+    # surface = the full amplitude, since the core decay is 1.
+    flat = WrinkleMesh(
+        Laminate.from_angles([0.0] * N_PLIES,
+                             MaterialLibrary().get("IM7_8552"), PLY_T),
+        None, Lx=48.0, Ly=20.0, nx=36, ny=3, nz_per_ply=1,
+    ).generate()
+    dz = mesh.nodes[:, 2] - flat.nodes[:, 2]
+    pocket_depth = float(np.max(np.abs(dz)))
+    assert pocket_depth == pytest.approx(A, rel=0.02)
+    assert pocket_depth / PLY_T > 1.0
+
+
+def test_pinned_surface_is_exactly_flat():
+    """The tool_side surface(s) carry no residual waviness."""
+    mesh, _ = _toolflat_mesh(0.30, side="both", s_trans=2)
+    per_layer = (mesh.nx + 1) * (mesh.ny + 1)
+    k_idx = np.arange(mesh.n_nodes) // per_layer
+    top = mesh.nodes[k_idx == mesh.nz, 2]
+    bot = mesh.nodes[k_idx == 0, 2]
+    assert float(top.max() - top.min()) < 1e-12
+    assert float(bot.max() - bot.min()) < 1e-12
+
+
+def test_multi_layer_pocket_volume_is_conserved():
+    """Σ weight·h over the S-layer transition zone == the integrated gap."""
+    from wrinklefe.core.resin_pocket import (
+        SurfacePocketSpec,
+        compute_surface_resin_blend,
+    )
+
+    A, S = 0.3, 3
+    mesh, wc = _toolflat_mesh(A, side="top", s_trans=S, nx=48)
+    w = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+    tagged = w > 0
+    # Exactly S element-layers carry the pocket.
+    k_layers = np.unique(np.flatnonzero(tagged) // (mesh.nx * mesh.ny))
+    assert len(k_layers) == S
+
+    ez = mesh.nodes[mesh.elements][:, :, 2]
+    ex = mesh.nodes[mesh.elements][:, :, 0]
+    ey = mesh.nodes[mesh.elements][:, :, 1]
+    h = ez[:, 4:8].mean(axis=1) - ez[:, 0:4].mean(axis=1)
+    area = (ex.max(1) - ex.min(1)) * (ey.max(1) - ey.min(1))
+    zc = np.asarray(mesh.laminate.z_coords(), dtype=float)
+    h0 = float(zc[-1] - zc[0]) / mesh.nz
+
+    # weight·h == h − h0 per element (excess vertical stretch), so the tagged
+    # volume equals the integrated kinematic gap through the whole zone.
+    vol_weight = float((w * h * area)[tagged].sum())
+    vol_gap = float(((h - h0) * area)[tagged].sum())
+    assert np.isclose(vol_weight, vol_gap, rtol=1e-9)
+    assert vol_gap > 0.0
+
+
+def test_positive_jacobians_at_the_amplitude_bound():
+    """At the max validated amplitude the mesh generates (positive Jacobians)."""
+    for s_trans in (2, 3):
+        a_bound = 0.8 * s_trans * PLY_T / 1  # nz_per_ply = 1
+        # Mesh generation runs the strict det(J) > 0 check and would raise
+        # MeshValidationError on inversion — reaching here means it passed.
+        mesh, _ = _toolflat_mesh(a_bound, side="both", s_trans=s_trans)
+        assert mesh.n_elements > 0
+
+
+# ---------------------------------------------------------------------------
+# (d) validation: inversion bound, S >= 1, combination rules, auto-enable
+# ---------------------------------------------------------------------------
+
+
+def test_amplitude_above_bound_is_rejected_with_both_remedies():
+    a_bound = 0.8 * 2 * PLY_T / 1
+    with pytest.raises(ValueError) as exc:
+        AnalysisConfig(**_common(morphology="tool_flat",
+                                 amplitude=a_bound * 1.2,
+                                 surface_transition_plies=2))
+    msg = str(exc.value)
+    assert "surface_transition_plies" in msg  # remedy 1: more transition plies
+    assert "amplitude" in msg                  # remedy 2: smaller amplitude
+
+
+def test_surface_transition_plies_must_be_at_least_one():
+    with pytest.raises(ValueError, match="surface_transition_plies"):
+        AnalysisConfig(**_common(morphology="tool_flat", amplitude=0.2,
+                                 surface_transition_plies=0))
+
+
+def test_toolflat_auto_enables_pockets_on_fe_path():
+    cfg = AnalysisConfig(**_common(morphology="tool_flat", amplitude=0.25))
+    assert cfg.enable_surface_resin_pockets is True
+
+
+def test_toolflat_analytical_only_does_not_auto_enable():
+    cfg = AnalysisConfig(morphology="tool_flat", amplitude=0.25,
+                         analytical_only=True,
+                         material=MaterialLibrary().get("IM7_8552"),
+                         angles=[0.0] * N_PLIES, ply_thickness=PLY_T)
+    assert cfg.enable_surface_resin_pockets is False
+
+
+def test_toolflat_rejects_unverified_combinations():
+    from wrinklefe.analysis import WrinkleSpec
+
+    with pytest.raises(NotImplementedError, match="multi-wrinkle"):
+        AnalysisConfig(**_common(
+            morphology="tool_flat", amplitude=0.2,
+            wrinkles=[WrinkleSpec(amplitude=0.2, wavelength=16.0, width=12.0,
+                                  ply_interface=11)],
+        ))
+    with pytest.raises(NotImplementedError, match="enable_czm"):
+        AnalysisConfig(**_common(morphology="tool_flat", amplitude=0.2,
+                                 enable_czm=True))
+    with pytest.raises(NotImplementedError, match="transverse_mode"):
+        AnalysisConfig(**_common(morphology="tool_flat", amplitude=0.2,
+                                 transverse_mode="gaussian_decay"))
+
+
+def test_toolflat_roundtrips_new_field():
+    """surface_transition_plies rides the #259 dataclass-walk round-trip."""
+    cfg = AnalysisConfig(**_common(morphology="tool_flat", amplitude=0.25,
+                                   surface_transition_plies=3))
+    restored = AnalysisConfig.from_dict(cfg.to_dict())
+    assert restored.surface_transition_plies == 3
+    assert restored.morphology == "tool_flat"
+
+
+# ---------------------------------------------------------------------------
+# (a) Headline significance — the user's complaint, encoded (FE solve; slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_toggling_pockets_is_significant_for_toolflat_not_for_stack():
+    """tool_flat pockets move the modulus by >= 3 %; the old stack barely moves.
+
+    The toggle for tool_flat compares the auto-tagged pockets against the
+    *identical* geometry with tagging suppressed (a huge ``min_gap``), so the
+    only difference is the resin material — a clean on/off of the feature.
+    """
+    A, S = 0.55, 4
+
+    def run(**kw):
+        return WrinkleAnalysis(AnalysisConfig(**_common(**kw))).run()
+
+    tf_on = run(morphology="tool_flat", amplitude=A, surface_pocket_side="both",
+                surface_transition_plies=S)
+    tf_off = run(morphology="tool_flat", amplitude=A, surface_pocket_side="both",
+                 surface_transition_plies=S, surface_pocket_min_gap=1.0e9)
+    st_on = run(morphology="stack", amplitude=A,
+                enable_surface_resin_pockets=True, surface_pocket_side="both")
+    st_off = run(morphology="stack", amplitude=A,
+                 enable_surface_resin_pockets=False)
+
+    tf_delta = tf_off.modulus_retention_global - tf_on.modulus_retention_global
+    st_delta = st_off.modulus_retention_global - st_on.modulus_retention_global
+
+    assert int((tf_on.mesh.resin_blend > 0).sum()) > 0
+    assert tf_off.mesh.resin_blend is None or not (tf_off.mesh.resin_blend > 0).any()
+
+    # tool_flat: a clearly significant, asserted change (>= 3 %).
+    assert tf_delta >= 0.03
+    # Old stack: negligible (the original bug — pockets insignificant).
+    assert st_delta < 0.01
+    # ... and the tool_flat toggle dwarfs the old one.
+    assert tf_delta > 5.0 * st_delta
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_toolflat_tags_multiple_transition_layers():
+    """All S transition layers are tagged (not just the outermost one)."""
+    res = WrinkleAnalysis(
+        AnalysisConfig(**_common(morphology="tool_flat", amplitude=0.3,
+                                 surface_pocket_side="top",
+                                 surface_transition_plies=3))
+    ).run()
+    weight = res.mesh.resin_blend
+    tagged = np.flatnonzero(weight > 0)
+    k_layers = np.unique(tagged // (res.mesh.nx * res.mesh.ny))
+    assert len(k_layers) == 3  # one per transition ply

--- a/tests/test_toolflat_spike.py
+++ b/tests/test_toolflat_spike.py
@@ -1,0 +1,195 @@
+"""Diagnostic spike for the ``tool_flat`` morphology (issue #371, Part A).
+
+This module *protects the diagnosis* behind the ``tool_flat`` morphology
+and pins the element-inversion bound the morphology's validation relies
+on.  It deliberately depends only on primitives that predate the feature
+(``WrinkleConfiguration`` decay helpers, a hand-rolled tool-flat decay,
+the hex8 Jacobian check), so it stands on its own as the pre-implementation
+spike.
+
+Two findings are pinned:
+
+1. **The bug (linear-decay morphologies give insignificant pockets).**
+   At app defaults (24 plies, ``t = 0.183`` mm, ``A = 0.5`` mm) every
+   tool-flat-*compatible* morphology (``stack`` and ``graded`` with
+   ``decay_floor = 0``) decays the wave linearly across the whole
+   thickness, so the outermost undulating ply displaces only
+   ~0.043-0.046 mm — a trough gap of ~0.24 of a *single* ply thickness,
+   invisible in the preview and mechanically negligible.  This is the
+   user's report, encoded as a regression guard.
+
+2. **The fix and its geometric limit.**  A uniform-amplitude core with a
+   short linear transition to an exactly-flat pinned surface makes the
+   trough gap ≈ the *full* amplitude ``A`` (≈2.7 ply thicknesses at
+   defaults).  But on the crest side the ``S`` transition elements each
+   *compress* by ``A / S`` over an element height ``t / nz_per_ply``, so
+   they invert (negative Jacobian) once
+
+       A / S >= t / nz_per_ply    <=>    A >= S * t / nz_per_ply.
+
+   The spike verifies this bound numerically: positive Jacobians at the
+   bound, inversion just beyond.  ``AnalysisConfig._validate`` rejects
+   ``tool_flat`` amplitudes above ``0.8 * S * t / nz_per_ply``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import MaterialLibrary
+from wrinklefe.core.mesh import MeshData, WrinkleMesh
+from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+from wrinklefe.elements.hex8 import _detJ_at_centroid_batch
+
+# App defaults reproduced from the issue.
+N_PLIES = 24
+PLY_T = 0.183
+A_DEFAULT = 0.5
+LAM = 16.0
+WIDTH = 12.0
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — the bug: linear-decay morphologies give an insignificant gap
+# ---------------------------------------------------------------------------
+
+
+def _outer_ply_displacement(morphology: str, **kw) -> float:
+    """Max trough displacement of the outermost *undulating* ply."""
+    Lx = 3.0 * LAM
+    prof = GaussianSinusoidal(
+        amplitude=A_DEFAULT, wavelength=LAM, width=WIDTH, center=Lx / 2.0
+    )
+    wc = WrinkleConfiguration.from_morphology_name(
+        morphology, prof, interface1=11, interface2=12, **kw
+    )
+    # Node ply-ids for a single through-thickness column (k = 0 .. n_plies).
+    ply_ids = np.minimum(np.arange(N_PLIES + 1), N_PLIES - 1)
+    k = wc.wrinkles[0].ply_interface if wc.n_wrinkles() == 1 else 11
+    decay = wc._through_thickness_decay(ply_ids, k, N_PLIES)
+    xs = np.linspace(0.0, Lx, 4000)
+    dmax = float(np.max(np.abs(prof.displacement(xs))))
+    # The outermost undulating ply is the node-layer one in from the (flat)
+    # surface: ply-id N_PLIES - 2.
+    return dmax * float(decay[N_PLIES - 2])
+
+
+def test_linear_decay_gap_is_insignificant():
+    """Both tool-flat-compatible morphologies leave a sub-quarter-ply gap."""
+    stack = _outer_ply_displacement("stack")
+    graded = _outer_ply_displacement("graded", decay_floor=0.0)
+    # ~0.045 mm for stack, ~0.043 mm for graded (the issue's numbers).
+    assert 0.040 < stack < 0.050
+    assert 0.038 < graded < 0.048
+    # ... i.e. ~a quarter of ONE ply thickness — the user's "invisible" gap.
+    assert stack / PLY_T < 0.30
+    assert graded / PLY_T < 0.30
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — the fix: a tool-flat decay makes the gap ~= full amplitude,
+# and the element-inversion bound A_crit = S * t / nz_per_ply.
+# ---------------------------------------------------------------------------
+
+
+def _toolflat_decay(
+    ply_ids: np.ndarray, n_plies: int, s_trans: int, side: str = "top"
+) -> np.ndarray:
+    """Hand-rolled tool-flat decay: 1 in the core, linear ramp to 0 at
+    the pinned surface(s) over ``s_trans`` plies.  Mirrors the production
+    ``_through_thickness_decay(decay_mode="tool_flat")`` this spike predates.
+    """
+    p = np.asarray(ply_ids, dtype=np.float64)
+    top_ply = n_plies - 1
+    top = (
+        np.clip((top_ply - p) / s_trans, 0.0, 1.0)
+        if side in ("top", "both")
+        else np.ones_like(p)
+    )
+    bot = (
+        np.clip(p / s_trans, 0.0, 1.0)
+        if side in ("bottom", "both")
+        else np.ones_like(p)
+    )
+    return np.minimum(top, bot)
+
+
+def _build_toolflat_mesh(
+    amplitude: float, *, nz_per_ply: int = 1, s_trans: int = 2, nx: int = 16
+) -> tuple[MeshData, np.ndarray]:
+    """Coarse hand-rolled tool-flat mesh (uniform core, flat top surface).
+
+    Returns the deformed mesh and the per-node z-displacement field.
+    """
+    mat = MaterialLibrary().get("AS4_3501_6")
+    lam = Laminate.from_angles([0.0] * N_PLIES, mat, PLY_T)
+    Lx = LAM
+    flat = WrinkleMesh(
+        lam, None, Lx=Lx, Ly=4.0, nx=nx, ny=1, nz_per_ply=nz_per_ply
+    ).generate()
+    nodes = flat.nodes.copy()
+    per_layer = (nx + 1) * 2
+    k_idx = np.arange(flat.n_nodes) // per_layer
+    node_ply = np.minimum(k_idx // nz_per_ply, N_PLIES - 1)
+    prof = GaussianSinusoidal(
+        amplitude=amplitude, wavelength=LAM, width=1.0e6, center=Lx / 2.0
+    )
+    dz = prof.displacement(nodes[:, 0]) * _toolflat_decay(
+        node_ply, N_PLIES, s_trans, "top"
+    )
+    nodes[:, 2] += dz
+    mesh = MeshData(
+        nodes=nodes,
+        elements=flat.elements,
+        ply_ids=flat.ply_ids,
+        fiber_angles=flat.fiber_angles,
+        ply_angles=flat.ply_angles,
+        nx=nx,
+        ny=1,
+        nz=flat.nz,
+    )
+    return mesh, dz
+
+
+def test_toolflat_gap_is_full_amplitude():
+    """The trough pocket depth under the flat surface is ~= the full A."""
+    A = 0.25  # a safe amplitude for S = 2, nz_per_ply = 1
+    mesh, dz = _build_toolflat_mesh(A, nz_per_ply=1, s_trans=2)
+    # Top surface node layer is pinned exactly flat.
+    per_layer = (mesh.nx + 1) * 2
+    k_idx = np.arange(mesh.n_nodes) // per_layer
+    top = mesh.nodes[k_idx == mesh.nz, 2]
+    assert float(top.max() - top.min()) < 1e-12
+    # The pocket depth is the displacement the outermost undulating (core)
+    # plies pull away from the pinned surface — the full amplitude A, since
+    # the core carries decay = 1 while the surface is pinned at 0.
+    pocket_depth = float(np.max(np.abs(dz)))
+    assert np.isclose(pocket_depth, A, rtol=0.02)  # ~= full amplitude A
+    assert pocket_depth / PLY_T > 1.0  # >= one ply thickness (vs ~0.25 linear)
+
+
+def test_inversion_bound_is_S_times_t_over_nz():
+    """Positive Jacobians at the bound; inversion just beyond it."""
+    s_trans = 2
+    for nz_per_ply in (1, 2):
+        a_crit = s_trans * PLY_T / nz_per_ply
+        # At the safe fraction and at the bound: every element is valid.
+        for frac in (0.8, 1.0):
+            mesh, _ = _build_toolflat_mesh(
+                frac * a_crit, nz_per_ply=nz_per_ply, s_trans=s_trans
+            )
+            detj = _detJ_at_centroid_batch(mesh.nodes[mesh.elements])
+            assert detj.min() > 0.0, (
+                f"nz_per_ply={nz_per_ply} frac={frac}: min detJ "
+                f"{detj.min():.3e} should be positive at/under the bound"
+            )
+        # Just beyond the bound: elements invert (negative Jacobian).
+        mesh, _ = _build_toolflat_mesh(
+            1.1 * a_crit, nz_per_ply=nz_per_ply, s_trans=s_trans
+        )
+        detj = _detJ_at_centroid_batch(mesh.nodes[mesh.elements])
+        assert detj.min() < 0.0, (
+            f"nz_per_ply={nz_per_ply}: amplitude 1.1x the bound must invert"
+        )


### PR DESCRIPTION
## Linked issue

Part A of #371. (Part B — the app/UX relocation of the surface-pocket controls into the morphology selector — is a separate later PR, so this does **not** close the issue.)

## Summary

Adds a new `tool_flat` morphology that produces **significant** surface resin pockets, fixing the root cause of the reported bug that pockets were invisible in the preview and mechanically negligible on/off.

**The diagnosis (reproduced as a spike).** Under every tool-flat-*compatible* morphology (`stack`/`convex`/`concave`, or `graded` with `decay_floor=0`) the amplitude tapers **linearly** across the whole thickness, so at the 24-ply defaults (t=0.183 mm, A=0.5 mm) the outermost undulating ply moves only ~0.045 mm — a trough gap of **~0.25 of one ply thickness**. The pockets were insignificant *by construction*.

**The fix.** `morphology="tool_flat"` models a wrinkle cured against rigid tooling: a uniform-amplitude core, a short linear transition over `surface_transition_plies` (new field, default 2), and an **exactly-flat pinned surface** on `surface_pocket_side` (`top`/`bottom`/`both`). The mismatch collects at the flat surface, so the trough pocket is ≈ the full amplitude (**~2.7 ply thicknesses** at defaults). Pockets **auto-enable** for `tool_flat` (they are its defining physics; skipped only for `analytical_only`), and the analytical path equals `uniform` (M_f = 1.0; pocket effect is FE-only).

**Measured element-inversion bound (the mandatory spike).** On the crest side the `surface_transition_plies` transition elements compress by `A / surface_transition_plies` over element height `ply_thickness / nz_per_ply`, so they invert once `A ≥ surface_transition_plies · ply_thickness / nz_per_ply`. Verified numerically: positive Jacobians at (and just under) the bound, inversion just beyond. `_validate` rejects `A > 0.8 · surface_transition_plies · ply_thickness / nz_per_ply` with a message naming **both** remedies (more transition plies, or smaller amplitude).

**Significance numbers (the complaint, encoded).** Toggling the pockets on the *identical* geometry moves `modulus_retention_global`:

| morphology | pocket toggle Δ(modulus retention) |
|---|---|
| `tool_flat` (A=0.5 mm, S=4, both) | **~3.1 %** |
| `tool_flat` (A=0.55 mm, S=4, both) | **~3.4 %** |
| legacy `stack` (same A) | **~0.3 %** |

≈ **10× larger** effect for `tool_flat` — the original bug resolved. Preview-gap magnitude goes from ~0.25 → ~2.7 ply thicknesses.

### Notable implementation detail

`compute_surface_resin_blend` now (a) tags **all** stretched layers in the multi-ply transition zone (not just the outermost), and (b) measures per-element height as the **tilt-invariant vertical stretch** (top-face minus bottom-face mean-z) against the **nominal (undeformed)** element height. The previous bounding-box metric conflated the wrinkle's in-plane slope with the resin gap — negligible for the wide-envelope #361 fixtures, but for a realistically-localized wrinkle it swamped the true stretch and, on a one-sided tool-flat surface, tagged the whole interior. Volume conservation (`weight·h == gap`) is preserved and now exact.

Multi-wrinkle / CZM / non-uniform-transverse combinations with `tool_flat` raise `NotImplementedError`. Existing morphologies are untouched (validation ledger: **zero drift**; the #361 pocket fixtures were updated only to track the corrected height metric).

## Checklist

- [x] Tests added or updated for the change (spike + acceptance suite; FE solves marked `integration`/`slow`)
- [x] `pytest` green (1627 passed `-m "not slow"`; 6 slow FE tests passed once)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean (only the pre-existing `app.py:226`)
- [x] Docs/README updated (wrinkle-parameter table row + `tool_flat` subsection)
- [x] `CHANGELOG.md` `[Unreleased]` updated with the measured before/after numbers
- [x] `python scripts/validate.py` shows no validation-ledger drift
- [x] `sphinx-build -W docs docs/_build` succeeds; `pytest --doctest-modules src/wrinklefe` 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_