### PR TITLE
CLI: config-first sweeps/compares, transverse + stochastic exposure, ergonomics (part of #375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- CLI — **config-first sweeps/compares, transverse + stochastic exposure,
+  and ergonomics** (issue #375, CLI slice). `sweep` and `compare` gain
+  `--config PATH`: the file supplies the base `AnalysisConfig` (laminate,
+  material, mesh, penetration gate) so a **UD amplitude sweep through the
+  penetration gate** — previously impossible from the CLI — is reachable
+  with `wrinklefe sweep --config ud_gate.json --parameter amplitude ...`;
+  explicitly-passed geometry flags override the file via the #259
+  SUPPRESS-default precedence. `analyze` exposes the through-width
+  transverse surface (`--transverse-mode {uniform,gaussian_decay,
+  sinusoidal_y,elliptical}`, `--transverse-span`, `--transverse-width`; a
+  non-uniform mode forces the FE path) and the previously config-only
+  `--nz-per-ply`, `--ply-thickness` (sets the gate D/T) and `--output-csv`.
+  A new **`wrinklefe stochastic`** subcommand wraps
+  `stochastic.probabilistic_analysis`: a `--config` base plus repeatable
+  `--distribution FIELD:DIST:P1:P2` specs (`normal`/`uniform`/`lognormal`),
+  `--n-samples`/`--seed`/`--method`, printing percentile knockdowns and
+  writing JSON/CSV. `wrinklefe --version` now reads the installed package
+  metadata instead of a hardcoded string. (App config upload/download and
+  the app transverse controls are a separate follow-up; this slice does not
+  complete #375.)
 - App / CLI — **`tool_flat` surface-pocket controls live in the morphology
   definition** (issue #371, Part B — *Fixes #371*, completing the issue).
   The Streamlit Morphology selectbox gains **`tool_flat`** (Expert mode)

--- a/README.md
+++ b/README.md
@@ -477,6 +477,21 @@ wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 5
 # Full-FE sweep across 4 worker processes (--parallel 0 = all cores)
 wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
     --no-analytical-only --parallel 4
+
+# Sweep over a saved config's laminate/gate (the headline UD capability):
+# --config supplies the base (material, layup, gate); --parameter/--min/
+# --max/--steps drive the variation over it. `compare` takes --config too.
+wrinklefe sweep --config ud_gate.json --parameter amplitude \
+    --min 0.2 --max 0.9 --steps 6
+```
+
+Through-width (transverse) wrinkle surfaces and the mesh/thickness knobs
+are exposed on `analyze` (a non-uniform `--transverse-mode` forces the FE
+path; `--ply-thickness` sets the gate's D/T):
+
+```bash
+wrinklefe analyze --transverse-mode gaussian_decay --transverse-width 5 \
+    --nz-per-ply 2 --ply-thickness 0.25
 ```
 
 #### Wrinkle-defect capabilities
@@ -551,6 +566,26 @@ unknown key or a mismatched version fails loudly. YAML is supported when
 PyYAML is installed (it is not a required dependency). Library materials
 serialise by name, custom materials inline, and penetration-gate presets
 serialise by their registry name.
+
+### Probabilistic (stochastic) analysis
+
+`wrinklefe stochastic` propagates input distributions through the analysis
+to report percentile knockdowns — the "P5 knockdown under measurement
+uncertainty" number — from a `--config` base plus one or more repeatable
+`--distribution FIELD:DIST:P1:P2` specs (`DIST` is `normal`, `uniform`, or
+`lognormal`). A fixed `--seed` makes the whole run reproducible; results
+write to JSON (percentiles + per-sample arrays) and/or a per-sample CSV.
+
+```bash
+wrinklefe stochastic --config case.json \
+    --distribution amplitude:normal:0.5:0.05 \
+    --distribution wavelength:uniform:12:20 \
+    --n-samples 1000 --seed 42 --method lhs \
+    --output-json prob.json --output-csv prob.csv
+```
+
+These are model-**input-propagation** statistics, **not** CMH-17 A-/B-basis
+allowables (the printed summary carries the disclaimer).
 
 ### Exporting results to CSV / JSON
 

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -36,6 +36,45 @@ from wrinklefe.core.morphology import MORPHOLOGY_PHASES, SINGLE_WRINKLE_MODES
 # engine / Streamlit app (see issue #83).
 MORPHOLOGY_CHOICES = sorted(set(MORPHOLOGY_PHASES.keys()) | SINGLE_WRINKLE_MODES)
 
+# Transverse (through-width) envelope modes exposed on ``analyze`` (#300 /
+# #375). Kept in sync with ``AnalysisConfig.transverse_mode`` validation.
+TRANSVERSE_MODE_CHOICES = ("uniform", "gaussian_decay", "sinusoidal_y", "elliptical")
+
+# Geometry/profile flags on ``sweep`` / ``compare`` that participate in the
+# config-file precedence (issue #375): each is given an ``argparse.SUPPRESS``
+# default so an explicit flag overrides a ``--config`` file while a flag left
+# off inherits the file value. Runtime flags (analytical_only, parallel,
+# outputs, verbose, and the sweep parameter/range) keep ordinary defaults and
+# always drive the run.
+_SWEEP_CONFIG_FLAGS = (
+    "morphology", "amplitude_profile", "amplitude_profile_decay_length",
+    "amplitude_profile_axis",
+)
+_COMPARE_CONFIG_FLAGS = (
+    "amplitude", "wavelength", "width", "amplitude_profile",
+    "amplitude_profile_decay_length", "amplitude_profile_axis",
+)
+
+
+def _resolve_version() -> str:
+    """Return the installed package version, or the source fallback.
+
+    Reads :func:`importlib.metadata.version` so ``wrinklefe --version``
+    always matches the installed distribution rather than a hard-coded
+    string (issue #375). Falls back to the package ``__version__`` when the
+    distribution metadata is unavailable (e.g. running from a source tree
+    that was never installed).
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        return _pkg_version("wrinklefe")
+    except PackageNotFoundError:  # pragma: no cover - source-tree fallback
+        from wrinklefe import __version__
+
+        return __version__
+
 
 def _normalize_morphology(value: str) -> str:
     """Normalise a ``--morphology`` argument to its canonical engine name.
@@ -62,7 +101,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 1.0.0",
+        version=f"%(prog)s {_resolve_version()}",
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
@@ -325,8 +364,9 @@ def _build_parser() -> argparse.ArgumentParser:
     # ------------------------------------------------------------------ #
     # Wrinkle-defect capabilities (issue #346): surface the AnalysisConfig
     # fields shipped by the resin-pocket / progressive-damage / penetration-
-    # gate / off-mid-plane-wrinkle work so ``analyze`` (and, via --config,
-    # ``sweep``) can express them. Added BEFORE the SUPPRESS loop below so
+    # gate / off-mid-plane-wrinkle work so ``analyze`` — and, via their own
+    # ``--config`` flags (issue #375), ``sweep`` / ``compare`` — can express
+    # them. Added BEFORE the SUPPRESS loop below so
     # they inherit the config-file precedence for free (a flag left off keeps
     # the --config value; a flag passed overrides it). The long tail of finer
     # knobs stays reachable through --config.
@@ -521,6 +561,24 @@ def _build_parser() -> argparse.ArgumentParser:
             "logger to DEBUG with a stderr handler)"
         ),
     )
+    p_compare.add_argument(
+        "--config", type=str, default=None, dest="config",
+        help=(
+            "Load an AnalysisConfig from a JSON (or .yaml/.yml) file as the "
+            "base for the comparison -- so all three morphologies are run "
+            "over the file's laminate, material, mesh and gate. Any geometry "
+            "flag given on the same command line overrides the file value; "
+            "flags left off keep the file value. The three morphologies "
+            "(stack/convex/concave) always override the file's morphology."
+        ),
+    )
+    # Config-file precedence for the geometry/profile flags (issue #375):
+    # a SUPPRESS default means ``vars(args)`` holds only the ones the user
+    # actually passed, so an explicit flag overrides the ``--config`` file
+    # while a flag left off inherits the file value.
+    for _action in p_compare._actions:
+        if _action.dest in _COMPARE_CONFIG_FLAGS:
+            _action.default = argparse.SUPPRESS
 
     # ------------------------------------------------------------------ #
     # sweep
@@ -622,6 +680,25 @@ def _build_parser() -> argparse.ArgumentParser:
             "logger to DEBUG with a stderr handler)"
         ),
     )
+    p_sweep.add_argument(
+        "--config", type=str, default=None, dest="config",
+        help=(
+            "Load an AnalysisConfig from a JSON (or .yaml/.yml) file as the "
+            "base for the sweep, so the sweep runs over the file's laminate, "
+            "material, mesh and gate (e.g. a UD laminate through the "
+            "penetration gate) instead of the default IM7/8552 quasi-iso "
+            "laminate. The --parameter/--min/--max/--steps flags drive the "
+            "variation over that base; any geometry flag given on the same "
+            "command line overrides the file value."
+        ),
+    )
+    # Config-file precedence for the geometry/profile flags (issue #375):
+    # a SUPPRESS default means ``vars(args)`` holds only the ones the user
+    # actually passed, so an explicit flag overrides the ``--config`` file
+    # while a flag left off inherits the file value.
+    for _action in p_sweep._actions:
+        if _action.dest in _SWEEP_CONFIG_FLAGS:
+            _action.default = argparse.SUPPRESS
 
     # ------------------------------------------------------------------ #
     # converge
@@ -1012,18 +1089,41 @@ def _print_czm_extras(result) -> None:
 
 
 def _cmd_compare(args: argparse.Namespace) -> None:
-    """Handle the ``compare`` subcommand."""
+    """Handle the ``compare`` subcommand.
+
+    Config-file precedence (issue #375): when ``--config`` is given the file
+    supplies the base laminate/material/mesh/gate and every explicitly-passed
+    geometry flag overrides it; the three compared morphologies always drive
+    the ``morphology`` field. Without ``--config`` the behaviour is unchanged.
+    """
+    import dataclasses
+
     from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 
-    config = AnalysisConfig(
-        amplitude=args.amplitude,
-        wavelength=args.wavelength,
-        width=args.width,
-        amplitude_profile=args.amplitude_profile,
-        amplitude_profile_decay_length=args.amplitude_profile_decay_length,
-        amplitude_profile_axis=args.amplitude_profile_axis,
-        verbose=args.verbose,
-    )
+    present = vars(args)
+
+    def given(name: str) -> bool:
+        return name in present
+
+    _geom_defaults: dict = {
+        "amplitude": 0.366, "wavelength": 16.0, "width": 12.0,
+        "amplitude_profile": "constant",
+        "amplitude_profile_decay_length": None,
+        "amplitude_profile_axis": "x",
+    }
+    overrides = {n: getattr(args, n) for n in _geom_defaults if given(n)}
+    overrides["verbose"] = args.verbose
+
+    try:
+        if getattr(args, "config", None):
+            base = AnalysisConfig.load(args.config)
+            config = dataclasses.replace(base, **overrides)
+        else:
+            config = AnalysisConfig(**{**_geom_defaults, **overrides})
+    except (OSError, ValueError, KeyError, ImportError,
+            NotImplementedError) as exc:
+        print(f"error: could not build configuration: {exc}", file=sys.stderr)
+        sys.exit(2)
 
     all_results = WrinkleAnalysis.compare_morphologies(
         config,
@@ -1035,9 +1135,9 @@ def _cmd_compare(args: argparse.Namespace) -> None:
     print("=" * 72)
     print("  WrinkleFE Morphology Comparison")
     print("=" * 72)
-    print(f"  Amplitude:  {args.amplitude:.3f} mm")
-    print(f"  Wavelength: {args.wavelength:.1f} mm")
-    print(f"  Width:      {args.width:.1f} mm")
+    print(f"  Amplitude:  {config.amplitude:.3f} mm")
+    print(f"  Wavelength: {config.wavelength:.1f} mm")
+    print(f"  Width:      {config.width:.1f} mm")
     print()
     print(f"  {'Morphology':<12} {'M_f':>8} {'theta_max':>10} {'theta_eff':>10} "
           f"{'Damage':>8} {'Knockdown':>10} {'Strength':>10}")
@@ -1148,7 +1248,16 @@ def _write_batch_outputs(
 
 
 def _cmd_sweep(args: argparse.Namespace) -> None:
-    """Handle the ``sweep`` subcommand."""
+    """Handle the ``sweep`` subcommand.
+
+    Config-file precedence (issue #375): when ``--config`` is given the file
+    supplies the base laminate/material/mesh/gate (so a UD amplitude sweep
+    through the penetration gate is reachable from the CLI) and every
+    explicitly-passed geometry flag overrides it; the ``--parameter``/range
+    flags drive the variation. Without ``--config`` the behaviour is unchanged.
+    """
+    import dataclasses
+
     from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
 
     # Validate the range/steps before burning any compute (issue #298).
@@ -1175,13 +1284,29 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
 
     values = np.linspace(args.sweep_min, args.sweep_max, args.steps)
 
-    config = AnalysisConfig(
-        morphology=args.morphology,
-        amplitude_profile=args.amplitude_profile,
-        amplitude_profile_decay_length=args.amplitude_profile_decay_length,
-        amplitude_profile_axis=args.amplitude_profile_axis,
-        verbose=args.verbose,
-    )
+    present = vars(args)
+
+    def given(name: str) -> bool:
+        return name in present
+
+    _geom_defaults: dict = {
+        "morphology": "stack", "amplitude_profile": "constant",
+        "amplitude_profile_decay_length": None,
+        "amplitude_profile_axis": "x",
+    }
+    overrides = {n: getattr(args, n) for n in _geom_defaults if given(n)}
+    overrides["verbose"] = args.verbose
+
+    try:
+        if getattr(args, "config", None):
+            base = AnalysisConfig.load(args.config)
+            config = dataclasses.replace(base, **overrides)
+        else:
+            config = AnalysisConfig(**{**_geom_defaults, **overrides})
+    except (OSError, ValueError, KeyError, ImportError,
+            NotImplementedError) as exc:
+        print(f"error: could not build configuration: {exc}", file=sys.stderr)
+        sys.exit(2)
 
     # parametric_sweep raises AttributeError for an unknown field name;
     # catch it (and any config/solve error) and exit cleanly with a
@@ -1200,7 +1325,7 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
 
     print("=" * 60)
     print(f"  WrinkleFE Parametric Sweep: {args.parameter}")
-    print(f"  Morphology: {args.morphology}")
+    print(f"  Morphology: {config.morphology}")
     print("=" * 60)
     print()
     print(f"  {args.parameter:>14} {'Knockdown':>12} {'Strength (MPa)':>16} {'Damage':>10}")
@@ -1216,7 +1341,7 @@ def _cmd_sweep(args: argparse.Namespace) -> None:
 
     _write_batch_outputs(
         [
-            (args.parameter, float(val), args.morphology, r)
+            (args.parameter, float(val), config.morphology, r)
             for val, r in zip(values, results)
         ],
         args.output_json,

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -461,6 +461,71 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # ------------------------------------------------------------------ #
+    # Through-width (transverse / y) wrinkle surface (issue #300 CLI
+    # exposure, #375). FE-only: a non-uniform mode forces the FE path and
+    # is rejected together with a multi-wrinkle 'wrinkles' list or CZM
+    # (AnalysisConfig validation surfaces those as clean CLI errors).
+    # Added BEFORE the SUPPRESS loop so they inherit the --config precedence.
+    # ------------------------------------------------------------------ #
+    p_analyze.add_argument(
+        "--transverse-mode", type=str, default="uniform",
+        dest="transverse_mode", choices=list(TRANSVERSE_MODE_CHOICES),
+        help=(
+            "Through-width (transverse y) wrinkle-surface envelope "
+            "(default: uniform, the bare x-only wrinkle). 'gaussian_decay' "
+            "decays the amplitude toward the specimen edges, 'sinusoidal_y' "
+            "ripples it across the width, and 'elliptical' confines it to a "
+            "mid-width patch. FE-ONLY: any non-uniform mode forces the FE "
+            "path and is not combinable with a multi-wrinkle config or CZM."
+        ),
+    )
+    p_analyze.add_argument(
+        "--transverse-span", type=float, default=None,
+        dest="transverse_span",
+        help=(
+            "Specimen width span_y in mm seen by the transverse envelope. "
+            "Must be > 0. Defaults to the meshed domain width. Ignored when "
+            "--transverse-mode=uniform."
+        ),
+    )
+    p_analyze.add_argument(
+        "--transverse-width", type=float, default=None,
+        dest="transverse_width",
+        help=(
+            "Transverse localization half-width width_y in mm: the Gaussian "
+            "1/e length for 'gaussian_decay' and the ellipse half-width for "
+            "'elliptical' (ignored by 'uniform'/'sinusoidal_y'). Must be > 0. "
+            "Defaults to span_y / 4 (a localized mid-width patch)."
+        ),
+    )
+
+    # ------------------------------------------------------------------ #
+    # Ergonomics (issue #375): mesh/thickness knobs and a per-run CSV that
+    # were previously config-only. --ply-thickness sets the laminate T and
+    # therefore the penetration gate's D/T. Added BEFORE the SUPPRESS loop.
+    # ------------------------------------------------------------------ #
+    p_analyze.add_argument(
+        "--nz-per-ply", type=int, default=1, dest="nz_per_ply",
+        help="Mesh divisions per ply through-thickness (default: 1).",
+    )
+    p_analyze.add_argument(
+        "--ply-thickness", type=float, default=0.183, dest="ply_thickness",
+        help=(
+            "Single-ply thickness in mm (default: 0.183). Sets the laminate "
+            "thickness T = n_plies * ply_thickness and hence the penetration "
+            "gate's D/T ratio."
+        ),
+    )
+    p_analyze.add_argument(
+        "--output-csv", type=str, default=None, dest="output_csv",
+        help=(
+            "Write the run to a one-row tidy CSV (full float precision, "
+            "matching the sweep/compare CSV schema); the stdout summary is "
+            "still printed."
+        ),
+    )
+
     # Config-file precedence (issue #259): give every analyze option a
     # SUPPRESS default so ``vars(args)`` contains only the flags the user
     # actually passed. ``_cmd_analyze`` starts from the --config file (or
@@ -951,6 +1016,20 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     if given("increments"):
         overrides["progressive_n_increments"] = args.increments
 
+    # Transverse (through-width) surface (issue #300 / #375) and ergonomic
+    # mesh/thickness knobs. Each maps onto its AnalysisConfig field and
+    # composes with --config / --save-config.
+    if given("transverse_mode"):
+        overrides["transverse_mode"] = args.transverse_mode
+    if given("transverse_span"):
+        overrides["transverse_span"] = args.transverse_span
+    if given("transverse_width"):
+        overrides["transverse_width"] = args.transverse_width
+    if given("nz_per_ply"):
+        overrides["nz_per_ply"] = args.nz_per_ply
+    if given("ply_thickness"):
+        overrides["ply_thickness"] = args.ply_thickness
+
     # Resolve analytical-only vs. full FE intent.
     #
     # Precedence (highest first):
@@ -966,7 +1045,11 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     enable_czm_eff = overrides.get("enable_czm", False) or (
         base is not None and base.enable_czm
     )
-    fe_feature_eff = enable_czm_eff or (
+    transverse_eff = (
+        overrides.get("transverse_mode", "uniform") != "uniform"
+        or (base is not None and base.transverse_mode != "uniform")
+    )
+    fe_feature_eff = enable_czm_eff or transverse_eff or (
         overrides.get("enable_resin_pocket", False)
         or overrides.get("enable_surface_resin_pockets", False)
         or overrides.get("enable_progressive_damage", False)
@@ -997,7 +1080,7 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
             config = AnalysisConfig(**overrides)
         else:
             config = dataclasses.replace(base, **overrides)
-    except (ValueError, KeyError) as exc:
+    except (ValueError, KeyError, NotImplementedError) as exc:
         print(f"error: invalid configuration: {exc}", file=sys.stderr)
         sys.exit(2)
 
@@ -1060,6 +1143,15 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         from wrinklefe.io.export import export_results_json
         export_results_json(result, args.output_json)
         print(f"\nResults exported to: {args.output_json}")
+
+    # Export a one-row tidy CSV if requested (issue #375), reusing the
+    # sweep/compare per-run writer so the schema matches.
+    if given("output_csv") and args.output_csv is not None:
+        _write_batch_outputs(
+            [("", "", config.morphology, result)],
+            None,
+            args.output_csv,
+        )
 
 
 def _print_czm_extras(result) -> None:

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -857,6 +857,98 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # ------------------------------------------------------------------ #
+    # stochastic
+    # ------------------------------------------------------------------ #
+    p_stochastic = subparsers.add_parser(
+        "stochastic",
+        help="Monte-Carlo / LHS uncertainty propagation",
+        description=(
+            "Propagate input distributions through the analytical (or FE) "
+            "wrinkle analysis and report percentile knockdowns/strengths -- "
+            "the 'P5 knockdown under measurement uncertainty' number. These "
+            "are model-INPUT-propagation statistics, NOT CMH-17 A-/B-basis "
+            "allowables (see the printed disclaimer)."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--config", type=str, default=None, dest="config",
+        help=(
+            "Load the deterministic base AnalysisConfig from a JSON (or "
+            ".yaml/.yml) file. Every non-sampled field is held at its file "
+            "value. When omitted, the AnalysisConfig defaults are used."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--distribution", action="append", default=None, dest="distribution",
+        metavar="FIELD:DIST:P1:P2", required=True,
+        help=(
+            "Sample an AnalysisConfig field from a distribution. Repeatable. "
+            "Format 'FIELD:DIST:P1:P2' where DIST is one of normal|uniform|"
+            "lognormal: 'amplitude:normal:0.5:0.05' (mean, std), "
+            "'wavelength:uniform:12:20' (lo, hi), "
+            "'amplitude:lognormal:-0.7:0.2' (mu, sigma of the underlying "
+            "normal). At least one --distribution is required."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--n-samples", type=int, default=1000, dest="n_samples",
+        help="Number of samples (default: 1000; the analytical path is fast).",
+    )
+    p_stochastic.add_argument(
+        "--seed", type=int, default=None, dest="seed",
+        help=(
+            "Sampler seed. A fixed seed makes the whole run reproducible "
+            "(same samples, same percentiles). Default: unseeded."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--method", type=str, default="lhs", choices=["lhs", "mc"],
+        help=(
+            "Sampling method: 'lhs' (Latin-hypercube, default, lower "
+            "variance) or 'mc' (plain Monte-Carlo)."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--analytical-only", action=argparse.BooleanOptionalAction,
+        default=True, dest="analytical_only",
+        help=(
+            "Run only the analytical path per sample (default). Use "
+            "--no-analytical-only for the full FE pipeline per sample "
+            "(prohibitive beyond small --n-samples; pair with --parallel)."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--parallel", type=int, default=1, metavar="N", dest="parallel",
+        help=(
+            "Worker processes for the per-sample runs (default: 1 = "
+            "in-process; 0 = all CPU cores). Sampling always happens in the "
+            "parent, so results are identical for any worker count."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--output-json", type=str, default=None, dest="output_json",
+        help=(
+            "Write the percentile summary and per-sample arrays to a JSON "
+            "file; the stdout summary is still printed."
+        ),
+    )
+    p_stochastic.add_argument(
+        "--output-csv", type=str, default=None, dest="output_csv",
+        help=(
+            "Write one row per sample (each sampled input plus knockdown, "
+            "strength and modulus knockdown) to a tidy CSV; the stdout "
+            "summary is still printed."
+        ),
+    )
+    p_stochastic.add_argument(
+        "-v", "--verbose", action="store_true", default=False,
+        help=(
+            "Show detailed pipeline progress (sets the 'wrinklefe' "
+            "logger to DEBUG with a stderr handler)"
+        ),
+    )
+
+    # ------------------------------------------------------------------ #
     # materials
     # ------------------------------------------------------------------ #
     subparsers.add_parser(
@@ -1517,6 +1609,171 @@ def _cmd_converge(args: argparse.Namespace) -> None:
         print(f"\nConvergence plot saved to: {args.save_plot}")
 
 
+def _parse_distribution_specs(specs: list[str]) -> dict:
+    """Parse ``--distribution FIELD:DIST:P1:P2`` specs for ``stochastic``.
+
+    Returns a ``{field: (dist, p1, p2)}`` mapping in exactly the tuple form
+    :func:`wrinklefe.stochastic.probabilistic_analysis` accepts
+    (``("normal", mean, std)`` / ``("uniform", lo, hi)`` /
+    ``("lognormal", mu, sigma)``). Any malformed spec is a fatal CLI error
+    (exit 2) with a clear message rather than a deep traceback.
+    """
+    dists: dict = {}
+    for spec in specs:
+        parts = spec.split(":")
+        if len(parts) != 4:
+            print(
+                f"error: --distribution {spec!r} must be "
+                "'FIELD:DIST:P1:P2' (e.g. 'amplitude:normal:0.5:0.05')",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        field, kind, p1, p2 = (p.strip() for p in parts)
+        kind = kind.lower()
+        if not field:
+            print(
+                f"error: --distribution {spec!r} has an empty field name",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if kind not in ("normal", "uniform", "lognormal"):
+            print(
+                f"error: --distribution {spec!r}: unknown distribution "
+                f"{kind!r}; expected normal, uniform or lognormal",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        try:
+            a, b = float(p1), float(p2)
+        except ValueError:
+            print(
+                f"error: --distribution {spec!r}: P1/P2 ({p1!r}, {p2!r}) "
+                "must be numbers",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if field in dists:
+            print(
+                f"error: --distribution field {field!r} given more than once",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        dists[field] = (kind, a, b)
+    return dists
+
+
+def _cmd_stochastic(args: argparse.Namespace) -> None:
+    """Handle the ``stochastic`` subcommand (issue #375 CLI exposure of #301)."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.stochastic import probabilistic_analysis
+
+    if args.config is not None:
+        try:
+            base = AnalysisConfig.load(args.config)
+        except (OSError, ValueError, ImportError) as exc:
+            print(f"error: could not load --config: {exc}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        base = AnalysisConfig()
+
+    distributions = _parse_distribution_specs(args.distribution)
+
+    try:
+        prob = probabilistic_analysis(
+            base,
+            distributions,
+            n_samples=args.n_samples,
+            seed=args.seed,
+            method=args.method,
+            analytical_only=args.analytical_only,
+            n_workers=args.parallel,
+        )
+    except (ValueError, TypeError) as exc:
+        print(f"error: stochastic analysis failed: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    print(prob.summary())
+
+    _write_stochastic_outputs(prob, args.output_json, args.output_csv)
+
+
+def _write_stochastic_outputs(prob, output_json, output_csv) -> None:
+    """Write stochastic percentiles + per-sample data to JSON and/or CSV."""
+    if output_json is None and output_csv is None:
+        return
+
+    import csv
+    import json
+    from pathlib import Path
+
+    percentiles = [1.0, 5.0, 10.0, 25.0, 50.0, 75.0, 90.0, 95.0, 99.0]
+    input_names = sorted(prob.input_samples)
+
+    if output_json is not None:
+        payload = {
+            "n_samples": prob.n_samples,
+            "seed": prob.seed,
+            "method": prob.method,
+            "analytical_only": prob.analytical_only,
+            "knockdown": {
+                "mean": prob.knockdown_mean,
+                "std": prob.knockdown_std,
+                "percentiles": {
+                    str(q): float(prob.knockdown_percentile(q))
+                    for q in percentiles
+                },
+            },
+            "strength_MPa": {
+                "mean": prob.strength_mean,
+                "std": prob.strength_std,
+                "percentiles": {
+                    str(q): float(prob.strength_percentile(q))
+                    for q in percentiles
+                },
+            },
+            "samples": {
+                "knockdown": [float(x) for x in prob.knockdown],
+                "strength_MPa": [float(x) for x in prob.strength_MPa],
+                "modulus_knockdown": [
+                    float(x) for x in prob.modulus_knockdown
+                ],
+                **{
+                    f"input_{name}": [
+                        float(x) for x in prob.input_samples[name]
+                    ]
+                    for name in input_names
+                },
+            },
+        }
+        path = Path(output_json)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nResults written to: {path}")
+
+    if output_csv is not None:
+        fieldnames = [
+            *(f"input_{name}" for name in input_names),
+            "knockdown", "strength_MPa", "modulus_knockdown",
+        ]
+        path = Path(output_csv)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for i in range(prob.n_samples):
+                row = {
+                    f"input_{name}": repr(float(prob.input_samples[name][i]))
+                    for name in input_names
+                }
+                row["knockdown"] = repr(float(prob.knockdown[i]))
+                row["strength_MPa"] = repr(float(prob.strength_MPa[i]))
+                row["modulus_knockdown"] = repr(
+                    float(prob.modulus_knockdown[i])
+                )
+                writer.writerow(row)
+        print(f"\nResults written to: {path}")
+
+
 def _configure_logging(verbose: bool) -> None:
     """Attach a stderr handler to the package logger for ``--verbose``.
 
@@ -1558,6 +1815,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         "compare": _cmd_compare,
         "sweep": _cmd_sweep,
         "converge": _cmd_converge,
+        "stochastic": _cmd_stochastic,
         "materials": _cmd_materials,
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -862,6 +862,95 @@ def test_sweep_wrinkle_z_position_end_to_end(capsys):
 
 
 # --------------------------------------------------------------------------- #
+# analyze: transverse modes + ergonomics (issue #375)
+# --------------------------------------------------------------------------- #
+
+
+def test_analyze_transverse_mode_maps_and_forces_fe():
+    """A non-uniform --transverse-mode reaches the config and forces FE."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--transverse-mode", "gaussian_decay",
+            "--transverse-span", "20.0", "--transverse-width", "5.0",
+        ])
+    cfg = captured["config"]
+    assert cfg.transverse_mode == "gaussian_decay"
+    assert cfg.transverse_span == pytest.approx(20.0)
+    assert cfg.transverse_width == pytest.approx(5.0)
+    # FE-only feature forces the full FE path over the analytical default.
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_transverse_uniform_default_untouched():
+    """Without the flag the config keeps the uniform (x-only) default."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main(["analyze", "--analytical-only"])
+    assert captured["config"].transverse_mode == "uniform"
+    assert captured["analytical_only"] is True
+
+
+def test_analyze_transverse_czm_conflict_is_clean(capsys):
+    """--transverse-mode combined with --enable-czm surfaces a clean error,
+    not a raw traceback (the config validation rejects the combination)."""
+    with pytest.raises(SystemExit) as exc:
+        cli_main([
+            "analyze", "--transverse-mode", "gaussian_decay", "--enable-czm",
+        ])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "error:" in err and "Traceback" not in err
+
+
+def test_analyze_nz_per_ply_and_ply_thickness_map():
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--analytical-only",
+            "--nz-per-ply", "3", "--ply-thickness", "0.25",
+        ])
+    cfg = captured["config"]
+    assert cfg.nz_per_ply == 3
+    assert cfg.ply_thickness == pytest.approx(0.25)
+
+
+def test_analyze_output_csv(tmp_path):
+    """`analyze --output-csv` writes a one-row tidy CSV matching the
+    sweep/compare schema."""
+    import csv
+
+    csv_path = tmp_path / "run.csv"
+    cli_main([
+        "analyze", "--analytical-only",
+        "--amplitude", "0.3", "--wavelength", "16",
+        "--output-csv", str(csv_path),
+    ])
+    rows = list(csv.DictReader(csv_path.open()))
+    assert len(rows) == 1
+    assert {"parameter_name", "parameter_value", "morphology",
+            "knockdown", "predicted_strength_MPa"} <= set(rows[0])
+    assert 0.0 < float(rows[0]["knockdown"]) <= 1.0
+
+
+# --------------------------------------------------------------------------- #
+# --version (issue #375)
+# --------------------------------------------------------------------------- #
+
+
+def test_version_matches_installed_metadata(capsys):
+    """`wrinklefe --version` reports the installed distribution version, not
+    a hardcoded string."""
+    from importlib.metadata import version as _pkg_version
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["--version"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert _pkg_version("wrinklefe") in out
+
+
+# --------------------------------------------------------------------------- #
 # sweep / compare: --config base (issue #375)
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -859,3 +859,122 @@ def test_sweep_wrinkle_z_position_end_to_end(capsys):
     assert "wrinkle_z_position" in out
     # Three data rows should be present between the header rules.
     assert out.count("\n") > 5
+
+
+# --------------------------------------------------------------------------- #
+# sweep / compare: --config base (issue #375)
+# --------------------------------------------------------------------------- #
+
+
+def test_sweep_config_uses_files_laminate_not_default(tmp_path):
+    """`sweep --config` runs over the file's UD laminate/gate, not the
+    default IM7/8552 quasi-iso laminate."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.penetration_gate import GATE_LI2025_VACBAG
+
+    base = AnalysisConfig(
+        morphology="graded",
+        angles=[0.0] * 14,
+        ply_thickness=0.44,
+        wavelength=12.9,
+        width=6.45,
+        penetration_gate=GATE_LI2025_VACBAG,
+        analytical_only=True,
+    )
+    path = tmp_path / "ud_gate.json"
+    base.save_json(path)
+
+    captured: dict = {}
+
+    def fake_sweep(base_config, parameter, values, analytical_only,
+                   n_workers=1):
+        captured["base_config"] = base_config
+        return [_make_fake_result() for _ in values]
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.parametric_sweep",
+        new=staticmethod(fake_sweep),
+    ):
+        cli_main([
+            "sweep", "--config", str(path),
+            "--parameter", "amplitude",
+            "--min", "0.3", "--max", "0.9", "--steps", "4",
+        ])
+
+    cfg = captured["base_config"]
+    # The file's UD laminate + gate reached the sweep engine, NOT the
+    # IM7/8552 quasi-iso default (angles=None, ply_thickness=0.183).
+    assert cfg.angles == [0.0] * 14
+    assert cfg.ply_thickness == pytest.approx(0.44)
+    assert cfg.morphology == "graded"
+    assert cfg.penetration_gate is GATE_LI2025_VACBAG
+
+
+def test_sweep_config_explicit_flag_overrides_file(tmp_path):
+    """A geometry flag on the command line overrides the --config file."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    base = AnalysisConfig(morphology="graded", analytical_only=True)
+    path = tmp_path / "case.json"
+    base.save_json(path)
+
+    captured: dict = {}
+
+    def fake_sweep(base_config, parameter, values, analytical_only,
+                   n_workers=1):
+        captured["base_config"] = base_config
+        return [_make_fake_result() for _ in values]
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.parametric_sweep",
+        new=staticmethod(fake_sweep),
+    ):
+        cli_main([
+            "sweep", "--config", str(path), "--morphology", "convex",
+            "--parameter", "amplitude", "--min", "0.1", "--max", "0.3",
+            "--steps", "2",
+        ])
+
+    assert captured["base_config"].morphology == "convex"
+
+
+def test_sweep_bad_config_path_exits_cleanly(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main([
+            "sweep", "--config", "/no/such/file.json",
+            "--parameter", "amplitude", "--min", "0.1", "--max", "0.3",
+        ])
+    assert exc.value.code == 2
+    assert "error:" in capsys.readouterr().err
+
+
+def test_compare_config_uses_files_laminate(tmp_path):
+    """`compare --config` runs the three morphologies over the file's
+    laminate/material, not the default."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    base = AnalysisConfig(
+        angles=[0.0] * 8,
+        interface_1=3,
+        interface_2=4,
+        ply_thickness=0.25,
+        analytical_only=True,
+    )
+    path = tmp_path / "case.json"
+    base.save_json(path)
+
+    captured: dict = {}
+
+    def fake_compare(base_config, morphologies, analytical_only):
+        captured["base_config"] = base_config
+        return {m: _make_fake_result() for m in morphologies}
+
+    with patch(
+        "wrinklefe.analysis.WrinkleAnalysis.compare_morphologies",
+        new=staticmethod(fake_compare),
+    ):
+        cli_main(["compare", "--config", str(path)])
+
+    cfg = captured["base_config"]
+    assert cfg.angles == [0.0] * 8
+    assert cfg.ply_thickness == pytest.approx(0.25)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -934,6 +934,123 @@ def test_analyze_output_csv(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# stochastic subcommand (issue #375 CLI exposure of #301)
+# --------------------------------------------------------------------------- #
+
+
+def test_stochastic_reports_percentiles_and_is_reproducible(capsys):
+    """`stochastic` prints percentiles and a fixed --seed reproduces them."""
+    argv = [
+        "stochastic",
+        "--distribution", "amplitude:normal:0.4:0.05",
+        "--n-samples", "128", "--seed", "11",
+    ]
+    cli_main(argv)
+    out_a = capsys.readouterr().out
+    assert "Probabilistic Analysis" in out_a
+    assert "P5=" in out_a and "P50=" in out_a and "P95=" in out_a
+
+    cli_main(argv)
+    out_b = capsys.readouterr().out
+    # Same seed -> byte-identical percentile summary.
+    assert out_a == out_b
+
+
+def test_stochastic_json_and_csv_outputs(tmp_path):
+    import csv
+    import json
+
+    json_path = tmp_path / "prob.json"
+    csv_path = tmp_path / "prob.csv"
+    cli_main([
+        "stochastic",
+        "--distribution", "amplitude:normal:0.4:0.05",
+        "--distribution", "wavelength:uniform:14:18",
+        "--n-samples", "64", "--seed", "3",
+        "--output-json", str(json_path),
+        "--output-csv", str(csv_path),
+    ])
+
+    payload = json.loads(json_path.read_text())
+    assert payload["n_samples"] == 64
+    assert payload["seed"] == 3
+    assert "5.0" in payload["knockdown"]["percentiles"]
+    assert len(payload["samples"]["knockdown"]) == 64
+
+    rows = list(csv.DictReader(csv_path.open()))
+    assert len(rows) == 64
+    assert {"input_amplitude", "input_wavelength", "knockdown",
+            "strength_MPa", "modulus_knockdown"} <= set(rows[0])
+
+
+def test_stochastic_reproducible_percentile_values(tmp_path):
+    """Two seeded runs produce identical percentile knockdowns in JSON."""
+    import json
+
+    def run(dst):
+        cli_main([
+            "stochastic", "--distribution", "amplitude:normal:0.4:0.05",
+            "--n-samples", "100", "--seed", "42", "--output-json", str(dst),
+        ])
+        return json.loads(dst.read_text())["knockdown"]["percentiles"]
+
+    a = run(tmp_path / "a.json")
+    b = run(tmp_path / "b.json")
+    assert a == b
+    # A genuine spread was produced (not a degenerate constant).
+    assert a["5.0"] < a["95.0"]
+
+
+@pytest.mark.parametrize("bad", [
+    "amplitude:normal:0.4",          # too few fields
+    "amplitude:normal:0.4:0.05:1",   # too many fields
+    "amplitude:weibull:0.4:0.05",    # unknown distribution
+    "amplitude:normal:x:0.05",       # non-numeric parameter
+    ":normal:0.4:0.05",              # empty field name
+])
+def test_stochastic_bad_distribution_spec_exits_cleanly(bad, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["stochastic", "--distribution", bad, "--n-samples", "10"])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "error:" in err and "--distribution" in err
+    assert "Traceback" not in err
+
+
+def test_stochastic_uses_config_base(tmp_path):
+    """`stochastic --config` samples over the file's base laminate."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    base = AnalysisConfig(
+        angles=[0.0] * 8, interface_1=3, interface_2=4,
+        analytical_only=True,
+    )
+    path = tmp_path / "base.json"
+    base.save_json(path)
+
+    from wrinklefe.stochastic import (
+        probabilistic_analysis as _real_prob,
+    )
+
+    captured: dict = {}
+
+    def fake_prob(base_config, distributions, **kwargs):
+        captured["base_config"] = base_config
+        captured["distributions"] = distributions
+        return _real_prob(base_config, distributions, **kwargs)
+
+    with patch("wrinklefe.stochastic.probabilistic_analysis", new=fake_prob):
+        cli_main([
+            "stochastic", "--config", str(path),
+            "--distribution", "amplitude:normal:0.3:0.02",
+            "--n-samples", "16", "--seed", "1",
+        ])
+
+    assert captured["base_config"].angles == [0.0] * 8
+    assert captured["distributions"] == {"amplitude": ("normal", 0.3, 0.02)}
+
+
+# --------------------------------------------------------------------------- #
 # --version (issue #375)
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Linked issue
Part of #375 (CLI slice). Does **not** close #375 — the app config upload/download and the app transverse controls are a separate follow-up.

## Summary
Finishes wiring the command line to the `AnalysisConfig` file format (#259) and exposes capabilities that were config/API-only. CLI-only; no app/Streamlit changes; no new physics.

- **`sweep` and `compare` gain `--config PATH`** — the file supplies the base `AnalysisConfig` (laminate, material, mesh, penetration gate), so a **UD amplitude sweep through the penetration gate** — previously impossible from the CLI — is now `wrinklefe sweep --config ud_gate.json --parameter amplitude …`. Explicitly-passed geometry flags override the file. Fixes the stale #346 comment that claimed sweep was already config-reachable.
- **`analyze` transverse flags (#300 exposure):** `--transverse-mode {uniform,gaussian_decay,sinusoidal_y,elliptical}`, `--transverse-span`, `--transverse-width`, composing with `--config` (a non-uniform mode forces the FE path; config validation errors surfaced cleanly).
- **New `wrinklefe stochastic` subcommand** wrapping `stochastic.probabilistic_analysis`: a `--config` base plus repeatable `--distribution FIELD:DIST:P1:P2` specs (`normal`/`uniform`/`lognormal`), `--n-samples`/`--seed`/`--method`, printing percentile knockdowns and writing JSON/CSV.
- **Ergonomics:** `analyze --nz-per-ply`, `--ply-thickness` (sets the gate D/T), `--output-csv`; `wrinklefe --version` reads installed package metadata instead of a hardcoded string.

Four commits: `55104a6` (sweep/compare --config + dynamic --version), `baa7461` (transverse + ergonomics on analyze), `6c29c81` (stochastic subcommand), `de97672` (docs).

## Checklist
- [x] Tests added/updated (flag→config mapping, sweep-uses-config-laminate, stochastic percentiles + seed reproducibility, `--version`)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean
- [x] `pytest` — fast lane green (CI runs the full matrix, doctests, `sphinx -W`)
- [x] `scripts/validate.py` — zero ledger drift
- [x] `CHANGELOG.md` `### Added`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_