### PR TITLE
tool_flat morphology UX: surface pockets live in the morphology definition (Part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- App / CLI — **`tool_flat` surface-pocket controls live in the morphology
+  definition** (issue #371, Part B — *Fixes #371*, completing the issue).
+  The Streamlit Morphology selectbox gains **`tool_flat`** (Expert mode)
+  with its own schematic cartoon (flat pinned face, uniform-amplitude core,
+  amber resin wedges at the troughs). Selecting it renders the pinned-side
+  and **surface-transition-plies** controls *directly under* the morphology
+  controls — no longer in the FE expert section — alongside a live
+  inversion-bound caption (max safe amplitude = `0.8 · S · t / nz`) and a
+  pre-run warning naming both remedies, so the config `ValueError` is never
+  the user's first feedback. Surface pockets **auto-enable** for `tool_flat`
+  (no checkbox). The Analyze-tab cross-section renders the *thick* pockets
+  via the actual `tool_flat` decay (pinned plies flat, uniform core); a
+  fidelity test binds the analytic preview gap area to the multi-layer FE
+  tagged volume (~10 %). The CLI accepts `--morphology tool-flat` (alias for
+  `tool_flat`) and `--surface-transition-plies N`, with help noting the
+  pockets auto-enable and the amplitude bound.
 - Analysis — **`tool_flat` morphology with significant surface resin
   pockets** (issue #371, Part A). A new through-thickness decay mode /
   morphology (`morphology="tool_flat"`) models a wrinkle cured against
@@ -433,6 +449,20 @@ version produced a given file.
   access in `max_angle` / `fiber_angles_at_nodes`.
 
 ### Changed
+- App — **surface-pocket controls relocated into the morphology
+  definition** (issue #371, Part B). The standalone *Surface resin pockets*
+  expander in the Expert FE section is gone; its controls now live directly
+  under the Morphology selector. For `tool_flat` the pockets are implicit
+  (auto-enabled, shown as a caption) with the pinned-side and
+  transition-ply controls inline; the legacy tool-flat morphologies
+  (`stack`/`convex`/`concave`, `graded` with `decay_floor=0`) keep an
+  *advanced* opt-in whose help explains their pockets are inherently small
+  (~0.25 ply thickness — use `tool_flat` for significant pockets). The
+  `sb_surface_transition_plies` widget key joins `DEFAULTS` so *Reset to
+  defaults* round-trips it. Rationale: under the linear-decay morphologies
+  the pockets were mechanically negligible by construction (measured
+  ~0.25 ply-thickness trough gap), so a tooling-dominated wrinkle belongs
+  in the morphology definition, not as an add-on toggle.
 - Packaging — **PyVista/VTK moved to an optional `vtk` extra** (issue
   #302). Plain `pip install wrinklefe` no longer pulls in VTK (~150 MB
   lighter) and stays headless-safe; the 3D cohesive-zone plots

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ required: **<https://wrinklefe.streamlit.app/>**. Pick a material from the
 sidebar (or **Custom…** to enter your own elastic constants and strength
 allowables), enter a layup in contracted notation (e.g. `[0/45/-45/90]_3s`),
 set the wrinkle geometry, and click **Run analysis**. The app ships with
-per-morphology schematic cartoons, a live wrinkle preview, and the same
-analytical + FE pipeline as the Python API. See
+per-morphology schematic cartoons (including the `tool_flat`
+surface-resin-pocket morphology, whose pinned-side and transition-ply
+controls appear inline with the Morphology selector), a live wrinkle
+preview, and the same analytical + FE pipeline as the Python API. See
 [`DEPLOYMENT_STREAMLIT.md`](docs/internal/DEPLOYMENT_STREAMLIT.md) for the full feature
 tour and instructions for self-hosting.
 
@@ -497,6 +499,12 @@ wrinklefe analyze --resin-pocket --progressive --increments 15
 
 # Surface resin pockets under a tool-flat surface (FE)
 wrinklefe analyze --surface-resin-pockets --surface-pocket-side both
+
+# tool_flat morphology — significant pockets (auto-enabled). The
+# hyphenated --morphology tool-flat is an alias for tool_flat; amplitude
+# is bounded by 0.8 * surface-transition-plies * ply_thickness / nz_per_ply.
+wrinklefe analyze --morphology tool-flat --amplitude 0.35 \
+    --surface-pocket-side both --surface-transition-plies 3
 ```
 
 | Flag | Config field | Notes |
@@ -504,7 +512,8 @@ wrinklefe analyze --surface-resin-pockets --surface-pocket-side both
 | `--wrinkle-z-position Z` | `wrinkle_z_position` | Fraction of thickness in `[0, 1]` (0.5 = midplane); graded morphology |
 | `--gate {li2024-moulded,li2025-vacbag}` | `penetration_gate` | Calibrated `GateParameters` preset; UD-scoped |
 | `--resin-pocket` | `enable_resin_pocket` | Crest resin lens (FE-only) |
-| `--surface-resin-pockets` / `--surface-pocket-side {top,bottom,both}` | `enable_surface_resin_pockets` / `surface_pocket_side` | Tool-flat surface pockets (FE-only) |
+| `--surface-resin-pockets` / `--surface-pocket-side {top,bottom,both}` | `enable_surface_resin_pockets` / `surface_pocket_side` | Tool-flat surface pockets (FE-only). Auto-enabled for `--morphology tool-flat` |
+| `--surface-transition-plies N` | `surface_transition_plies` | `tool_flat` only: amplitude-ramp width (≥ 1, default 2); bounds the amplitude |
 | `--progressive` / `--increments N` | `enable_progressive_damage` / `progressive_n_increments` | Load-stepping ultimate strength (FE-only) |
 
 The long tail of finer knobs (custom `GateParameters`, resin-pocket
@@ -683,7 +692,7 @@ amplitude varies through the thickness**. The first three names below
 are *dual-wrinkle* modes distinguished by the phase offset φ between
 two adjacent wrinkle centrelines (the through-thickness amplitude
 follows a linear taper from the wrinkle interface plies down to zero
-at the laminate outer surfaces). The last two are *single-wrinkle*
+at the laminate outer surfaces). The last three are *single-wrinkle*
 modes that swap that taper for a different through-thickness profile.
 
 | Morphology   | # wrinkles | Phase φ | Through-thickness amplitude            | M_f (compression) | When to use                                                                                                                                          |
@@ -693,6 +702,7 @@ modes that swap that taper for a different through-thickness profile.
 | `concave`    | 2          | −π/2    | Linear decay, 1 at interface → 0 at surfaces | > 1               | Two phase-shifted wrinkles whose interface pinches inward. *Most* damaging dual-wrinkle case in compression — design-driving.                       |
 | `uniform`    | 1          | n/a     | Full amplitude on **every** ply (no decay)   | 1.0 (no pairing)  | A single through-thickness-wide wrinkle — every ply wavy with the same A. Conservative bound and sanity-check baseline.                              |
 | `graded`     | 1          | n/a     | Linear decay from mid-ply to surfaces, with floor `decay_floor` ∈ [0, 1] | 1.0 (no pairing) | An embedded wrinkle that fades toward the surface plies. `decay_floor=0` is pure graded; `decay_floor=1` collapses to `uniform`.                    |
+| `tool_flat`  | 1          | n/a     | Full-amplitude core, linear ramp over `surface_transition_plies`, **flat** at the pinned surface | 1.0 (no pairing) | A wrinkle cured against rigid tooling / a caul sheet: the pinned-flat surface fills the wrinkle troughs with **significant** resin pockets (auto-enabled). Shares `uniform`'s analytical knockdown; amplitude is bounded (see below). |
 
 ### `stack` vs `uniform` — what's the difference?
 

--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ st.caption(
 
 LIB = MaterialLibrary()
 MATERIAL_NAMES = sorted(LIB.list_names())
-MORPHOLOGIES = ["stack", "convex", "concave", "uniform", "graded"]
+MORPHOLOGIES = ["stack", "convex", "concave", "uniform", "graded", "tool_flat"]
 
 CUSTOM_MATERIAL_LABEL = "Custom…"
 MATERIAL_OPTIONS = MATERIAL_NAMES + [CUSTOM_MATERIAL_LABEL]
@@ -174,6 +174,10 @@ DEFAULT_CZM_TAU_MAX = float(_default_mat_for_czm.tau_max)
 # expert-mode sidebar and the Reset button.
 DEFAULT_ENABLE_SURFACE_POCKETS = _CFG_DEFAULTS.enable_surface_resin_pockets
 DEFAULT_SURFACE_POCKET_SIDE = _CFG_DEFAULTS.surface_pocket_side
+# ``tool_flat`` morphology (issue #371): number of surface transition plies
+# over which the wrinkle amplitude ramps from the full-amplitude core to the
+# pinned flat surface. Mirrors ``AnalysisConfig`` so the UI cannot drift.
+DEFAULT_SURFACE_TRANSITION_PLIES = _CFG_DEFAULTS.surface_transition_plies
 
 # Single source of truth used by the "Reset to defaults" button: maps each
 # sidebar widget ``key=`` argument to the value it should hold after a reset.
@@ -207,9 +211,11 @@ DEFAULTS: dict[str, object] = {
     "sb_czm_GIIc": DEFAULT_CZM_GIIC,
     "sb_czm_sigma_max": DEFAULT_CZM_SIGMA_MAX,
     "sb_czm_tau_max": DEFAULT_CZM_TAU_MAX,
-    # Surface resin pockets (issue #361)
+    # Surface resin pockets — legacy advanced opt-in (issue #361) and the
+    # tool_flat morphology's own transition-ply control (issue #371).
     "sb_enable_surface_pockets": DEFAULT_ENABLE_SURFACE_POCKETS,
     "sb_surface_pocket_side": DEFAULT_SURFACE_POCKET_SIDE,
+    "sb_surface_transition_plies": DEFAULT_SURFACE_TRANSITION_PLIES,
 }
 
 
@@ -398,6 +404,31 @@ def _morphology_schematic(
             raw = 1.0 - abs(offset) / 0.55  # 1 at core, 0 at surfaces
             decay = decay_floor + (1.0 - decay_floor) * raw
             ax.plot(x_canvas, decay * z + offset, color=blue, lw=1.4)
+    elif morphology == "tool_flat":
+        # Uniform-amplitude core with the outer face(s) pinned exactly flat
+        # over a short transition, and amber resin wedges filling the wrinkle
+        # troughs just under the flat surface (issue #371). Seven plies:
+        # the top ply is flat (tool face), the next two ramp, the core plies
+        # carry the full wave, and the bottom face here is left undulating so
+        # the flat-vs-wavy contrast reads at a glance.
+        offsets = np.linspace(-0.55, 0.55, 7)
+        n = len(offsets)
+        # decay ramps 0 (top/flat) -> 1 across the top three plies, then
+        # stays 1 for the interior.
+        top_decays = [0.0, 0.5, 1.0]
+        for i, offset in enumerate(offsets):
+            k = n - 1 - i  # 0 at the top ply, increasing downward
+            decay = top_decays[k] if k < len(top_decays) else 1.0
+            ax.plot(x_canvas, decay * z + offset, color=blue, lw=1.4)
+        # Amber trough pockets just under the flat top ply: the gap between
+        # the flat cap (top offset) and the outermost full-amplitude core ply.
+        flat_line = np.full_like(x_canvas, offsets[-1])
+        core = z + offsets[-3]  # first full-amplitude ply below the transition
+        ax.fill_between(
+            x_canvas, core, flat_line, where=core < flat_line,
+            facecolor="#e8a33d", alpha=0.55, hatch="xxx",
+            edgecolor="#9c6a12", linewidth=0.0,
+        )
 
     ax.set_xlim(-1.0, 1.0)
     ax.set_ylim(-0.85, 0.85)
@@ -424,6 +455,10 @@ def _is_tool_flat_morphology(morphology: str, decay_floor: float) -> bool:
     validation so the preview never shows a zone an FE run would reject.
     """
     m = (morphology or "").lower().strip()
+    # ``tool_flat`` (issue #371) pins the outer face(s) exactly flat by
+    # construction — it is the canonical surface-pocket morphology.
+    if m == "tool_flat":
+        return True
     if m in ("stack", "convex", "concave"):
         return True
     return m == "graded" and abs(float(decay_floor)) < 1e-12
@@ -443,6 +478,7 @@ def _through_thickness_cross_section(
     amplitude_profile_axis: str,
     enable_surface_resin_pockets: bool = False,
     surface_pocket_side: str = "top",
+    surface_transition_plies: int = 2,
 ) -> Figure:
     """Deformed through-thickness (x–z) cross-section of the wrinkled stack.
 
@@ -502,6 +538,12 @@ def _through_thickness_cross_section(
         amplitude_profile_axis=cast(
             Literal["x", "y"], amplitude_profile_axis
         ),
+        # tool_flat (issue #371): the pinned face(s) and the transition-zone
+        # width define the pocket geometry; ignored by every other morphology.
+        tool_side=cast(
+            Literal["top", "bottom", "both"], surface_pocket_side
+        ),
+        surface_transition_plies=int(surface_transition_plies),
     )
 
     # x-window matches the mid-surface plot (±3·width captures the
@@ -540,18 +582,27 @@ def _through_thickness_cross_section(
             ax.plot(x, z_def[p] + t / 2, color="#d62728", linewidth=1.1)
             ax.plot(x, z_def[p] - t / 2, color="#d62728", linewidth=1.1)
 
-    # --- Surface resin pockets (issue #361, Part 4 follow-up) ----------
+    # --- Surface resin pockets (issue #361, #371) ----------------------
     # Shade the neat-resin zones filling the wrinkle troughs under a
-    # tool-flat surface.  For a tool-flat morphology the decay reaches
-    # exactly zero at the outer surface, so the outermost ply is flat and
-    # the first ply inward (``p_outer``) is the transition zone whose
-    # trough pulls away from the flat cap.  The amber wedge is the analytic
-    # kinematic gap between that ply's deformed outer edge and the flat
-    # nominal edge — identical to the gap
+    # tool-flat surface.  The amber wedge is the analytic kinematic gap
+    # between the flat tool line and the deformed outer edge of the
+    # outermost *undulating* ply — identical to the gap
     # ``compute_surface_resin_blend`` integrates on an FE mesh (bound by
-    # ``test_preview_gap_matches_fe_tagged_volume``), drawn here without a
-    # mesh deform.  Rendered in the bands' own (mm) data coordinates so it
-    # lines up with the exaggerated vertical scale.
+    # the fidelity tests), drawn here without a mesh deform.  Rendered in
+    # the bands' own (mm) data coordinates so it lines up with the
+    # exaggerated vertical scale.
+    #
+    # The morphology sets *which* ply is the outermost undulating one:
+    #   - smooth-decay modes (stack/convex/concave, graded floor 0): the
+    #     surface ply is flat and the first ply inward carries the (small)
+    #     residual displacement, so the gap is a sub-ply sliver.
+    #   - ``tool_flat`` (#371): the amplitude ramps over
+    #     ``surface_transition_plies`` plies to the flat surface, so the
+    #     outermost *full-amplitude* core ply is the one that pulls away —
+    #     its displacement (~the full amplitude) is the pocket depth.  The
+    #     summed vertical stretch the FE tags across the transition band
+    #     equals that single displacement, so measuring the gap at the core
+    #     ply matches the FE volume while giving a thick, visible pocket.
     gap_areas: dict[str, float] = {}
     if enable_surface_resin_pockets and _is_tool_flat_morphology(
         morphology, decay_floor
@@ -559,19 +610,34 @@ def _through_thickness_cross_section(
         dz_field = z_def - z0[:, None]
         max_disp = float(np.abs(dz_field).max())
         tol = 1.0e-6 * max_disp
+        per_ply_max = np.abs(dz_field).max(axis=1)
+        is_tool_flat = (morphology or "").lower().strip() == "tool_flat"
+        # Full-amplitude core plies (used by tool_flat to place the pocket at
+        # the transition/core boundary rather than the sub-amplitude surface).
+        core_mask = per_ply_max >= (1.0 - 1.0e-6) * max_disp
         sides = (
             ("top", "bottom")
             if surface_pocket_side == "both"
             else (surface_pocket_side,)
         )
         for side in sides:
-            p_seq = (
-                range(n_plies - 1, -1, -1) if side == "top" else range(n_plies)
-            )
-            p_outer: int | None = next(
-                (p for p in p_seq if float(np.abs(dz_field[p]).max()) > tol),
-                None,
-            )
+            if is_tool_flat:
+                # Outermost full-amplitude ply toward the pinned surface.
+                core_plies = np.flatnonzero(core_mask)
+                if core_plies.size == 0:
+                    continue
+                p_outer: int | None = int(
+                    core_plies.max() if side == "top" else core_plies.min()
+                )
+            else:
+                p_seq = (
+                    range(n_plies - 1, -1, -1)
+                    if side == "top" else range(n_plies)
+                )
+                p_outer = next(
+                    (p for p in p_seq if float(per_ply_max[p]) > tol),
+                    None,
+                )
             if p_outer is None:
                 continue
             if side == "top":
@@ -826,7 +892,13 @@ with st.sidebar:
                 "- *uniform*: full amplitude on *every* ply (no decay). M_f = 1.0 "
                 "but unlike *stack* the outer-surface plies are also displaced.\n"
                 "- *graded*: linear decay from wrinkle core to surfaces, controlled "
-                "by the **Decay floor** slider (0 = full decay, 1 = uniform).\n\n"
+                "by the **Decay floor** slider (0 = full decay, 1 = uniform).\n"
+                "- *tool_flat*: full-amplitude core with the outer face(s) pinned "
+                "exactly flat over a short transition, cured against rigid tooling "
+                "/ a caul sheet. Shares *uniform*'s M_f = 1.0 and analytical "
+                "knockdown, but the pinned-flat surface fills the wrinkle troughs "
+                "with *significant* surface resin pockets (auto-enabled). Its side "
+                "and transition-ply controls appear directly below.\n\n"
                 "Note: *stack* and *uniform* both report M_f = 1.0 but produce "
                 "different deformed meshes — *stack* is two wrinkles with the "
                 "envelope fading at the outer surfaces; *uniform* is one wrinkle "
@@ -867,6 +939,122 @@ with st.sidebar:
             ),
             width="stretch",
         )
+
+        # --- Surface resin pockets: part of the morphology definition ---
+        # (issue #371). For ``tool_flat`` the pockets ARE the morphology's
+        # physics — auto-enabled, with the pinned side and transition-ply
+        # controls rendered right here, plus a live inversion-bound hint so
+        # the config ValueError is never the user's first feedback. For the
+        # legacy tool-flat morphologies the pockets are inherently tiny, so
+        # they stay behind an advanced opt-in in the same visual group.
+        if morphology == "tool_flat":
+            surface_pocket_side = st.selectbox(
+                "Pinned tool-flat surface(s)",
+                ["top", "bottom", "both"],
+                index=["top", "bottom", "both"].index(
+                    DEFAULT_SURFACE_POCKET_SIDE
+                ),
+                key="sb_surface_pocket_side",
+                help=(
+                    "Which outer surface(s) the tooling / caul sheet pins "
+                    "exactly flat: *top* (+z), *bottom* (-z), or *both*. The "
+                    "wrinkle troughs just under each pinned face fill with "
+                    "neat resin."
+                ),
+            )
+            surface_transition_plies = int(
+                st.number_input(
+                    "Surface transition plies",
+                    min_value=1, max_value=12,
+                    value=int(DEFAULT_SURFACE_TRANSITION_PLIES), step=1,
+                    key="sb_surface_transition_plies",
+                    help=(
+                        "Number of plies over which the amplitude ramps from "
+                        "the full-amplitude core to the flat pinned surface. "
+                        "Fewer plies concentrate the mismatch into deeper "
+                        "pockets but tighten the amplitude bound (the "
+                        "crest-side transition elements must not invert)."
+                    ),
+                )
+            )
+            enable_surface_pockets = True  # implicit for tool_flat
+            _nz_hint = int(
+                st.session_state.get("sb_nz_per_ply", DEFAULT_NZ_PER_PLY)
+            )
+            _a_safe = (
+                0.8 * surface_transition_plies * ply_thickness
+                / max(_nz_hint, 1)
+            )
+            st.caption(
+                "Surface resin pockets are **auto-enabled** for tool_flat — "
+                "they are its defining physics. Max safe amplitude for the "
+                f"current settings ≈ **{_a_safe:.3g} mm** "
+                f"(0.8 · {surface_transition_plies} plies · "
+                f"{ply_thickness:g} mm / {max(_nz_hint, 1)} nz)."
+            )
+            if amplitude > _a_safe:
+                _need_plies = int(
+                    np.ceil(
+                        amplitude * max(_nz_hint, 1)
+                        / (0.8 * ply_thickness)
+                    )
+                )
+                st.warning(
+                    f"Amplitude {amplitude:g} mm exceeds the tool_flat "
+                    f"inversion bound ≈ {_a_safe:.3g} mm — the crest-side "
+                    "transition elements would invert. Increase **Surface "
+                    f"transition plies** to ≥ {_need_plies} or reduce the "
+                    f"amplitude below {_a_safe:.3g} mm before running."
+                )
+        else:
+            with st.expander(
+                "Surface resin pockets (advanced)", expanded=False
+            ):
+                enable_surface_pockets = st.checkbox(
+                    "Model surface resin pockets",
+                    value=DEFAULT_ENABLE_SURFACE_POCKETS,
+                    key="sb_enable_surface_pockets",
+                    help=(
+                        "Legacy opt-in for the smooth-decay tool-flat "
+                        "morphologies (stack/convex/concave, or graded with "
+                        "decay floor 0). Their linear through-thickness decay "
+                        "spreads the wave across every ply, so the trough gap "
+                        "is only ~0.25 ply thickness — the pockets are "
+                        "inherently small and barely move the result. For "
+                        "*significant* pockets choose the **tool_flat** "
+                        "morphology above, where they are the defining "
+                        "physics. Requires the full FE solve."
+                    ),
+                )
+                surface_pocket_side = st.selectbox(
+                    "Tool-flat surface(s)",
+                    ["top", "bottom", "both"],
+                    index=["top", "bottom", "both"].index(
+                        DEFAULT_SURFACE_POCKET_SIDE
+                    ),
+                    key="sb_surface_pocket_side",
+                    help=(
+                        "Which flat face(s) to tag: *top* (+z), *bottom* "
+                        "(-z), or *both*."
+                    ),
+                )
+                if enable_surface_pockets and not _is_tool_flat_morphology(
+                    morphology, decay_floor
+                ):
+                    st.warning(
+                        "Surface resin pockets need a tool-flat morphology — "
+                        "stack/convex/concave, graded with decay floor 0, or "
+                        "tool_flat. The current morphology (**"
+                        f"{morphology}**"
+                        + (
+                            f", decay floor {decay_floor:g}"
+                            if morphology == "graded" else ""
+                        )
+                        + ") leaves wavy outer surfaces, so pockets are "
+                        "disabled for this run and not drawn in the "
+                        "cross-section."
+                    )
+            surface_transition_plies = int(DEFAULT_SURFACE_TRANSITION_PLIES)
 
         st.markdown("**Amplitude profile**")
         amplitude_profile = st.selectbox(
@@ -933,6 +1121,11 @@ with st.sidebar:
         amplitude_profile = DEFAULT_AMPLITUDE_PROFILE
         amplitude_profile_decay_length = None
         amplitude_profile_axis = DEFAULT_AMPLITUDE_PROFILE_AXIS
+        # Surface resin pockets depend on the expert-only FE solve, so the
+        # novice path leaves them off with the contract defaults.
+        enable_surface_pockets = DEFAULT_ENABLE_SURFACE_POCKETS
+        surface_pocket_side = DEFAULT_SURFACE_POCKET_SIDE
+        surface_transition_plies = int(DEFAULT_SURFACE_TRANSITION_PLIES)
 
     _loading_options = ["compression", "tension"]
     _loading_default_idx = (
@@ -1197,74 +1390,28 @@ with st.sidebar:
         czm_newton_tol = DEFAULT_CZM_NEWTON_TOL
 
     # ------------------------------------------------------------------
-    # Surface resin pockets (tool-flat outer surface; issue #361). Expert
-    # only, like CZM: it is an FE-only material effect (the neat-resin
-    # zones filling the wrinkle troughs under a flat tool surface) and the
-    # FE solve it needs is itself expert-gated. When enabled for a
-    # tool-flat morphology, the Analyze-tab cross-section shades the zones
-    # and the FE run tags them; incompatible morphologies (uniform, or
-    # graded with a non-zero decay floor) leave wavy surfaces, so the flag
-    # is withheld from the run and a note explains why — the preview and
-    # the run never diverge.
+    # Surface resin pockets now live in the morphology definition (issue
+    # #371): the tool_flat side/transition controls and the legacy advanced
+    # opt-in are rendered above, directly under the Morphology selector.
+    # Here we only resolve how they thread into the run.
+    #
+    #   - ``tool_flat``: pockets are the morphology's physics — the config
+    #     auto-enables them on the FE path.  We respect *Analytical only*
+    #     (tool_flat analytical == uniform), so it does NOT force the FE
+    #     path; the side + transition-plies just travel into the config.
+    #   - legacy morphologies: the advanced checkbox is an explicit FE-only
+    #     opt-in, wired in only when the morphology is genuinely tool-flat
+    #     (so an incompatible morphology can never build an invalid config).
     # ------------------------------------------------------------------
-    if expert_mode:
-        with st.expander("Surface resin pockets (tool-flat surface)", expanded=False):
-            enable_surface_pockets = st.checkbox(
-                "Model surface resin pockets",
-                value=DEFAULT_ENABLE_SURFACE_POCKETS,
-                key="sb_enable_surface_pockets",
-                help=(
-                    "Parts cured against rigid tooling / a caul sheet keep "
-                    "perfectly flat outer surfaces while the fibres undulate "
-                    "internally; the wrinkle troughs fill with neat resin "
-                    "just under the flat surface. When enabled, the "
-                    "through-thickness cross-section shades these zones and "
-                    "the FE solve blends in the soft isotropic resin card "
-                    "(fibre-free, misalignment suppressed). Requires a "
-                    "tool-flat morphology (stack/convex/concave, or graded "
-                    "with decay floor 0) and the full FE solve (untick "
-                    "*Analytical only*; it is forced off when this is on)."
-                ),
-            )
-            surface_pocket_side = st.selectbox(
-                "Tool-flat surface(s)",
-                ["top", "bottom", "both"],
-                index=["top", "bottom", "both"].index(
-                    DEFAULT_SURFACE_POCKET_SIDE
-                ),
-                key="sb_surface_pocket_side",
-                help=(
-                    "Which flat face(s) to tag: *top* (+z), *bottom* (-z), "
-                    "or *both*. A part flat on one face only (e.g. a caul on "
-                    "top, bag on the bottom) uses a single side."
-                ),
-            )
-            if enable_surface_pockets and not _is_tool_flat_morphology(
-                morphology, decay_floor
-            ):
-                st.warning(
-                    "Surface resin pockets need a tool-flat morphology — "
-                    "stack/convex/concave, or graded with decay floor 0. The "
-                    f"current morphology (**{morphology}**"
-                    + (
-                        f", decay floor {decay_floor:g}"
-                        if morphology == "graded" else ""
-                    )
-                    + ") leaves wavy outer surfaces, so pockets are disabled "
-                    "for this run and not drawn in the cross-section."
-                )
-    else:
-        # Novice path: surface pockets depend on the expert-only FE solve.
-        enable_surface_pockets = False
-        surface_pocket_side = DEFAULT_SURFACE_POCKET_SIDE
-
-    # Surface pockets are only wired into the run when both requested and
-    # compatible, so an incompatible morphology can never build an invalid
-    # AnalysisConfig (which would raise in ``_validate``).
-    _surface_pockets_active = bool(
+    _is_tool_flat_selected = morphology == "tool_flat"
+    _legacy_pockets_active = bool(
         enable_surface_pockets
+        and not _is_tool_flat_selected
         and _is_tool_flat_morphology(morphology, decay_floor)
     )
+    # Only the explicit legacy opt-in forces the FE path (tool_flat honours
+    # the Analytical-only checkbox).
+    _surface_pockets_active = _legacy_pockets_active
 
     run_disabled = bool(mesh_diag is not None and mesh_diag.will_invert)
     run_clicked = st.button(
@@ -1343,11 +1490,22 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             czm_newton_tol=float(cfg_dict.get("czm_newton_tol", 1.0e-4)),
         )
 
-    # Surface resin pockets (issue #361) — only threaded in when the run
-    # handler flagged them active (requested + tool-flat morphology), so an
-    # incompatible morphology never reaches AnalysisConfig validation.
+    # Surface resin pockets (issues #361 / #371). For the tool_flat
+    # morphology the config auto-enables the pockets on the FE path, so we
+    # only thread through its pinned side + transition-ply width. For the
+    # legacy morphologies the run handler flags the explicit opt-in
+    # (requested + tool-flat morphology) so an incompatible morphology never
+    # reaches AnalysisConfig validation.
     surface_pocket_kwargs: dict = {}
-    if cfg_dict.get("enable_surface_resin_pockets", False):
+    _morph_name = cfg_dict.get("morphology", "stack")
+    if _morph_name == "tool_flat":
+        surface_pocket_kwargs["surface_pocket_side"] = cfg_dict.get(
+            "surface_pocket_side", "top"
+        )
+        surface_pocket_kwargs["surface_transition_plies"] = int(
+            cfg_dict.get("surface_transition_plies", 2)
+        )
+    elif cfg_dict.get("enable_surface_resin_pockets", False):
         surface_pocket_kwargs = dict(
             enable_surface_resin_pockets=True,
             surface_pocket_side=cfg_dict.get("surface_pocket_side", "top"),
@@ -1758,10 +1916,16 @@ if run_clicked or _demo_pending:
             cfg_items["czm_tau_max"] = float(czm_tau_max)
             cfg_items["czm_n_load_increments"] = int(czm_load_increments)
             cfg_items["czm_newton_tol"] = float(czm_newton_tol)
-        # Surface resin pockets — only added when requested AND the
-        # morphology is tool-flat, so the config never sees the flag with an
-        # incompatible morphology (bit-identical cache key when off).
-        if _surface_pockets_active:
+        # Surface resin pockets (issues #361 / #371).
+        #   - tool_flat: thread the pinned side + transition-ply width; the
+        #     config auto-enables the pockets on the FE path.
+        #   - legacy opt-in: only added when requested AND the morphology is
+        #     tool-flat, so the config never sees the flag with an
+        #     incompatible morphology (bit-identical cache key when off).
+        if _is_tool_flat_selected:
+            cfg_items["surface_pocket_side"] = surface_pocket_side
+            cfg_items["surface_transition_plies"] = int(surface_transition_plies)
+        elif _surface_pockets_active:
             cfg_items["enable_surface_resin_pockets"] = True
             cfg_items["surface_pocket_side"] = surface_pocket_side
         cfg_payload = tuple(sorted(cfg_items.items()))
@@ -1889,6 +2053,7 @@ with tab_analyze:
                     amplitude_profile_axis=amplitude_profile_axis,
                     enable_surface_resin_pockets=enable_surface_pockets,
                     surface_pocket_side=surface_pocket_side,
+                    surface_transition_plies=surface_transition_plies,
                 )
                 _gap_areas = getattr(fig_tt, "surface_pocket_gap_area", {})
                 st.pyplot(fig_tt, clear_figure=True)

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -37,6 +37,19 @@ from wrinklefe.core.morphology import MORPHOLOGY_PHASES, SINGLE_WRINKLE_MODES
 MORPHOLOGY_CHOICES = sorted(set(MORPHOLOGY_PHASES.keys()) | SINGLE_WRINKLE_MODES)
 
 
+def _normalize_morphology(value: str) -> str:
+    """Normalise a ``--morphology`` argument to its canonical engine name.
+
+    The engine spells the tool-flat morphology ``tool_flat`` (underscore),
+    but a hyphenated ``tool-flat`` is the natural CLI spelling (issue #371),
+    so accept both.  Applied as the argparse ``type=`` callable, which runs
+    *before* the ``choices`` membership check, so the canonical
+    :data:`MORPHOLOGY_CHOICES` list stays authoritative and an unknown name
+    still exits with code 2.
+    """
+    return value.replace("-", "_")
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser with subcommands."""
     parser = argparse.ArgumentParser(
@@ -89,11 +102,15 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_analyze.add_argument(
-        "--morphology", type=str, default="stack",
+        "--morphology", type=_normalize_morphology, default="stack",
         choices=MORPHOLOGY_CHOICES,
         help=(
             "Wrinkle morphology type (default: stack). "
-            f"One of: {', '.join(MORPHOLOGY_CHOICES)}."
+            f"One of: {', '.join(MORPHOLOGY_CHOICES)} "
+            "(``tool-flat`` is accepted as an alias for ``tool_flat``). "
+            "For ``tool_flat`` the surface resin pockets auto-enable on the "
+            "FE path and the amplitude is bounded by "
+            "0.8 * surface_transition_plies * ply_thickness / nz_per_ply."
         ),
     )
     p_analyze.add_argument(
@@ -357,7 +374,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "between the flat surface and the outermost undulating ply and "
             "blends in the resin card. Requires a tool-flat morphology "
             "(stack/convex/concave, or graded with decay_floor=0). Forces "
-            "the FE path."
+            "the FE path. NOTE: for --morphology tool-flat the pockets "
+            "AUTO-ENABLE (they are its defining physics) — this flag is only "
+            "needed for the legacy morphologies, where the pockets are "
+            "inherently small (~0.25 ply thickness)."
         ),
     )
     p_analyze.add_argument(
@@ -365,8 +385,21 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="surface_pocket_side", choices=["top", "bottom", "both"],
         help=(
             "Which tool-flat surface(s) receive surface resin pockets: "
-            "'top' (+z, default), 'bottom' (-z), or 'both'. Only consulted "
-            "when --surface-resin-pockets is set."
+            "'top' (+z, default), 'bottom' (-z), or 'both'. Consulted when "
+            "--surface-resin-pockets is set or --morphology tool-flat is "
+            "selected (it doubles as the pinned tool_side)."
+        ),
+    )
+    p_analyze.add_argument(
+        "--surface-transition-plies", type=int, default=2,
+        dest="surface_transition_plies",
+        help=(
+            "tool_flat morphology only: number of plies over which the "
+            "wrinkle amplitude ramps from the full-amplitude core to the "
+            "flat pinned surface (default: 2, must be >= 1). Fewer plies "
+            "deepen the pockets but tighten the amplitude bound "
+            "0.8 * surface_transition_plies * ply_thickness / nz_per_ply "
+            "(the crest-side transition elements must not invert)."
         ),
     )
     p_analyze.add_argument(
@@ -834,6 +867,8 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         overrides["enable_surface_resin_pockets"] = True
     if given("surface_pocket_side"):
         overrides["surface_pocket_side"] = args.surface_pocket_side
+    if given("surface_transition_plies"):
+        overrides["surface_transition_plies"] = args.surface_transition_plies
     if given("progressive"):
         overrides["enable_progressive_damage"] = True
     if given("increments"):

--- a/tests/test_app_cross_section.py
+++ b/tests/test_app_cross_section.py
@@ -58,7 +58,8 @@ def _call(app_module, morphology, **overrides):
 
 
 @pytest.mark.parametrize(
-    "morphology", ["stack", "convex", "concave", "uniform", "graded"]
+    "morphology",
+    ["stack", "convex", "concave", "uniform", "graded", "tool_flat"],
 )
 def test_returns_figure_with_one_band_per_ply(app_module, morphology):
     """Every morphology renders a Figure with exactly one filled band per ply."""
@@ -106,7 +107,7 @@ def test_dual_morphologies_outline_interface_plies(app_module):
         assert _n_red_lines(fig) == 4, f"{morph}: expected 4 outline lines"
         plt.close(fig)
 
-    for morph in ("uniform", "graded"):
+    for morph in ("uniform", "graded", "tool_flat"):
         fig = _call(app_module, morph)
         assert _n_red_lines(fig) == 0, f"{morph}: should not outline an interface"
         plt.close(fig)
@@ -212,6 +213,7 @@ def test_is_tool_flat_morphology_predicate(app_module):
     f = app_module._is_tool_flat_morphology
     assert f("stack", 0.3) and f("convex", 0.0) and f("concave", 1.0)
     assert f("graded", 0.0)              # graded with zero floor IS tool-flat
+    assert f("tool_flat", 0.0)           # tool_flat pins the surface flat
     assert not f("graded", 0.2)          # a residual floor leaves waviness
     assert not f("uniform", 0.0)         # never decays
 
@@ -384,5 +386,138 @@ def test_preview_gap_matches_fe_tagged_volume(app_module, morphology):
     # The two independent computations of the same kinematic gap agree.
     assert preview_area == pytest.approx(fe_area_per_width, rel=0.10), (
         f"{morphology}: preview gap {preview_area:.5f} vs FE/width "
+        f"{fe_area_per_width:.5f} (ratio {preview_area / fe_area_per_width:.4f})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# tool_flat morphology (issue #371): thick, visible pockets
+# ---------------------------------------------------------------------------
+
+
+def test_tool_flat_renders_thick_flat_pockets(app_module):
+    """tool_flat renders SIGNIFICANT pockets (>= ~1 ply thickness at a safe
+    amplitude) with the pinned surface exactly flat and the core at full
+    amplitude — the preview uses the real tool_flat decay, not the sliver
+    the smooth-decay morphologies leave."""
+    import matplotlib.pyplot as plt
+
+    from wrinklefe.core.morphology import WrinkleConfiguration
+    from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+    # 0.43 < 0.8*3*0.183 = 0.439 bound; a wide envelope keeps the troughs
+    # near full amplitude so the deepest pocket clears one ply thickness.
+    amp, wl, w, t = 0.43, 16.0, 20.0, 0.183
+    angles = list(_ANGLES_12)
+    fig = _call(
+        app_module, "tool_flat",
+        amplitude=amp, wavelength=wl, width=w, ply_thickness=t,
+        decay_floor=0.0, enable_surface_resin_pockets=True,
+        surface_pocket_side="top", surface_transition_plies=3,
+    )
+    try:
+        # (a) pockets present and drawn.
+        area = fig.surface_pocket_gap_area.get("top", 0.0)
+        assert area > 0.0, "tool_flat drew no surface resin pocket"
+        poly = _resin_polys(fig, "top")
+        assert poly is not None
+        # (b) thick: the deepest trough gap is at least one ply thickness
+        #     (vs the ~0.25-ply sliver the linear-decay morphologies leave).
+        zs = np.concatenate([p.vertices[:, 1] for p in poly.get_paths()])
+        max_depth = float(zs.max() - zs.min())
+        assert max_depth >= t, (
+            f"tool_flat pocket depth {max_depth:.3f} mm < 1 ply {t} mm"
+        )
+    finally:
+        plt.close(fig)
+
+    # (c) the pinned top ply is exactly flat while the core carries the full
+    #     amplitude — confirms the preview reuses the tool_flat decay field.
+    n = len(angles)
+    mid = n // 2
+    i1, i2 = max(0, mid - 1), min(n - 1, mid)
+    prof = GaussianSinusoidal(amplitude=amp, wavelength=wl, width=w, center=0.0)
+    wc = WrinkleConfiguration.from_morphology_name(
+        "tool_flat", prof, interface1=i1, interface2=i2, decay_floor=0.0,
+        tool_side="top", surface_transition_plies=3,
+    )
+    n_x = 401
+    x = np.linspace(-24.0, 24.0, n_x)
+    total = n * t
+    z0 = (np.arange(n) + 0.5) * t - total / 2.0
+    nodes = np.column_stack(
+        [np.tile(x, n), np.zeros(n * n_x), np.repeat(z0, n_x)]
+    )
+    ply_ids = np.repeat(np.arange(n), n_x)
+    dz = (
+        wc.apply_to_nodes(nodes, ply_ids, n)[:, 2].reshape(n, n_x)
+        - z0[:, None]
+    )
+    per_ply = np.abs(dz).max(axis=1)
+    assert per_ply[n - 1] < 1e-9, "pinned top ply is not flat"
+    assert per_ply[: n - 3].max() == pytest.approx(amp, rel=5e-3), (
+        "core plies do not carry the full amplitude"
+    )
+
+
+def test_preview_gap_matches_fe_tagged_volume_tool_flat(app_module):
+    """FIDELITY CROSS-CHECK for tool_flat — the analytic preview gap area
+    equals the multi-layer neat-resin volume ``compute_surface_resin_blend``
+    tags on a real mesh (per unit width, ~10% coarse-mesh tolerance)."""
+    import matplotlib.pyplot as plt
+
+    from wrinklefe.core.laminate import Laminate
+    from wrinklefe.core.material import MaterialLibrary
+    from wrinklefe.core.mesh import WrinkleMesh
+    from wrinklefe.core.morphology import WrinkleConfiguration
+    from wrinklefe.core.resin_pocket import (
+        SurfacePocketSpec,
+        compute_surface_resin_blend,
+    )
+    from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+    amplitude, wavelength, width, ply_t = 0.4, 16.0, 8.0, 0.183
+    s_trans = 3  # 0.4 < 0.8 * 3 * 0.183 = 0.439 bound
+    angles = list(_ANGLES_12)
+    n = len(angles)
+
+    # 1) Preview analytic gap area (mm² per unit width).
+    fig = _call(
+        app_module, "tool_flat",
+        amplitude=amplitude, wavelength=wavelength, width=width,
+        ply_thickness=ply_t, decay_floor=0.0,
+        enable_surface_resin_pockets=True, surface_pocket_side="top",
+        surface_transition_plies=s_trans,
+    )
+    preview_area = fig.surface_pocket_gap_area["top"]
+    plt.close(fig)
+    assert preview_area > 0.0
+
+    # 2) FE volume from the SAME tool_flat field.
+    mid = n // 2
+    i1, i2 = max(0, mid - 1), min(n - 1, mid)
+    Lx, Ly = 6.0 * width, 4.0
+    prof = GaussianSinusoidal(
+        amplitude=amplitude, wavelength=wavelength, width=width, center=Lx / 2.0
+    )
+    wc = WrinkleConfiguration.from_morphology_name(
+        "tool_flat", prof, interface1=i1, interface2=i2, decay_floor=0.0,
+        tool_side="top", surface_transition_plies=s_trans,
+    )
+    lam = Laminate.from_angles(angles, MaterialLibrary().get("IM7_8552"), ply_t)
+    mesh = WrinkleMesh(lam, wc, Lx=Lx, Ly=Ly, nx=240, ny=1, nz_per_ply=1).generate()
+    weight = compute_surface_resin_blend(mesh, wc, SurfacePocketSpec(side="top"))
+
+    ez = mesh.nodes[mesh.elements][:, :, 2]
+    ex = mesh.nodes[mesh.elements][:, :, 0]
+    ey = mesh.nodes[mesh.elements][:, :, 1]
+    height = ez.max(axis=1) - ez.min(axis=1)
+    footprint = (ex.max(axis=1) - ex.min(axis=1)) * (ey.max(axis=1) - ey.min(axis=1))
+    tagged = weight > 0
+    assert tagged.any(), "FE mesh tagged no surface resin — bad fixture"
+    fe_area_per_width = float((weight * height * footprint)[tagged].sum()) / Ly
+
+    assert preview_area == pytest.approx(fe_area_per_width, rel=0.10), (
+        f"tool_flat: preview gap {preview_area:.5f} vs FE/width "
         f"{fe_area_per_width:.5f} (ratio {preview_area / fe_area_per_width:.4f})"
     )

--- a/tests/test_app_surface_pockets.py
+++ b/tests/test_app_surface_pockets.py
@@ -57,12 +57,30 @@ def _app_path() -> str:
 
 
 def test_defaults_include_surface_pocket_entries(app_module):
-    """``DEFAULTS`` must hold both widget keys so Reset works."""
+    """``DEFAULTS`` must hold every surface-pocket widget key so Reset works."""
     d = app_module.DEFAULTS
     assert "sb_enable_surface_pockets" in d
     assert d["sb_enable_surface_pockets"] is False
     assert "sb_surface_pocket_side" in d
     assert d["sb_surface_pocket_side"] in ("top", "bottom", "both")
+    # tool_flat morphology's transition-ply control (issue #371).
+    assert "sb_surface_transition_plies" in d
+    assert d["sb_surface_transition_plies"] >= 1
+
+
+def test_transition_plies_default_matches_analysis_config(app_module):
+    """The tool_flat transition-ply default must mirror ``AnalysisConfig``."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig()
+    assert (
+        app_module.DEFAULT_SURFACE_TRANSITION_PLIES
+        == cfg.surface_transition_plies
+    )
+    assert (
+        app_module.DEFAULTS["sb_surface_transition_plies"]
+        == cfg.surface_transition_plies
+    )
 
 
 def test_surface_pocket_defaults_match_analysis_config(app_module):
@@ -159,3 +177,84 @@ def test_enabling_on_incompatible_morphology_warns_not_raises(
     assert any("tool-flat morphology" in w for w in warnings), (
         f"missing tool-flat note for {morphology}; saw {warnings}"
     )
+
+
+# ----------------------------------------------------------------------
+# 3. tool_flat morphology — controls live in the morphology definition
+#    (issue #371). The side + transition controls appear directly with
+#    the morphology; the standalone legacy checkbox is folded away.
+# ----------------------------------------------------------------------
+
+
+def test_tool_flat_is_selectable_in_expert_mode():
+    """``tool_flat`` joins the Morphology selectbox in Expert mode."""
+    assert "tool_flat" in __import__("app").MORPHOLOGIES
+
+
+def test_selecting_tool_flat_reveals_controls_and_hides_checkbox():
+    """Selecting tool_flat surfaces the pinned-side + transition-ply
+    controls and hides the standalone surface-pocket checkbox."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.session_state["sb_morphology"] = "tool_flat"
+    # A safe amplitude keeps the config valid on the FE path.
+    at.session_state["sb_amplitude"] = 0.2
+    at.session_state["sb_surface_transition_plies"] = 3
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    number_keys = {n.key for n in at.number_input if n.key is not None}
+    assert "sb_surface_transition_plies" in number_keys, (
+        f"transition-ply control missing for tool_flat; saw {number_keys}"
+    )
+    sel_keys = {s.key for s in at.selectbox if s.key is not None}
+    assert "sb_surface_pocket_side" in sel_keys
+    # The standalone legacy checkbox is folded away for tool_flat.
+    cb_keys = {c.key for c in at.checkbox if c.key is not None}
+    assert "sb_enable_surface_pockets" not in cb_keys, (
+        f"standalone surface-pocket checkbox leaked for tool_flat: {cb_keys}"
+    )
+
+
+def test_legacy_opt_in_still_reachable_for_stack():
+    """A legacy morphology keeps the advanced opt-in checkbox (and hides
+    the tool_flat-only transition control)."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.session_state["sb_morphology"] = "stack"
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    cb_keys = {c.key for c in at.checkbox if c.key is not None}
+    assert "sb_enable_surface_pockets" in cb_keys, (
+        f"legacy opt-in checkbox missing for stack; saw {cb_keys}"
+    )
+    number_keys = {n.key for n in at.number_input if n.key is not None}
+    assert "sb_surface_transition_plies" not in number_keys
+
+
+def test_tool_flat_over_bound_amplitude_warns_before_run():
+    """An amplitude above the inversion bound surfaces a pre-run warning
+    (naming both remedies) so the config ValueError is never first feedback."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["expert_mode"] = True
+    at.session_state["sb_morphology"] = "tool_flat"
+    # Default amplitude 0.366 mm exceeds 0.8*2*0.183/1 = 0.293 mm at S = 2.
+    at.session_state["sb_amplitude"] = 0.366
+    at.session_state["sb_surface_transition_plies"] = 2
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    warnings = [w.value for w in at.warning]
+    assert any("inversion bound" in w for w in warnings), (
+        f"missing pre-run inversion-bound warning; saw {warnings}"
+    )
+    # Both remedies are named (more transition plies OR smaller amplitude).
+    joined = " ".join(warnings)
+    assert "transition plies" in joined and "amplitude" in joined

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,6 +421,75 @@ def test_analyze_accepts_uniform_and_graded(morph):
     assert cfg.morphology == morph
 
 
+# --------------------------------------------------------------------------- #
+# issue #371: tool_flat morphology + surface-transition-plies
+# --------------------------------------------------------------------------- #
+
+
+def test_tool_flat_is_a_cli_morphology_choice():
+    """``tool_flat`` reaches the CLI choices via the canonical core set."""
+    from wrinklefe.cli import MORPHOLOGY_CHOICES
+
+    assert "tool_flat" in MORPHOLOGY_CHOICES
+
+
+@pytest.mark.parametrize("spelling", ["tool_flat", "tool-flat"])
+def test_analyze_accepts_tool_flat_and_hyphen_alias(spelling):
+    """Both ``tool_flat`` and the hyphenated ``tool-flat`` alias map to the
+    canonical ``tool_flat`` morphology in the AnalysisConfig."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--morphology", spelling,
+            "--amplitude", "0.2", "--analytical-only",
+        ])
+
+    cfg = captured["config"]
+    assert cfg.morphology == "tool_flat"
+
+
+def test_analyze_surface_transition_plies_maps_into_config():
+    """--surface-transition-plies threads into AnalysisConfig for tool_flat."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--morphology", "tool-flat",
+            "--amplitude", "0.3", "--surface-transition-plies", "4",
+            "--analytical-only",
+        ])
+
+    cfg = captured["config"]
+    assert cfg.morphology == "tool_flat"
+    assert cfg.surface_transition_plies == 4
+
+
+def test_analyze_tool_flat_amplitude_bound_rejected():
+    """An amplitude above the tool_flat inversion bound exits with code 2
+    (the actionable ValueError from AnalysisConfig validation)."""
+    # 0.8 * 2 * 0.183 / 1 = 0.293 mm bound at the default transition plies.
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main([
+            "analyze", "--morphology", "tool-flat",
+            "--amplitude", "0.5", "--surface-transition-plies", "2",
+        ])
+    assert exc_info.value.code == 2
+
+
+def test_analyze_tool_flat_default_fe_auto_enables_pockets():
+    """A default tool_flat FE run auto-enables surface resin pockets (they
+    are the morphology's defining physics)."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--morphology", "tool-flat", "--amplitude", "0.2",
+        ])
+
+    cfg = captured["config"]
+    assert cfg.morphology == "tool_flat"
+    assert captured["analytical_only"] is False
+    assert cfg.enable_surface_resin_pockets is True
+
+
 def test_analyze_contracted_layup_expands_to_24_plies():
     """'[0/45/-45/90]_3s' must reach AnalysisConfig as the same 24-ply
     list the Streamlit app produces."""


### PR DESCRIPTION
## Linked issue

Fixes #371 — this Part B completes the issue (Part A, the `tool_flat` physics, merged in #372).

## Summary

Surface resin pockets now live in the **morphology definition** instead of a standalone expert-section toggle. This is the user's UX requirement: a tooling-dominated wrinkle is a distinct through-thickness morphology, not an add-on toggle to the smooth-decay morphologies.

**App — morphology integration**
- `tool_flat` joins the Morphology selectbox (Expert mode), with a schematic cartoon: flat pinned face, uniform-amplitude core, amber resin wedges at the troughs.
- Selecting `tool_flat` renders its **pinned-side** and **surface-transition-plies** controls *directly under* the morphology controls, plus a live inversion-bound caption (max safe amplitude = `0.8 · S · t / nz`) and a **pre-run warning** naming both remedies — so the config `ValueError` is never the user's first feedback.
- Pockets **auto-enable** for `tool_flat` (shown as a caption, no checkbox).

**Before → after UI placement**
- *Before:* a standalone `Surface resin pockets (tool-flat surface)` expander in the Expert **FE** section, separate from the Morphology controls.
- *After:* the expander is gone. For `tool_flat` the side + transition-ply controls render inline with the Morphology selector; for the legacy tool-flat morphologies (`stack`/`convex`/`concave`, `graded` decay_floor 0) an **advanced opt-in** is relocated into the same visual group, its help noting their pockets are inherently small (~0.25 ply thickness — use `tool_flat` for significant ones). `sb_surface_transition_plies` joins `DEFAULTS` so *Reset* round-trips it; no stale session-state keys.

**Cross-section preview**
- Renders the *thick* `tool_flat` pockets via the actual `tool_flat` decay (pinned plies flat, uniform core): it threads `tool_side` + `surface_transition_plies` into `from_morphology_name` and measures the trough gap at the outermost full-amplitude core ply. The summed multi-layer vertical stretch the FE tags equals that single displacement, so the cheap analytic render matches the FE volume while giving a visually unmistakable, ≥1-ply-thickness pocket.
- **Fidelity:** for a representative safe config (A=0.4, S=3, t=0.183) the analytic preview gap area **1.565 mm²/width** vs the multi-layer `compute_surface_resin_blend` FE volume **1.589 mm²/width** — ratio **0.985**, well inside the ~10% coarse-mesh tolerance.

**Run-handler wiring**
- `tool_flat` threads `morphology` + side + transition-plies into `AnalysisConfig` (pockets auto-enable on the FE path; honours *Analytical only* since `tool_flat` analytical == `uniform`). The legacy opt-in path is unchanged; the incompatible-morphology warning still fires for `uniform`/`graded`+floor.

**CLI**
- `--morphology tool-flat` accepted (hyphen alias normalised to the canonical `tool_flat` before the choices check, so `MORPHOLOGY_CHOICES` stays authoritative) + `--surface-transition-plies N`; help notes pockets auto-enable and the amplitude bound.

**Docs**
- README: `tool_flat` row in the morphology comparison table, CLI example + flag-table rows, app-features mention. CHANGELOG: `### Added` (Part B, Fixes #371) + `### Changed` (relocation rationale with the measured numbers).

No behavior change to existing numeric outputs — validation ledger shows zero drift.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (`-m "not slow"`: 1641 passed, 81 deselected)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean (only the pre-existing `reset_inputs` error)
- [x] Docs/README updated
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_