### PR TITLE
App config upload/download + transverse controls (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- App — **config upload/download and through-width transverse controls**
+  (issue #375, app slice — *Fixes #375*, completing the issue). The
+  Streamlit sidebar gains a **Config file** section: **Download config
+  (JSON)** serialises the current effective `AnalysisConfig` from the live
+  sidebar state (works before any run) and round-trips with the CLI
+  `--config` / `--save-config` flags, and **Load config (JSON/YAML)**
+  reads a saved case back into the sidebar. Loading parses via
+  `AnalysisConfig.from_dict` (bad files surface an `st.error`, never a
+  crash) and *seeds* the widgets from the config — the seed is staged in
+  `session_state` and applied at the top of the sidebar before the widgets
+  instantiate (then a rerun), so Streamlit's set-after-instantiate error is
+  avoided; custom materials route through the custom-editor keys and stale
+  results are cleared. Expert mode also exposes the through-width
+  **transverse** envelope (`transverse_mode` selectbox plus span/width
+  inputs); a non-uniform mode forces the FE path and is threaded into the
+  run config, while the incompatible transverse+CZM combo shows a sidebar
+  warning and is not threaded into an invalid config.
 - CLI — **config-first sweeps/compares, transverse + stochastic exposure,
   and ergonomics** (issue #375, CLI slice). `sweep` and `compare` gain
   `--config PATH`: the file supplies the base `AnalysisConfig` (laminate,

--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ set the wrinkle geometry, and click **Run analysis**. The app ships with
 per-morphology schematic cartoons (including the `tool_flat`
 surface-resin-pocket morphology, whose pinned-side and transition-ply
 controls appear inline with the Morphology selector), a live wrinkle
-preview, and the same analytical + FE pipeline as the Python API. See
+preview, and the same analytical + FE pipeline as the Python API. Expert
+mode also exposes the through-width `transverse_mode` envelope, and the
+sidebar **Config file** section can **download** the current settings as a
+portable `AnalysisConfig` JSON — round-tripping with the CLI `--config` /
+`--save-config` flags — or **load** a saved case (JSON/YAML) back into the
+sidebar. See
 [`DEPLOYMENT_STREAMLIT.md`](docs/internal/DEPLOYMENT_STREAMLIT.md) for the full feature
 tour and instructions for self-hosting.
 

--- a/app.py
+++ b/app.py
@@ -16,10 +16,11 @@ import csv
 import io
 import json
 import sys
+from collections.abc import MutableMapping
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import matplotlib
 
@@ -139,6 +140,15 @@ DEFAULT_AMPLITUDE_PROFILE = _CFG_DEFAULTS.amplitude_profile
 # legacy back-compat behaviour.
 DEFAULT_AMPLITUDE_PROFILE_DECAY_LENGTH = _CFG_DEFAULTS.width
 DEFAULT_AMPLITUDE_PROFILE_AXIS = _CFG_DEFAULTS.amplitude_profile_axis
+# Through-width (transverse / y) envelope (#300 / #375). The dataclass
+# defaults for the span / width are ``None`` (auto: track the mesh width and
+# ``span_y / 4`` respectively). Streamlit's ``number_input`` cannot hold
+# ``None``, so the sidebar uses ``0.0`` as the "auto" sentinel — a 0 value is
+# threaded back to ``AnalysisConfig`` as ``None``, preserving the auto
+# behaviour and round-tripping the default config.
+DEFAULT_TRANSVERSE_MODE = _CFG_DEFAULTS.transverse_mode
+DEFAULT_TRANSVERSE_SPAN = 0.0
+DEFAULT_TRANSVERSE_WIDTH = 0.0
 DEFAULT_ANALYTICAL_ONLY = _CFG_DEFAULTS.analytical_only
 DEFAULT_NX = _CFG_DEFAULTS.nx
 DEFAULT_NY = _CFG_DEFAULTS.ny
@@ -196,6 +206,10 @@ DEFAULTS: dict[str, object] = {
     "sb_amplitude_profile": DEFAULT_AMPLITUDE_PROFILE,
     "sb_amplitude_profile_decay_length": DEFAULT_AMPLITUDE_PROFILE_DECAY_LENGTH,
     "sb_amplitude_profile_axis": DEFAULT_AMPLITUDE_PROFILE_AXIS,
+    # Through-width transverse envelope (#300 / #375).
+    "sb_transverse_mode": DEFAULT_TRANSVERSE_MODE,
+    "sb_transverse_span": DEFAULT_TRANSVERSE_SPAN,
+    "sb_transverse_width": DEFAULT_TRANSVERSE_WIDTH,
     "sb_loading": DEFAULT_LOADING,
     "sb_strain_mag_pct": DEFAULT_STRAIN_MAG_PCT,
     "sb_analytical_only": DEFAULT_ANALYTICAL_ONLY,
@@ -247,6 +261,166 @@ def reset_inputs() -> None:
 
 # Back-compat alias for older call sites.
 _reset_sidebar_defaults = reset_inputs
+
+
+# ---------------------------------------------------------------------------
+# Config file I/O (upload / download) — issue #375 app slice.
+#
+# The download button serialises the current effective ``AnalysisConfig``
+# (built from the live sidebar payload) with :meth:`AnalysisConfig.to_json`,
+# so a case file round-trips with the CLI ``--config`` / ``--save-config``
+# flags. Upload parses a file back into an ``AnalysisConfig`` and *seeds* the
+# sidebar widgets from it — the inverse of ``_assemble_cfg_payload``. Seeding
+# writes the widget ``session_state`` keys BEFORE the widgets are
+# instantiated (a pending-upload object is staged in ``session_state`` and
+# applied at the very top of the sidebar, exactly like the Reset callback),
+# which is the only way to avoid Streamlit's "cannot be modified after the
+# widget is instantiated" error.
+# ---------------------------------------------------------------------------
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp ``value`` into ``[lo, hi]`` so a seeded widget value can never
+    fall outside the widget's own ``min_value`` / ``max_value`` (an
+    externally-authored config could carry a physically-valid but
+    out-of-widget-range number; clamping keeps the seeding from raising a
+    ``StreamlitAPIException`` and crashing the rerun)."""
+    return float(min(max(value, lo), hi))
+
+
+def _angles_to_layup_str(angles: list[float]) -> str:
+    """Render a resolved ply-angle list as a layup string the textarea (and
+    :func:`parse_layup`) accept, e.g. ``[0, 45, -45, 90]`` -> ``"0, 45, -45,
+    90"``. Integer-valued angles print without a trailing ``.0``."""
+    return ", ".join(f"{float(a):g}" for a in angles)
+
+
+def _seed_material_state(
+    material: OrthotropicMaterial | None,
+    state: MutableMapping[str, Any],
+) -> None:
+    """Seed the material widgets from a loaded config's material.
+
+    A library preset (name known and field-for-field equal) selects the
+    matching dropdown entry; anything else routes through the custom-material
+    editor (``Custom…`` + the ``custom_*`` elastic/strength keys), mirroring
+    the sidebar's own custom path. Stale ``custom_*`` keys are cleared first
+    so a preset load doesn't inherit a previous custom edit.
+    """
+    stale_key: str
+    for stale_key in [
+        k for k in state if isinstance(k, str) and k.startswith("custom_")
+    ]:
+        state.pop(stale_key, None)
+    if material is None:
+        state["sb_material"] = DEFAULT_MATERIAL
+        return
+    if material.name in MATERIAL_NAMES:
+        try:
+            if LIB.get(material.name).to_dict() == material.to_dict():
+                state["sb_material"] = material.name
+                return
+        except KeyError:
+            pass
+    # Custom (or a tweaked preset): drive the custom editor.
+    state["sb_material"] = CUSTOM_MATERIAL_LABEL
+    state["sb_custom_name"] = material.name
+    for fkey, _label, _fmt in (
+        CUSTOM_MAT_ELASTIC_FIELDS + CUSTOM_MAT_STRENGTH_FIELDS
+    ):
+        state[f"custom_{fkey}"] = float(getattr(material, fkey))
+
+
+def _seed_state_from_config(
+    cfg: AnalysisConfig, state: MutableMapping[str, Any]
+) -> None:
+    """Seed every sidebar widget ``session_state`` key from ``cfg``.
+
+    The inverse of the sidebar-to-``AnalysisConfig`` mapping used by
+    ``_assemble_cfg_payload`` / :func:`_config_from_payload`. Loading a config
+    is an expert action (many controls only render in Expert mode), so this
+    forces ``expert_mode`` on. Numeric values are clamped to the widgets'
+    ranges so an out-of-range external config seeds without crashing.
+    """
+    state["expert_mode"] = True
+    state["sb_amplitude"] = _clamp(cfg.amplitude, 0.0, 5.0)
+    state["sb_wavelength"] = _clamp(cfg.wavelength, 1.0, 200.0)
+    state["sb_width"] = _clamp(cfg.width, 1.0, 200.0)
+    state["sb_ply_thickness"] = _clamp(cfg.ply_thickness, 0.05, 1.0)
+    if cfg.angles is not None:
+        state["sb_layup"] = _angles_to_layup_str(cfg.angles)
+    state["sb_morphology"] = cfg.morphology
+    state["sb_decay_floor"] = _clamp(cfg.decay_floor, 0.0, 1.0)
+    # Amplitude profile.
+    state["sb_amplitude_profile"] = cfg.amplitude_profile
+    state["sb_amplitude_profile_decay_length"] = (
+        max(0.0, float(cfg.amplitude_profile_decay_length))
+        if cfg.amplitude_profile_decay_length is not None
+        else float(DEFAULT_AMPLITUDE_PROFILE_DECAY_LENGTH)
+    )
+    state["sb_amplitude_profile_axis"] = cfg.amplitude_profile_axis
+    # Through-width transverse envelope (0 = auto sentinel).
+    state["sb_transverse_mode"] = cfg.transverse_mode
+    state["sb_transverse_span"] = (
+        max(0.0, float(cfg.transverse_span))
+        if cfg.transverse_span is not None
+        else 0.0
+    )
+    state["sb_transverse_width"] = (
+        max(0.0, float(cfg.transverse_width))
+        if cfg.transverse_width is not None
+        else 0.0
+    )
+    # Loading — sign lives on the radio, magnitude on the number input.
+    state["sb_loading"] = cfg.loading
+    state["sb_strain_mag_pct"] = _clamp(abs(cfg.applied_strain) * 100.0, 0.0, 5.0)
+    # Mesh.
+    state["sb_nx"] = int(_clamp(cfg.nx, 4, 64))
+    state["sb_ny"] = int(_clamp(cfg.ny, 4, 32))
+    state["sb_nz_per_ply"] = int(_clamp(cfg.nz_per_ply, 1, 4))
+    state["sb_analytical_only"] = bool(cfg.analytical_only)
+    # Material.
+    _seed_material_state(cfg.material, state)
+    # Cohesive zone modelling.
+    state["sb_enable_czm"] = bool(cfg.enable_czm)
+    if isinstance(cfg.czm_interfaces, str):
+        state["sb_czm_interfaces"] = cfg.czm_interfaces
+    if cfg.czm_GIc is not None:
+        state["sb_czm_GIc"] = float(cfg.czm_GIc)
+    if cfg.czm_GIIc is not None:
+        state["sb_czm_GIIc"] = float(cfg.czm_GIIc)
+    if cfg.czm_sigma_max is not None:
+        state["sb_czm_sigma_max"] = float(cfg.czm_sigma_max)
+    if cfg.czm_tau_max is not None:
+        state["sb_czm_tau_max"] = float(cfg.czm_tau_max)
+    state["sb_czm_load_increments"] = int(
+        _clamp(cfg.czm_n_load_increments, 5, 100)
+    )
+    state["sb_czm_newton_tol"] = _clamp(cfg.czm_newton_tol, 1.0e-8, 1.0e-2)
+    # Surface resin pockets.
+    state["sb_enable_surface_pockets"] = bool(cfg.enable_surface_resin_pockets)
+    state["sb_surface_pocket_side"] = cfg.surface_pocket_side
+    state["sb_surface_transition_plies"] = int(
+        _clamp(cfg.surface_transition_plies, 1, 12)
+    )
+
+
+def _parse_uploaded_config(name: str, data: bytes | str) -> AnalysisConfig:
+    """Parse uploaded config bytes into an :class:`AnalysisConfig`.
+
+    Dispatches on the filename suffix (``.yaml`` / ``.yml`` -> YAML, else
+    JSON) and validates through :meth:`AnalysisConfig.from_dict`, so an
+    unknown key or a version mismatch raises a :class:`ValueError` the caller
+    surfaces via ``st.error``.
+    """
+    text = data.decode("utf-8") if isinstance(data, (bytes, bytearray)) else data
+    if Path(name).suffix.lower() in (".yaml", ".yml"):
+        import yaml  # type: ignore[import-untyped]
+
+        raw = yaml.safe_load(text)
+    else:
+        raw = json.loads(text)
+    return AnalysisConfig.from_dict(raw)
 
 
 # ---------------------------------------------------------------------------
@@ -704,6 +878,22 @@ _HERO_INTRO_MD = (
 # ---------------------------------------------------------------------------
 
 with st.sidebar:
+    # Apply a pending uploaded config BEFORE any widget is instantiated. The
+    # file_uploader (rendered lower down) stages the parsed AnalysisConfig in
+    # ``session_state["_pending_config"]`` and reruns; here — at the top of
+    # the sidebar, before the widgets exist — we seed their keys, which is
+    # the only point Streamlit allows a widget-backed key to be written.
+    _pending_config = st.session_state.pop("_pending_config", None)
+    if _pending_config is not None:
+        _seed_state_from_config(
+            _pending_config, cast("MutableMapping[str, Any]", st.session_state)
+        )
+        # Drop any prior run so the Analyze tab doesn't show stale results
+        # under the freshly-loaded inputs (issue #374 semantics).
+        for _run_key in ("results", "cfg_payload"):
+            st.session_state.pop(_run_key, None)
+        st.session_state["_config_loaded_toast"] = True
+
     expert_mode = st.toggle(
         "Expert mode", value=DEFAULT_EXPERT_MODE, key="expert_mode",
         help=(
@@ -1124,6 +1314,72 @@ with st.sidebar:
             amplitude_profile_decay_length = float(
                 amplitude_profile_decay_length_ui
             )
+
+        # --- Through-width (transverse / y) variation (#300 / #375) --------
+        # The x-only wrinkle is uniform across the specimen width; the
+        # non-uniform modes wrap the profile in a WrinkleSurface3D so the
+        # crest amplitude varies across y (localized real-world wrinkles).
+        # FE-only, single-wrinkle — the compatibility gate below refuses to
+        # thread it alongside CZM. ``span`` / ``width`` use 0 = auto.
+        st.markdown("**Through-width (transverse) variation**")
+        _transverse_modes = [
+            "uniform", "gaussian_decay", "sinusoidal_y", "elliptical",
+        ]
+        transverse_mode = st.selectbox(
+            "Transverse mode",
+            _transverse_modes,
+            index=_transverse_modes.index(DEFAULT_TRANSVERSE_MODE),
+            key="sb_transverse_mode",
+            help=(
+                "Through-width envelope f(y) applied to the wrinkle crest "
+                "amplitude. 'uniform' (default) is the bare x-only wrinkle "
+                "(bit-identical to before). 'gaussian_decay' decays the "
+                "amplitude toward the edges (localized mid-width defect), "
+                "'sinusoidal_y' ripples it across the width, and 'elliptical' "
+                "confines it to a mid-width patch. Non-uniform modes are "
+                "**FE-only** (they force the full solve) and cannot combine "
+                "with Cohesive Zone Modeling."
+            ),
+        )
+        _transverse_ui_active = transverse_mode != "uniform"
+        transverse_span_ui = st.number_input(
+            "Transverse span span_y [mm]  (0 = auto: mesh width)",
+            min_value=0.0, max_value=1000.0,
+            value=float(DEFAULT_TRANSVERSE_SPAN), step=1.0,
+            disabled=not _transverse_ui_active,
+            key="sb_transverse_span",
+            help=(
+                "Specimen width the transverse envelope spans. 0 (auto) "
+                "tracks the meshed y-extent (domain_width). Ignored when "
+                "Transverse mode = uniform."
+            ),
+        )
+        transverse_width_ui = st.number_input(
+            "Transverse half-width width_y [mm]  (0 = auto: span/4)",
+            min_value=0.0, max_value=1000.0,
+            value=float(DEFAULT_TRANSVERSE_WIDTH), step=0.5,
+            disabled=not _transverse_ui_active,
+            key="sb_transverse_width",
+            help=(
+                "Localization half-width: the Gaussian 1/e length for "
+                "'gaussian_decay' and the ellipse half-width for "
+                "'elliptical' (ignored by 'uniform'/'sinusoidal_y'). "
+                "0 (auto) resolves to span_y / 4."
+            ),
+        )
+        # 0 is the "auto" sentinel -> hand None to AnalysisConfig.
+        transverse_span = (
+            float(transverse_span_ui) if transverse_span_ui > 0 else None
+        )
+        transverse_width = (
+            float(transverse_width_ui) if transverse_width_ui > 0 else None
+        )
+        if _transverse_ui_active:
+            st.caption(
+                f"Through-width variation active (mode = {transverse_mode}) — "
+                "forces the full FE path. The cross-section preview is an "
+                "x–z slice, so this y-effect is not drawn there."
+            )
     else:
         # Sensible defaults; the cartoon and morphology selector are exposed
         # in Expert mode for users who want to compare phase offsets.
@@ -1132,6 +1388,9 @@ with st.sidebar:
         amplitude_profile = DEFAULT_AMPLITUDE_PROFILE
         amplitude_profile_decay_length = None
         amplitude_profile_axis = DEFAULT_AMPLITUDE_PROFILE_AXIS
+        transverse_mode = DEFAULT_TRANSVERSE_MODE
+        transverse_span = None
+        transverse_width = None
         # Surface resin pockets depend on the expert-only FE solve, so the
         # novice path leaves them off with the contract defaults.
         enable_surface_pockets = DEFAULT_ENABLE_SURFACE_POCKETS
@@ -1424,6 +1683,26 @@ with st.sidebar:
     # the Analytical-only checkbox).
     _surface_pockets_active = _legacy_pockets_active
 
+    # ------------------------------------------------------------------
+    # Through-width transverse envelope compatibility gate (#300 / #375).
+    # A non-uniform transverse mode is FE-only and cannot combine with CZM
+    # (rejected at AnalysisConfig construction). Mirror the tool_flat UX:
+    # when the combo is incompatible, warn and DON'T thread the flags (so a
+    # run can never build an invalid config); otherwise mark it threaded so
+    # ``_assemble_cfg_payload`` carries it and the effective analytical-only
+    # flag is forced off (a non-uniform mode requires the FE path).
+    # ------------------------------------------------------------------
+    _transverse_active = transverse_mode != "uniform"
+    _transverse_incompatible = _transverse_active and bool(enable_czm)
+    _transverse_threaded = _transverse_active and not _transverse_incompatible
+    if _transverse_incompatible:
+        st.warning(
+            "Through-width transverse modes are FE-only and cannot combine "
+            "with Cohesive Zone Modeling (rejected at config construction). "
+            "Disable CZM or set **Transverse mode** to *uniform*. The "
+            "transverse envelope is ignored for this run."
+        )
+
     run_disabled = bool(mesh_diag is not None and mesh_diag.will_invert)
     run_clicked = st.button(
         "Run analysis",
@@ -1480,9 +1759,18 @@ with st.sidebar:
 # ---------------------------------------------------------------------------
 
 
-@st.cache_data(show_spinner=False)
-def run_analysis_cached(cfg_payload: tuple) -> dict:
-    """Cached analysis run. cfg_payload is a hashable tuple of config items."""
+def _config_from_payload(cfg_payload: tuple) -> AnalysisConfig:
+    """Build an :class:`AnalysisConfig` from a sidebar ``cfg_payload`` tuple.
+
+    Single source of truth for turning the hashable sidebar payload (the
+    ``angles_tuple`` / ``material_tuple`` shapes assembled by
+    :func:`_assemble_cfg_payload`) into a real :class:`AnalysisConfig`.
+    Shared by :func:`run_analysis_cached` (which solves on it) and the
+    sidebar **Download config** button (which serialises it via
+    :meth:`AnalysisConfig.to_json`), so a downloaded case file is exactly
+    the config a run would use and round-trips with the CLI ``--config`` /
+    ``--save-config`` flags.
+    """
     cfg_dict = dict(cfg_payload)
     angles = list(cfg_dict.pop("angles_tuple"))
     material_dict = dict(cfg_dict.pop("material_tuple"))
@@ -1526,7 +1814,24 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             surface_pocket_side=cfg_dict.get("surface_pocket_side", "top"),
         )
 
-    cfg = AnalysisConfig(
+    # Through-width transverse envelope (#300 / #375). Only threaded when a
+    # non-uniform mode is active — the sidebar refuses to add these keys for
+    # an incompatible combo (CZM / analytical-only), so a payload carrying a
+    # non-uniform ``transverse_mode`` is always FE-path and valid. ``span`` /
+    # ``width`` travel only when the user pinned them (``None`` = auto).
+    transverse_kwargs: dict = {}
+    if cfg_dict.get("transverse_mode", "uniform") != "uniform":
+        transverse_kwargs["transverse_mode"] = cfg_dict["transverse_mode"]
+        if cfg_dict.get("transverse_span") is not None:
+            transverse_kwargs["transverse_span"] = float(
+                cfg_dict["transverse_span"]
+            )
+        if cfg_dict.get("transverse_width") is not None:
+            transverse_kwargs["transverse_width"] = float(
+                cfg_dict["transverse_width"]
+            )
+
+    return AnalysisConfig(
         amplitude=cfg_dict["amplitude"],
         wavelength=cfg_dict["wavelength"],
         width=cfg_dict["width"],
@@ -1548,7 +1853,15 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
         analytical_only=cfg_dict["analytical_only"],
         **czm_kwargs,
         **surface_pocket_kwargs,
+        **transverse_kwargs,
     )
+
+
+@st.cache_data(show_spinner=False)
+def run_analysis_cached(cfg_payload: tuple) -> dict:
+    """Cached analysis run. cfg_payload is a hashable tuple of config items."""
+    cfg_dict = dict(cfg_payload)
+    cfg = _config_from_payload(cfg_payload)
     result = WrinkleAnalysis(cfg).run(
         analytical_only=cfg_dict["analytical_only"],
     )
@@ -1901,6 +2214,17 @@ def _assemble_cfg_payload(
     elif _surface_pockets_active:
         cfg_items["enable_surface_resin_pockets"] = True
         cfg_items["surface_pocket_side"] = surface_pocket_side
+    # Through-width transverse envelope (#300 / #375). Only threaded for a
+    # compatible non-uniform mode (the gate above clears ``_transverse_threaded``
+    # for the CZM combo), so a payload carrying ``transverse_mode`` is always a
+    # valid FE-path config. ``span`` / ``width`` travel only when pinned (a 0
+    # sentinel resolved to ``None``), keeping the default cache key untouched.
+    if _transverse_threaded:
+        cfg_items["transverse_mode"] = transverse_mode
+        if transverse_span is not None:
+            cfg_items["transverse_span"] = float(transverse_span)
+        if transverse_width is not None:
+            cfg_items["transverse_width"] = float(transverse_width)
     return tuple(sorted(cfg_items.items()))
 
 
@@ -1915,10 +2239,87 @@ def _live_cfg_payload() -> tuple | None:
             bool(analytical_only)
             and not bool(enable_czm)
             and not _surface_pockets_active
+            and not _transverse_threaded
         )
         return _assemble_cfg_payload(_live_layup, _live_effective_ao)
     except Exception:
         return None
+
+
+def _current_config_json() -> str | None:
+    """Serialise the current effective config from the live sidebar state.
+
+    Builds the same payload a run would use (:func:`_live_cfg_payload`) and
+    turns it into an :class:`AnalysisConfig` via :func:`_config_from_payload`,
+    so the downloaded file is exactly the config the current inputs describe
+    and works before any run. Returns ``None`` when the inputs can't be
+    assembled into a valid config (e.g. a half-typed layup), so the download
+    button can disable itself instead of crashing.
+    """
+    payload = _live_cfg_payload()
+    if payload is None:
+        return None
+    try:
+        return _config_from_payload(payload).to_json()
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Config file I/O UI (issue #375). Rendered as a second sidebar block — it
+# lives after ``_live_cfg_payload`` / ``_config_from_payload`` are defined so
+# the download can serialise the live effective config. Appears at the bottom
+# of the sidebar (below Reset).
+# ---------------------------------------------------------------------------
+with st.sidebar:
+    if st.session_state.pop("_config_loaded_toast", False):
+        st.success("Config loaded into the sidebar.")
+    with st.expander("Config file (save / load)", expanded=False):
+        _cfg_json = _current_config_json()
+        # Stash the serialised effective config so the download reflects the
+        # exact bytes and the round-trip is inspectable (also used by tests).
+        st.session_state["_effective_config_json"] = _cfg_json
+        st.download_button(
+            "Download config (JSON)",
+            data=(_cfg_json or "{}").encode("utf-8"),
+            file_name="wrinklefe_config.json",
+            mime="application/json",
+            disabled=_cfg_json is None,
+            width="stretch",
+            help=(
+                "Save the current sidebar settings as a portable "
+                "AnalysisConfig JSON. Round-trips with the CLI "
+                "`--config` / `--save-config` flags and can be re-loaded "
+                "below. Works before running an analysis."
+            ),
+        )
+        _uploaded_cfg = st.file_uploader(
+            "Load config (JSON / YAML)",
+            type=["json", "yaml", "yml"],
+            help=(
+                "Load a saved AnalysisConfig (from this app or the CLI "
+                "`--save-config`) back into the sidebar. Expert mode is "
+                "switched on so every loaded control is visible."
+            ),
+        )
+        if _uploaded_cfg is not None and _uploaded_cfg.file_id != (
+            st.session_state.get("_config_upload_id")
+        ):
+            # Mark this upload processed up front so a parse error doesn't
+            # re-fire the error on every rerun.
+            st.session_state["_config_upload_id"] = _uploaded_cfg.file_id
+            try:
+                _loaded_cfg = _parse_uploaded_config(
+                    _uploaded_cfg.name, _uploaded_cfg.getvalue()
+                )
+            except Exception as _exc:
+                st.error(f"Could not load config: {_exc}")
+            else:
+                # Stage for the top-of-sidebar seeding block, then rerun so
+                # the widgets pick up the loaded values before they render
+                # (avoids the set-after-instantiate error).
+                st.session_state["_pending_config"] = _loaded_cfg
+                st.rerun()
 
 
 # Run handler — execute BEFORE tabs render so the Analyze tab's results
@@ -1967,15 +2368,16 @@ if run_clicked or _demo_pending:
             st.error(f"Invalid custom material: {e}")
             st.stop()
 
-        # CZM and surface resin pockets are both FE-only material effects;
-        # force analytical_only off when either is enabled regardless of the
-        # *Analytical only* checkbox so the user can't accidentally request
-        # a run that would silently drop (CZM) or reject in validation
-        # (surface pockets) the feature.
+        # CZM, surface resin pockets, and a non-uniform transverse envelope
+        # are all FE-only effects; force analytical_only off when any is
+        # enabled regardless of the *Analytical only* checkbox so the user
+        # can't accidentally request a run that would silently drop (CZM) or
+        # reject in validation (surface pockets / transverse) the feature.
         _effective_analytical_only = (
             bool(analytical_only)
             and not bool(enable_czm)
             and not _surface_pockets_active
+            and not _transverse_threaded
         )
 
         cfg_payload = _assemble_cfg_payload(layup, _effective_analytical_only)

--- a/tests/test_app_config_io.py
+++ b/tests/test_app_config_io.py
@@ -1,0 +1,296 @@
+"""Tests for the Streamlit app's config upload/download and the through-width
+transverse controls (issue #375 app slice).
+
+Two layers of coverage:
+
+1. Pure-function tests import ``app`` and exercise the seeding / parsing
+   helpers directly with plain dicts (the same headless pattern as
+   ``test_app_reset_inputs``).
+2. ``AppTest`` drives the real Streamlit script to confirm the download
+   serialises a round-trippable config, an uploaded config seeds the
+   sidebar widgets, the transverse controls appear in Expert mode and
+   thread into the run config, and an incompatible combo warns without
+   crashing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``app.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+
+import matplotlib  # noqa: E402
+
+pytestmark = pytest.mark.viz
+
+matplotlib.use("Agg")
+
+
+def _app_path() -> str:
+    return str(_REPO_ROOT / "app.py")
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    import app as app_module  # noqa: WPS433 - test-time import.
+    return app_module
+
+
+# ---------------------------------------------------------------------------
+# Pure-function coverage: parse + seed helpers.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_uploaded_config_roundtrips_json(app_module):
+    """A JSON dump from ``to_json`` parses back to an equal config."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig(amplitude=0.42, wavelength=18.0, morphology="uniform")
+    parsed = app_module._parse_uploaded_config(
+        "case.json", cfg.to_json().encode("utf-8")
+    )
+    assert parsed.to_dict() == cfg.to_dict()
+
+
+def test_parse_uploaded_config_bad_json_raises(app_module):
+    """A malformed / unknown-key file raises ``ValueError`` (surfaced as
+    ``st.error`` by the sidebar, never a crash)."""
+    with pytest.raises(Exception):
+        app_module._parse_uploaded_config("case.json", b"{not valid json")
+    # Valid JSON but an unknown key -> AnalysisConfig.from_dict rejects it.
+    payload = json.dumps(
+        {"config_version": "1", "not_a_field": 3}
+    ).encode("utf-8")
+    with pytest.raises(ValueError):
+        app_module._parse_uploaded_config("case.json", payload)
+
+
+def test_seed_state_from_config_maps_fields(app_module):
+    """``_seed_state_from_config`` is the inverse of the sidebar mapping."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.layup import parse_layup
+
+    cfg = AnalysisConfig(
+        amplitude=0.5,
+        wavelength=22.0,
+        width=9.0,
+        morphology="graded",
+        decay_floor=0.3,
+        loading="tension",
+        applied_strain=0.02,
+        angles=[0, 45, -45, 90, 90, -45, 45, 0],
+        ply_thickness=0.2,
+        transverse_mode="gaussian_decay",
+        transverse_span=16.0,
+        transverse_width=3.0,
+        analytical_only=False,
+        nx=10,
+        ny=8,
+        nz_per_ply=2,
+    )
+    state: dict[str, object] = {}
+    app_module._seed_state_from_config(cfg, state)
+
+    assert state["expert_mode"] is True
+    assert state["sb_amplitude"] == 0.5
+    assert state["sb_wavelength"] == 22.0
+    assert state["sb_width"] == 9.0
+    assert state["sb_morphology"] == "graded"
+    assert state["sb_decay_floor"] == 0.3
+    assert state["sb_loading"] == "tension"
+    # Loading sign lives on the radio; magnitude on the number input.
+    assert state["sb_strain_mag_pct"] == pytest.approx(2.0)
+    assert parse_layup(state["sb_layup"]) == [0, 45, -45, 90, 90, -45, 45, 0]
+    assert state["sb_ply_thickness"] == 0.2
+    assert state["sb_transverse_mode"] == "gaussian_decay"
+    assert state["sb_transverse_span"] == 16.0
+    assert state["sb_transverse_width"] == 3.0
+    assert state["sb_analytical_only"] is False
+    assert state["sb_nx"] == 10
+    assert state["sb_ny"] == 8
+    assert state["sb_nz_per_ply"] == 2
+
+
+def test_seed_state_auto_transverse_sentinels(app_module):
+    """A ``None`` transverse span/width seeds the 0 = auto sentinel."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig(
+        morphology="uniform",
+        transverse_mode="sinusoidal_y",
+        analytical_only=False,
+    )
+    state: dict[str, object] = {}
+    app_module._seed_state_from_config(cfg, state)
+    assert state["sb_transverse_span"] == 0.0
+    assert state["sb_transverse_width"] == 0.0
+
+
+def test_seed_state_preset_material(app_module):
+    """A library-preset material selects the matching dropdown entry."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.material import MaterialLibrary
+
+    name = app_module.MATERIAL_NAMES[0]
+    cfg = AnalysisConfig(material=MaterialLibrary().get(name))
+    state: dict[str, object] = {"custom_E1": 999.0}
+    app_module._seed_state_from_config(cfg, state)
+    assert state["sb_material"] == name
+    # Stale custom editor keys are cleared on a preset load.
+    assert "custom_E1" not in state
+
+
+def test_seed_state_custom_material(app_module):
+    """A tweaked (custom) material routes through the custom editor keys."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.material import MaterialLibrary
+
+    base = MaterialLibrary().get(app_module.MATERIAL_NAMES[0]).to_dict()
+    base["E1"] = base["E1"] * 1.10  # tweak -> no longer a preset
+    base["name"] = "my_custom"
+    from wrinklefe.core.material import OrthotropicMaterial
+
+    cfg = AnalysisConfig(material=OrthotropicMaterial.from_dict(base))
+    state: dict[str, object] = {}
+    app_module._seed_state_from_config(cfg, state)
+    assert state["sb_material"] == app_module.CUSTOM_MATERIAL_LABEL
+    assert state["sb_custom_name"] == "my_custom"
+    assert state["custom_E1"] == pytest.approx(base["E1"])
+
+
+def test_seed_state_clamps_out_of_range(app_module):
+    """A physically valid but out-of-widget-range value is clamped so the
+    seeding cannot raise a StreamlitAPIException on the rerun."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig(amplitude=50.0, wavelength=500.0)  # exceed widget max
+    state: dict[str, object] = {}
+    app_module._seed_state_from_config(cfg, state)
+    assert state["sb_amplitude"] == 5.0  # clamped to the number_input max
+    assert state["sb_wavelength"] == 200.0
+
+
+# ---------------------------------------------------------------------------
+# AppTest coverage: real Streamlit script.
+# ---------------------------------------------------------------------------
+
+
+def test_download_config_button_present_and_roundtrips():
+    """The sidebar exposes a config-download button whose serialised bytes
+    round-trip through ``AnalysisConfig.from_dict`` (works before any run)."""
+    from streamlit.testing.v1 import AppTest
+
+    from wrinklefe.analysis import AnalysisConfig
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    labels = [b.label for b in at.button] + [
+        getattr(b, "label", None) for b in at.get("download_button")
+    ]
+    assert "Download config (JSON)" in labels
+
+    eff = at.session_state["_effective_config_json"]
+    assert eff is not None
+    # The default sidebar state serialises to a valid, parseable config.
+    AnalysisConfig.from_dict(json.loads(eff))
+
+
+def test_upload_seeds_widgets_and_roundtrips_config():
+    """Staging an uploaded config seeds the sidebar widgets, and the
+    re-serialised effective config equals the uploaded one (download ->
+    upload -> rebuild round-trip)."""
+    from streamlit.testing.v1 import AppTest
+
+    from wrinklefe.analysis import AnalysisConfig
+
+    cfg = AnalysisConfig(
+        amplitude=0.44,
+        wavelength=19.0,
+        morphology="uniform",
+        transverse_mode="gaussian_decay",
+        transverse_span=17.0,
+        transverse_width=4.0,
+        analytical_only=False,
+    )
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    # Simulate a parsed upload staged for the top-of-sidebar seeding block.
+    at.session_state["_pending_config"] = cfg
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    # Widgets reflect the loaded values.
+    assert at.session_state["sb_amplitude"] == pytest.approx(0.44)
+    assert at.session_state["sb_morphology"] == "uniform"
+    assert at.session_state["sb_transverse_mode"] == "gaussian_decay"
+    assert at.session_state["expert_mode"] is True
+
+    # The re-serialised effective config equals the uploaded one.
+    rebuilt = AnalysisConfig.from_dict(
+        json.loads(at.session_state["_effective_config_json"])
+    )
+    assert rebuilt.to_dict() == cfg.to_dict()
+
+
+def test_transverse_controls_thread_into_run_config():
+    """Selecting a non-uniform transverse mode in Expert mode threads
+    ``transverse_mode`` into the effective run config and forces the FE
+    path (analytical-only is overridden)."""
+    from streamlit.testing.v1 import AppTest
+
+    from wrinklefe.analysis import AnalysisConfig
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    at.toggle(key="expert_mode").set_value(True)
+    at.run()
+    at.selectbox(key="sb_morphology").set_value("uniform")
+    at.selectbox(key="sb_transverse_mode").set_value("gaussian_decay")
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    eff = AnalysisConfig.from_dict(
+        json.loads(at.session_state["_effective_config_json"])
+    )
+    assert eff.transverse_mode == "gaussian_decay"
+    # Non-uniform transverse is FE-only.
+    assert eff.analytical_only is False
+
+
+def test_transverse_czm_incompatible_warns_without_crash():
+    """A non-uniform transverse mode combined with CZM warns and does NOT
+    thread the transverse flags into an invalid config (no crash)."""
+    from streamlit.testing.v1 import AppTest
+
+    from wrinklefe.analysis import AnalysisConfig
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    at.toggle(key="expert_mode").set_value(True)
+    at.run()
+    at.selectbox(key="sb_morphology").set_value("uniform")
+    at.selectbox(key="sb_transverse_mode").set_value("gaussian_decay")
+    at.checkbox(key="sb_enable_czm").set_value(True)
+    at.run()
+    # The incompatible combo must not crash the script.
+    assert not at.exception, [str(e.value) for e in at.exception]
+    warnings = " ".join(w.value for w in at.warning)
+    assert "transverse" in warnings.lower()
+
+    # The effective config must stay valid: transverse is dropped, CZM wins.
+    eff = AnalysisConfig.from_dict(
+        json.loads(at.session_state["_effective_config_json"])
+    )
+    assert eff.transverse_mode == "uniform"
+    assert eff.enable_czm is True


### PR DESCRIPTION
## Linked issue

Fixes #375 (app slice — completes the issue; the CLI slice #382 already merged).

## Summary

Wires the `AnalysisConfig` file format into the Streamlit app and exposes the through-width transverse envelope, the two remaining app surfaces from #375. App/Streamlit only — no library-code or numeric-output changes.

**Config download.** A new sidebar **Config file** expander adds **Download config (JSON)** that serialises the current *effective* `AnalysisConfig` from the live sidebar state via `AnalysisConfig.to_json` — so it works before any run and round-trips with the CLI `--config` / `--save-config` flags. `_config_from_payload` was factored out of `run_analysis_cached` as the single source of truth for building an `AnalysisConfig` from a sidebar payload, so a downloaded file is exactly the config a run would use.

**Config upload → sidebar seeding.** An `st.file_uploader` parses the file via `AnalysisConfig.from_dict` (JSON or YAML; bad/unknown-key files surface an `st.error`, never a crash) and *seeds* the sidebar widgets — the inverse of `_assemble_cfg_payload`. The mechanism that avoids Streamlit's *"cannot be modified after the widget is instantiated"* error: on a new upload the parsed config is staged in `st.session_state["_pending_config"]` and `st.rerun()` is called; the seeding is then applied at the **very top of the sidebar, before any widget is instantiated**, exactly mirroring the existing Reset-button callback timing. Custom materials route through the `custom_*` editor keys, out-of-range values are clamped so seeding can't raise, and stale `results`/`cfg_payload` are cleared after a load.

**Transverse controls (#300 app exposure).** Expert mode gains a `transverse_mode` selectbox plus span/width inputs (a `0` = auto sentinel → `None`) near the morphology block, registered in `DEFAULTS` and threaded into both the run config and `_assemble_cfg_payload`/`_config_from_payload`. A non-uniform mode forces the FE path; the incompatible transverse+CZM combo shows a sidebar warning and is **not** threaded into an invalid config (mirrors the `tool_flat` UX).

**Round-trip.** A download → upload → seed → rebuild round-trip is asserted equal at the `to_dict` level (an `AppTest` seeds a config and checks the re-serialised effective config equals the original), plus the JSON parse round-trip and the field-by-field seeding map.

## Checklist

- [x] Tests added or updated for the change (`tests/test_app_config_io.py`; existing app tests still green)
- [x] `pytest` green — targeted app + config-io subset (84 passed); CI runs the full matrix
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean
- [x] Docs/README updated (README app-features note)
- [x] `CHANGELOG.md` `[Unreleased]` updated (under **Added**; notes this completes #375; no prediction-shifting change)
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_