### PR TITLE
solver: Newton/CZM convergence-failure diagnostics + actionable hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Solver — **Newton/CZM convergence-failure diagnostics + actionable hint**
+  (issue #262). A failed nonlinear solve used to return a bare
+  `converged: False`. `NewtonRaphsonSolver.solve()` now also returns
+  `failure_diagnostics` (first failing increment: index + load fraction,
+  iteration count, final `||R_phys||` / BC violation / `||du||`, the tail
+  of the residual history, line-search status, tangent-singular flag, and a
+  classified `failure_reason` ∈ {`tangent_singular`, `diverged`,
+  `stagnated`, `iteration_cap`}) and `failure_hint`, a single string naming
+  the knob to turn (`czm_n_load_increments`, `czm_newton_tol`, the applied
+  strain, `max_newton_iter`, or the arc-length roadmap). The `_newton_step`
+  tuple return is unchanged and the numerical path is untouched, so
+  converged results are bit-identical. `AnalysisResults` gains
+  `czm_failure_diagnostics` / `czm_failure_hint`; the CLI prints the hint to
+  stderr and the Streamlit CZM section shows it as an error on a
+  non-converged `--enable-czm` run.
 - App — **config upload/download and through-width transverse controls**
   (issue #375, app slice — *Fixes #375*, completing the issue). The
   Streamlit sidebar gains a **Config file** section: **Download config

--- a/README.md
+++ b/README.md
@@ -382,6 +382,27 @@ so a delamination can propagate crest-to-crest between neighbours
 (`examples/08_multi_wrinkle_czm_linkup.py` demonstrates the link-up
 vs far-separated contrast).
 
+#### When a CZM solve fails to converge
+
+CZM solves can fail for physical reasons — the tangent goes indefinite
+near peak load, the load steps are too coarse for the damage evolution,
+or the residual stagnates. When that happens the run still returns
+(partial) results with `czm_converged = False`, and the solver now
+classifies *why* and hands back one actionable hint. `AnalysisResults`
+carries `czm_failure_diagnostics` (increment index + load fraction,
+iteration count, final residual, residual history, line-search status)
+and `czm_failure_hint`; the CLI prints the hint to stderr and the
+Streamlit CZM section shows it as an error. The hint names the knob to
+turn:
+
+- **still decreasing at the iteration cap** → raise `max_newton_iter` or
+  loosen `czm_newton_tol`;
+- **stagnated / diverged** → increase `czm_n_load_increments` or reduce
+  the applied strain;
+- **tangent singular (post-peak snap-back)** → more load increments or a
+  smaller strain; displacement/arc-length control is the robust fix on
+  the roadmap.
+
 ### Uncertainty propagation (probabilistic analysis)
 
 Measured wrinkle geometry is uncertain — amplitude and wavelength come

--- a/app.py
+++ b/app.py
@@ -1985,6 +1985,7 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             "enabled": True,
             "converged": bool(result.czm_converged)
             if result.czm_converged is not None else None,
+            "failure_hint": result.czm_failure_hint,
             "interfaces_used": list(result.czm_interfaces_used or []),
             "max_damage": max_d,
             "n_elements_above_half": n_above_half,
@@ -2064,6 +2065,11 @@ def _render_czm_results(czm: dict) -> None:
             or not result_obj.czm_damage.size
         )
         if damage_missing:
+            # If the Newton-Raphson solve reported a failure, lead with the
+            # actionable tuning hint instead of the generic message.
+            hint = czm.get("failure_hint")
+            if czm.get("converged") is False and hint:
+                st.error(hint)
             st.warning(
                 "CZM was enabled but no damage data was produced — "
                 "the solver may have failed before the Newton-Raphson "
@@ -2116,6 +2122,19 @@ def _render_czm_results(czm: dict) -> None:
             f"Interfaces: "
             f"**{', '.join(str(i) for i in czm.get('interfaces_used', [])) or '(none)'}**"
         )
+
+        # Non-converged solve: surface the actionable tuning hint so the
+        # user learns which knob to turn rather than a bare "converged:
+        # False". Partial damage results above are still shown.
+        if czm.get("converged") is False:
+            st.error(
+                czm.get("failure_hint")
+                or (
+                    "The CZM solve did not converge. Try more load "
+                    "increments (czm_n_load_increments) or a looser Newton "
+                    "tolerance (czm_newton_tol)."
+                )
+            )
 
         # Per-interface crack-length table
         if crack_lengths:

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -2409,6 +2409,20 @@ class AnalysisResults:
     czm_converged: bool | None = None
     """Whether every load increment converged."""
 
+    czm_failure_diagnostics: dict | None = None
+    """Diagnostics record for the first load increment that failed to
+    converge (``None`` when the CZM solve converged or was not run).  Carries
+    the increment index / load fraction, iteration count, final residual /
+    BC-violation / step norms, the tail of the residual history, line-search
+    status, and a classified ``failure_reason``.  See
+    :meth:`wrinklefe.solver.nonlinear.NewtonRaphsonSolver._record_increment_diag`."""
+
+    czm_failure_hint: str | None = None
+    """A single actionable tuning hint derived from
+    :attr:`czm_failure_diagnostics` (``None`` when converged).  Names the knob
+    to reach for — ``czm_n_load_increments``, ``czm_newton_tol``, the applied
+    strain, or the Newton iteration cap."""
+
     czm_interfaces_used: list[int] | None = None
     """Ply-interface indices that actually received cohesive elements."""
 
@@ -2525,6 +2539,11 @@ class AnalysisResults:
                 f"    Energy dissipated: {energy:.4e} N*mm",
                 f"    Converged:         {self.czm_converged}",
             ])
+            # When the solve did not converge, surface the actionable
+            # tuning hint right below the convergence flag so a CLI /
+            # summary reader learns which knob to turn.
+            if self.czm_converged is False and self.czm_failure_hint:
+                lines.append(f"    Hint:              {self.czm_failure_hint}")
 
         lines.append("=" * 65)
         return "\n".join(lines)
@@ -3338,6 +3357,8 @@ class WrinkleAnalysis:
         outcome = solver.solve(verbose=cfg.verbose)
 
         results.czm_converged = bool(outcome.get("converged", False))
+        results.czm_failure_diagnostics = outcome.get("failure_diagnostics")
+        results.czm_failure_hint = outcome.get("failure_hint")
         results.czm_load_displacement = outcome.get(
             "load_displacement", None,
         )

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -1205,6 +1205,16 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     if enable_czm and result.czm_damage is not None and result.czm_damage.size:
         _print_czm_extras(result)
 
+    # A non-converged CZM solve is not an error (partial results are still
+    # returned), but the actionable tuning hint must be prominent on
+    # stderr rather than buried in the summary body.
+    if enable_czm and result.czm_converged is False and result.czm_failure_hint:
+        print(
+            f"warning: CZM solve did not fully converge — "
+            f"{result.czm_failure_hint}",
+            file=sys.stderr,
+        )
+
     # Optional CZM figure export.
     if enable_czm and given("save_czm_figure") and args.save_czm_figure is not None:
         if result.czm_damage is None or not result.czm_damage.size:

--- a/src/wrinklefe/io/results.py
+++ b/src/wrinklefe/io/results.py
@@ -258,6 +258,13 @@ def _knockdown_factors(results: AnalysisResults) -> dict:
         out["modulus_retention_failed"] = True
     if results.modulus_retention_global_failed:
         out["modulus_retention_global_failed"] = True
+    # CZM/Newton convergence-failure diagnostics — present only on a
+    # non-converged nonlinear solve (both None when converged), so they are
+    # absent and byte-identical for valid runs, preserving ledger zero-drift.
+    if results.czm_failure_diagnostics is not None:
+        out["czm_failure_diagnostics"] = results.czm_failure_diagnostics
+    if results.czm_failure_hint is not None:
+        out["czm_failure_hint"] = results.czm_failure_hint
     return out
 
 

--- a/src/wrinklefe/solver/nonlinear.py
+++ b/src/wrinklefe/solver/nonlinear.py
@@ -102,6 +102,19 @@ class NewtonRaphsonSolver:
         self.tol_displacement = float(tol_displacement)
         self.line_search = bool(line_search)
 
+        # Convergence-failure diagnostics (issue #262).  ``_increment_diag``
+        # holds a small record for the most recently *failed* increment
+        # (``None`` after a fully converged increment); ``solve()`` reads
+        # it to populate ``failure_diagnostics``.  The line-search status
+        # attributes are refreshed on every ``_backtracking_line_search``
+        # call so the diagnostics can report whether the last step
+        # exhausted its trial budget.  None of these participate in the
+        # numerical path — a converged run is bit-identical with or
+        # without them.
+        self._increment_diag: dict | None = None
+        self._ls_exhausted: bool = False
+        self._ls_last_alpha: float = 1.0
+
     # ------------------------------------------------------------------
     # Main solve
     # ------------------------------------------------------------------
@@ -121,6 +134,12 @@ class NewtonRaphsonSolver:
             ``increments_completed`` : number of increments completed.
             ``iteration_counts`` : list of Newton iterations used per
             increment (helpful for line-search comparison tests).
+            ``failure_diagnostics`` : diagnostics record for the first
+            increment that failed to converge (``None`` when every
+            increment converged).  See :meth:`_record_increment_diag` for
+            the field layout.
+            ``failure_hint`` : a single actionable tuning hint derived
+            from ``failure_diagnostics`` (``None`` when converged).
         """
         n_dof = self._n_dof()
         u = np.zeros(n_dof)
@@ -128,6 +147,7 @@ class NewtonRaphsonSolver:
         iteration_counts: list[int] = []
         converged_all = True
         completed = 0
+        failure_diag: dict | None = None
 
         constrained_full = self.bc_handler.get_constrained_dofs(
             self.boundary_conditions
@@ -151,12 +171,16 @@ class NewtonRaphsonSolver:
             F_ext_inc = lam * F_ext_full
 
             u_new, n_iter, ok = self._newton_step(
-                u, F_ext_inc, constrained_inc, verbose=verbose, inc=inc
+                u, F_ext_inc, constrained_inc, verbose=verbose, inc=inc,
+                load_fraction=lam,
             )
             iteration_counts.append(n_iter)
 
             if not ok:
                 converged_all = False
+                # ``_newton_step`` recorded the failing increment's
+                # diagnostics on the instance; capture the FIRST one.
+                failure_diag = self._increment_diag
                 logger.warning(
                     "Increment %d: Newton failed to converge.", inc
                 )
@@ -173,12 +197,18 @@ class NewtonRaphsonSolver:
             completed, self.n_increments, converged_all,
         )
 
+        failure_hint = (
+            None if converged_all else self._failure_hint(failure_diag)
+        )
+
         return {
             "displacement": u,
             "load_displacement": np.asarray(load_displacement, dtype=float),
             "converged": converged_all,
             "increments_completed": completed,
             "iteration_counts": iteration_counts,
+            "failure_diagnostics": failure_diag,
+            "failure_hint": failure_hint,
         }
 
     # ------------------------------------------------------------------
@@ -192,12 +222,25 @@ class NewtonRaphsonSolver:
         constrained_dofs: dict[int, float],
         verbose: bool,
         inc: int,
+        load_fraction: float = 1.0,
     ) -> tuple[np.ndarray, int, bool]:
         from wrinklefe.solver.boundary import _PENALTY_SCALE
 
         u = u_prev.copy()
         phys_0: float | None = None
         phys_ref: float = self.tol_absolute
+
+        # Convergence-failure diagnostics (issue #262).  Reset per
+        # increment; ``_increment_diag`` stays ``None`` unless one of the
+        # failure exits records a diagnostics dict.  ``residual_history``
+        # accumulates the free-DOF physical residual norm each iteration
+        # so a failed increment can be classified (diverging / stagnant /
+        # still-decreasing).  Purely observational — it does not feed the
+        # Newton update.
+        self._increment_diag = None
+        self._ls_exhausted = False
+        self._ls_last_alpha = 1.0
+        residual_history: list[float] = []
 
         # Build the constrained-DOF index/value arrays once per increment.
         # Used both for BC application and for the BC-violation half of
@@ -226,6 +269,9 @@ class NewtonRaphsonSolver:
         bc_tol = max(self.tol_displacement, penalty_floor) * val_scale
 
         diag_max: float = 1.0
+        # Last Newton step norm; carried out of the loop so the max-iter
+        # diagnostics can report it even though it is assigned inside.
+        du_norm: float = 0.0
 
         for it in range(1, self.max_newton_iter + 1):
             # One combined pass: assembler returns (K_t, F_int) computed
@@ -253,6 +299,7 @@ class NewtonRaphsonSolver:
             R_phys = R.copy()
             R_phys[dofs_arr] = 0.0
             phys_norm = float(np.linalg.norm(R_phys))
+            residual_history.append(phys_norm)
             # BC violation: how far the current u is from prescribed
             # values on constrained DOFs.
             if dofs_arr.size:
@@ -320,10 +367,22 @@ class NewtonRaphsonSolver:
                 du = spla.spsolve(K_bc, -R_bc)
             except RuntimeError:
                 self._revert_state()
+                self._record_increment_diag(
+                    inc=inc, load_fraction=load_fraction, n_iterations=it,
+                    phys_norm=phys_norm, bc_violation=bc_violation,
+                    du_norm=None, residual_history=residual_history,
+                    tangent_singular=True, failure_reason="tangent_singular",
+                )
                 return u, it, False
 
             if not np.all(np.isfinite(du)):
                 self._revert_state()
+                self._record_increment_diag(
+                    inc=inc, load_fraction=load_fraction, n_iterations=it,
+                    phys_norm=phys_norm, bc_violation=bc_violation,
+                    du_norm=None, residual_history=residual_history,
+                    tangent_singular=False, failure_reason="diverged",
+                )
                 return u, it, False
 
             alpha = 1.0
@@ -360,7 +419,159 @@ class NewtonRaphsonSolver:
                     return u, it, True
 
         self._revert_state()
+        # Max-iter fall-through: distinguish a still-decreasing residual
+        # (raise the iteration cap) from a stagnant/diverging one (needs
+        # smaller load steps) via the residual-history trend.
+        self._record_increment_diag(
+            inc=inc, load_fraction=load_fraction,
+            n_iterations=self.max_newton_iter,
+            phys_norm=phys_norm, bc_violation=bc_violation,
+            du_norm=du_norm, residual_history=residual_history,
+            tangent_singular=False,
+            failure_reason=self._classify_residual_trend(residual_history),
+        )
         return u, self.max_newton_iter, False
+
+    # ------------------------------------------------------------------
+    # Failure diagnostics (issue #262)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _classify_residual_trend(residual_history: list[float]) -> str:
+        """Classify a max-iteration failure from the residual history.
+
+        Looks at the last few free-DOF physical residual norms:
+
+        - strictly *increasing* over the window -> ``"diverged"``
+          (the Newton iteration is running away; smaller load steps or
+          a smaller applied strain are needed),
+        - roughly *flat* (final residual still above ~90 % of the window
+          start) -> ``"stagnated"`` (the step is too coarse for the
+          damage evolution),
+        - still *decreasing* meaningfully at the cap -> ``"iteration_cap"``
+          (the solve would likely converge with a higher iteration cap or
+          a looser tolerance).
+
+        With fewer than two samples the trend is undefined; default to
+        ``"iteration_cap"`` (the benign, cap-bound interpretation).
+        """
+        window = residual_history[-5:]
+        if len(window) < 2:
+            return "iteration_cap"
+        first = window[0]
+        last = window[-1]
+        if first <= 0.0:
+            return "iteration_cap"
+        if last > first:
+            return "diverged"
+        if last > 0.9 * first:
+            return "stagnated"
+        return "iteration_cap"
+
+    def _record_increment_diag(
+        self,
+        *,
+        inc: int,
+        load_fraction: float,
+        n_iterations: int,
+        phys_norm: float,
+        bc_violation: float,
+        du_norm: float | None,
+        residual_history: list[float],
+        tangent_singular: bool,
+        failure_reason: str | None,
+    ) -> None:
+        """Store a small diagnostics record for the current increment.
+
+        Fields (all JSON-friendly scalars/lists so the record can be
+        serialised into a results payload):
+
+        - ``increment`` / ``n_increments`` : 1-based increment index and
+          the total,
+        - ``load_fraction`` : fraction of the full load applied at this
+          increment,
+        - ``n_iterations`` : Newton iterations used,
+        - ``final_phys_norm`` / ``final_bc_violation`` / ``final_du_norm`` :
+          the last free-DOF physical residual, BC violation and step norm
+          (``final_du_norm`` is ``None`` at the singular/non-finite exits
+          where the step is unusable),
+        - ``residual_history`` : the last <=5 physical residual norms,
+        - ``line_search_exhausted`` / ``last_alpha`` : whether the last
+          line search used its whole trial budget and the alpha it landed
+          on,
+        - ``tangent_singular`` : whether the tangent factorisation failed,
+        - ``failure_reason`` : one of ``"tangent_singular"``,
+          ``"diverged"``, ``"stagnated"``, ``"iteration_cap"`` (or
+          ``None`` — reserved for a converged increment).
+        """
+        self._increment_diag = {
+            "increment": int(inc),
+            "n_increments": int(self.n_increments),
+            "load_fraction": float(load_fraction),
+            "n_iterations": int(n_iterations),
+            "final_phys_norm": float(phys_norm),
+            "final_bc_violation": float(bc_violation),
+            "final_du_norm": None if du_norm is None else float(du_norm),
+            "residual_history": [float(r) for r in residual_history[-5:]],
+            "line_search_exhausted": bool(self._ls_exhausted),
+            "last_alpha": float(self._ls_last_alpha),
+            "tangent_singular": bool(tangent_singular),
+            "failure_reason": failure_reason,
+        }
+
+    @staticmethod
+    def _failure_hint(diag: dict | None) -> str:
+        """Map a failure-diagnostics record to one actionable hint string.
+
+        The hint names the specific tunable knob to reach for
+        (``czm_n_load_increments``, ``czm_newton_tol``, the applied
+        strain, or ``max_newton_iter``) and folds in the numbers that
+        drove the classification so the user can judge how far off the
+        solve was.
+        """
+        if diag is None:
+            return (
+                "Nonlinear solve failed to converge. Try more load "
+                "increments (czm_n_load_increments), a looser Newton "
+                "tolerance (czm_newton_tol), or a smaller applied strain."
+            )
+        reason = diag.get("failure_reason")
+        i = diag.get("increment")
+        n = diag.get("n_increments")
+        pct = int(round(100.0 * float(diag.get("load_fraction", 0.0))))
+        rphys = float(diag.get("final_phys_norm", 0.0))
+        iters = diag.get("n_iterations")
+        where = f"increment {i}/{n} ({pct}% load)"
+        if reason == "tangent_singular":
+            return (
+                f"Tangent went singular at {where}, ||R||={rphys:.2e} — "
+                "likely post-peak snap-back. Increase czm_n_load_increments "
+                "or reduce the applied strain; displacement/arc-length "
+                "control is the robust fix (roadmap)."
+            )
+        if reason == "diverged":
+            return (
+                f"Residual diverged at {where} (||R||={rphys:.2e} after "
+                f"{iters} iterations) — reduce the applied strain or "
+                "increase czm_n_load_increments."
+            )
+        if reason == "stagnated":
+            return (
+                f"Residual stagnated at {where} (||R||={rphys:.2e} after "
+                f"{iters} iterations) — increase czm_n_load_increments or "
+                "loosen czm_newton_tol."
+            )
+        if reason == "iteration_cap":
+            return (
+                f"Hit the Newton iteration cap ({iters}) while the residual "
+                f"was still decreasing at {where} (||R||={rphys:.2e}) — "
+                "raise max_newton_iter or loosen czm_newton_tol."
+            )
+        return (
+            f"Newton failed to converge at {where} (||R||={rphys:.2e}). "
+            "Try more load increments (czm_n_load_increments) or a looser "
+            "Newton tolerance (czm_newton_tol)."
+        )
 
     # ------------------------------------------------------------------
     # Line search
@@ -394,11 +605,17 @@ class NewtonRaphsonSolver:
             )
             trial_norm = float(np.linalg.norm(R_trial_bc))
             if trial_norm < res_norm:
+                # A trial improved the residual — budget not exhausted.
+                self._ls_exhausted = False
+                self._ls_last_alpha = alpha
                 return alpha
             if i < max_trials - 1:
                 alpha *= shrink
         # No trial reduced the residual; return the last (smallest)
-        # tried alpha rather than an untested ``alpha * shrink``.
+        # tried alpha rather than an untested ``alpha * shrink``.  Flag
+        # the exhaustion so the failure diagnostics can surface it.
+        self._ls_exhausted = True
+        self._ls_last_alpha = alpha
         return alpha
 
     # ------------------------------------------------------------------

--- a/tests/test_app_czm.py
+++ b/tests/test_app_czm.py
@@ -250,3 +250,78 @@ def test_render_czm_results_handles_missing_damage(app_module):
     assert any("CZM" in t and "no damage" in t.lower() for t in warning_texts), (
         f"missing CZM-no-damage warning; saw warnings: {warning_texts!r}"
     )
+
+
+# ----------------------------------------------------------------------
+# 4. Non-converged CZM run surfaces the actionable failure hint (#262)
+# ----------------------------------------------------------------------
+
+
+def test_render_czm_results_shows_failure_hint_on_non_convergence():
+    """When the CZM solve did not converge, ``_render_czm_results`` must
+    surface the ``failure_hint`` in an error box — not just the generic
+    "converged: False"."""
+    from streamlit.testing.v1 import AppTest
+
+    from wrinklefe.analysis import AnalysisConfig, AnalysisResults
+
+    empty_result = AnalysisResults(
+        config=AnalysisConfig(),
+        morphology_factor=1.0,
+        max_angle_rad=0.0,
+        effective_angle_rad=0.0,
+        damage_index=0.0,
+        analytical_knockdown=1.0,
+        analytical_strength_MPa=1000.0,
+        gamma_Y_eff=0.05,
+        czm_damage=np.empty((0, 0)),
+    )
+    hint = (
+        "Residual diverged at increment 3/20 (15% load, ||R||=9.90e+03 "
+        "after 7 iterations) — reduce the applied strain or increase "
+        "czm_n_load_increments."
+    )
+    fake_results = {
+        "summary": "stub summary",
+        "loading": "tension",
+        "applied_strain_abs": 0.01,
+        "max_angle_deg": 0.0,
+        "effective_angle_deg": 0.0,
+        "morphology_factor": 1.0,
+        "gamma_Y_eff": 0.05,
+        "analytical_knockdown": 1.0,
+        "analytical_strength_MPa": 1000.0,
+        "damage_index": 0.0,
+        "tension_mechanisms": None,
+        "fe": None,
+        "czm": {
+            "enabled": True,
+            "converged": False,
+            "failure_hint": hint,
+            "interfaces_used": [3],
+            "max_damage": 0.0,
+            "n_elements_above_half": 0,
+            "energy_dissipated": 0.0,
+            "crack_length_per_interface": {},
+            "energy_per_interface": {},
+            "_result": empty_result,
+        },
+    }
+    fake_payload = (
+        ("amplitude", 0.3),
+        ("angles_tuple", (0, 45, -45, 90)),
+        ("material_tuple", tuple()),
+        ("wavelength", 16.0),
+    )
+
+    at = AppTest.from_file(_app_path(), default_timeout=30)
+    at.session_state["results"] = fake_results
+    at.session_state["cfg_payload"] = fake_payload
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    error_texts = [e.value for e in at.error]
+    assert any("diverged" in t and "czm_n_load_increments" in t
+               for t in error_texts), (
+        f"failure hint not surfaced as an error; saw errors: {error_texts!r}"
+    )

--- a/tests/test_io/test_export_results.py
+++ b/tests/test_io/test_export_results.py
@@ -411,6 +411,15 @@ INTENTIONALLY_UNEXPORTED = {
         "diagnostic flag; emitted only when the global modulus-retention "
         "computation failed, absent for valid runs (#374)"
     ),
+    "czm_failure_diagnostics": (
+        "Newton/CZM convergence-failure diagnostics; results_to_dict emits it "
+        "only on a non-converged solve (None when converged), so it is absent "
+        "for valid runs (keeps the export byte-identical / zero-drift, #262)"
+    ),
+    "czm_failure_hint": (
+        "actionable tuning hint; emitted only on a non-converged CZM solve, "
+        "absent for valid runs (#262)"
+    ),
     "mesh": "heavy MeshData; summarised as the top-level 'mesh' block when present",
     "wrinkle_config": "WrinkleConfiguration object; geometry captured under config",
     "laminate": "Laminate object; layup captured under config.angles",

--- a/tests/test_solver/test_newton_diagnostics.py
+++ b/tests/test_solver/test_newton_diagnostics.py
@@ -1,0 +1,265 @@
+"""Convergence-failure diagnostics for :class:`NewtonRaphsonSolver` (#262).
+
+A failed nonlinear (CZM) solve used to surface only ``converged: False``.
+The solver now records a ``failure_diagnostics`` dict for the first failing
+increment and derives a single actionable ``failure_hint`` string.  These
+tests cover:
+
+1. The hint mapping (``_failure_hint``) and the residual-trend classifier
+   (``_classify_residual_trend``) — pure, fast, deterministic unit tests
+   that an ``iteration_cap`` diagnosis differs from a ``diverged`` one and
+   that each names the right tuning knob.
+2. A converged solve is unchanged: ``failure_diagnostics`` /
+   ``failure_hint`` are ``None`` and the displacement is bit-identical
+   across repeated runs.
+3. A deliberately under-incremented DCB (Mode-I) case fails and produces a
+   populated ``failure_diagnostics`` with an increment index and a
+   ``failure_reason`` from the enum (slow / integration).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from wrinklefe.solver.nonlinear import NewtonRaphsonSolver
+
+# ======================================================================
+# 1. Hint mapping + residual-trend classifier (fast unit tests)
+# ======================================================================
+
+_ITERATION_CAP_DIAG = {
+    "increment": 12,
+    "n_increments": 20,
+    "load_fraction": 0.6,
+    "n_iterations": 25,
+    "final_phys_norm": 3.2e-3,
+    "final_bc_violation": 1e-9,
+    "final_du_norm": 4e-4,
+    "residual_history": [1.0, 0.5, 0.2, 0.08, 0.03],
+    "line_search_exhausted": False,
+    "last_alpha": 1.0,
+    "tangent_singular": False,
+    "failure_reason": "iteration_cap",
+}
+
+_DIVERGED_DIAG = {
+    "increment": 3,
+    "n_increments": 20,
+    "load_fraction": 0.15,
+    "n_iterations": 7,
+    "final_phys_norm": 9.9e3,
+    "final_bc_violation": 2e-3,
+    "final_du_norm": None,
+    "residual_history": [1.0, 3.0, 12.0, 90.0, 9900.0],
+    "line_search_exhausted": True,
+    "last_alpha": 0.03125,
+    "tangent_singular": False,
+    "failure_reason": "diverged",
+}
+
+
+def test_hint_differs_between_iteration_cap_and_diverged():
+    """Acceptance #2: the hint string must change between an
+    iteration-cap failure and a divergence failure, and each must name the
+    knob appropriate to that failure mode."""
+    cap_hint = NewtonRaphsonSolver._failure_hint(_ITERATION_CAP_DIAG)
+    div_hint = NewtonRaphsonSolver._failure_hint(_DIVERGED_DIAG)
+
+    assert cap_hint != div_hint
+
+    # Iteration-cap: point the user at the iteration cap / tolerance.
+    assert "max_newton_iter" in cap_hint
+    assert "still decreasing" in cap_hint
+    # It should NOT tell them to reduce the applied strain (that is the
+    # divergence remedy, not the cap remedy).
+    assert "reduce the applied strain" not in cap_hint
+
+    # Divergence: point the user at smaller steps / applied strain.
+    assert "diverged" in div_hint.lower()
+    assert "czm_n_load_increments" in div_hint
+    assert "applied strain" in div_hint
+
+    # Both should locate the failing increment (index / total / % load).
+    assert "12/20" in cap_hint
+    assert "3/20" in div_hint
+
+
+def test_hint_tangent_singular_points_at_load_increments_and_roadmap():
+    diag = dict(_DIVERGED_DIAG, failure_reason="tangent_singular",
+                tangent_singular=True, increment=19, load_fraction=0.95)
+    hint = NewtonRaphsonSolver._failure_hint(diag)
+    assert "singular" in hint.lower()
+    assert "czm_n_load_increments" in hint
+    assert "arc-length" in hint
+    assert "19/20" in hint
+
+
+def test_hint_stagnated_points_at_load_increments_and_tol():
+    diag = dict(_ITERATION_CAP_DIAG, failure_reason="stagnated")
+    hint = NewtonRaphsonSolver._failure_hint(diag)
+    assert "stagnated" in hint.lower()
+    assert "czm_n_load_increments" in hint
+    assert "czm_newton_tol" in hint
+
+
+def test_hint_none_diag_is_generic_but_actionable():
+    hint = NewtonRaphsonSolver._failure_hint(None)
+    assert "czm_n_load_increments" in hint
+    assert "czm_newton_tol" in hint
+
+
+@pytest.mark.parametrize(
+    ("history", "expected"),
+    [
+        ([1.0, 3.0, 9.0, 27.0], "diverged"),        # strictly increasing
+        ([1.0, 0.99, 0.98, 0.97], "stagnated"),      # ~flat (>90% of start)
+        ([1.0, 0.5, 0.2, 0.05], "iteration_cap"),    # still decreasing fast
+        ([0.5], "iteration_cap"),                    # too few samples
+        ([0.0, 0.0], "iteration_cap"),               # degenerate zero start
+    ],
+)
+def test_classify_residual_trend(history, expected):
+    assert NewtonRaphsonSolver._classify_residual_trend(history) == expected
+
+
+# ======================================================================
+# 2. A converged solve is unchanged (acceptance #3)
+# ======================================================================
+
+class _Linear1DOFAssembler:
+    """Minimal linear spring assembler: F_int = K * u, constant tangent."""
+
+    def __init__(self, K: float) -> None:
+        self.K = float(K)
+
+        class _Mesh:
+            n_dof = 1
+
+        self.mesh = _Mesh()
+
+    def assemble_stiffness(self):
+        from scipy import sparse
+
+        return sparse.csc_matrix(np.array([[self.K]]))
+
+    def assemble_internal_force(self, u: np.ndarray) -> np.ndarray:
+        u = np.asarray(u, dtype=float).reshape(-1)
+        return np.array([self.K * float(u[0])])
+
+
+class _Single1DOFBCHandler:
+    def __init__(self, u_target: float) -> None:
+        self.u_target = float(u_target)
+
+        class _Mesh:
+            n_dof = 1
+
+        self.mesh = _Mesh()
+
+    def get_constrained_dofs(self, bcs):
+        return {0: self.u_target}
+
+    def get_force_dofs(self, bcs):
+        return np.zeros(1)
+
+
+def _make_converging_solver() -> NewtonRaphsonSolver:
+    return NewtonRaphsonSolver(
+        assembler=_Linear1DOFAssembler(K=1000.0),
+        bc_handler=_Single1DOFBCHandler(u_target=0.25),
+        n_increments=5,
+        max_newton_iter=25,
+        tol_residual=1e-8,
+        tol_displacement=1e-10,
+    )
+
+
+def test_converged_run_has_no_failure_record_and_is_bit_identical():
+    out_a = _make_converging_solver().solve()
+    out_b = _make_converging_solver().solve()
+
+    assert out_a["converged"] is True
+    assert out_a["failure_diagnostics"] is None
+    assert out_a["failure_hint"] is None
+    # The two new keys are additive; the converged displacement is
+    # unaffected by the diagnostics plumbing (bit-identical run to run).
+    assert out_a["displacement"].tolist() == out_b["displacement"].tolist()
+    assert float(out_a["displacement"][0]) == pytest.approx(0.25, rel=1e-6)
+
+
+# ======================================================================
+# 3. Under-incremented DCB fails with populated diagnostics (acceptance #1)
+# ======================================================================
+
+_VALID_REASONS = {"tangent_singular", "diverged", "stagnated", "iteration_cap"}
+
+
+def _load_dcb_module():
+    """Load the DCB integration module by path (the ``tests`` tree is not
+    an importable package, so a normal import will not resolve it)."""
+    dcb_path = (
+        Path(__file__).resolve().parents[1]
+        / "integration"
+        / "test_dcb_monotonic.py"
+    )
+    spec = importlib.util.spec_from_file_location("_dcb_monotonic", dcb_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_under_incremented_dcb_populates_failure_diagnostics():
+    """A DCB Mode-I opening driven to the full 20 mm ramp in just two
+    coarse increments, with a two-iteration Newton cap and a residual
+    tolerance below the penalty method's reachable floor, cannot
+    converge.  (Displacement control makes this benchmark otherwise very
+    hard to break with load-step coarsening alone — at a large opening
+    the cohesive elements fully fail and the residual settles — so we
+    also starve the Newton loop of iterations.)  The solve must report
+    ``converged=False`` plus a populated ``failure_diagnostics`` carrying
+    the failing increment index and a classified reason, and a non-empty
+    ``failure_hint``."""
+    from wrinklefe.solver.boundary import BoundaryHandler
+
+    dcb = _load_dcb_module()
+    mesh, cohesive_elements = dcb._build_dcb_mesh()
+    assembler = dcb._build_assembler(mesh, cohesive_elements)
+    bc_handler = BoundaryHandler(mesh)
+
+    solver = NewtonRaphsonSolver(
+        assembler=assembler,
+        bc_handler=bc_handler,
+        # Full 20 mm opening in TWO steps — a 10 mm/step jump straight
+        # through the cohesive law's softening branch.
+        boundary_conditions=dcb._build_bcs(mesh, dcb.DELTA_MAX),
+        n_increments=2,
+        max_newton_iter=2,
+        tol_residual=1e-30,
+        tol_absolute=1e-30,
+        tol_displacement=1e-30,
+        line_search=False,
+    )
+
+    out = solver.solve()
+
+    assert out["converged"] is False
+    diag = out["failure_diagnostics"]
+    assert diag is not None, "expected a populated failure_diagnostics record"
+    assert diag["failure_reason"] in _VALID_REASONS
+    assert 1 <= diag["increment"] <= 2
+    assert diag["n_increments"] == 2
+    assert 0.0 < diag["load_fraction"] <= 1.0
+    assert isinstance(diag["residual_history"], list)
+    assert diag["final_phys_norm"] >= 0.0
+
+    hint = out["failure_hint"]
+    assert isinstance(hint, str) and hint.strip()
+    # The hint locates the failing increment and names a real knob.
+    assert f"{diag['increment']}/2" in hint


### PR DESCRIPTION
## Linked issue

Fixes #262

## Summary

A failed nonlinear (CZM) solve used to surface exactly one bit: `converged: False`. There was no way — short of adding print statements to library code — to tell *which* increment failed or *why*, so a user staring at a dead run had no idea which of `czm_n_load_increments` / `czm_newton_tol` / applied strain / the iteration cap to turn.

This PR adds convergence-failure diagnostics and one actionable hint, and surfaces them in the CLI and Streamlit app. **Diagnostics only — the numerical path is untouched, so converged results are bit-identical** (validate.py ledger drift is 0.000 across every pinned case).

### Solver (`NewtonRaphsonSolver`)
- Accumulates a small per-increment free-DOF residual history, and on each of the three failure exits records a `_increment_diag` on the instance (the `_newton_step` tuple return is kept unchanged for backward-compat).
- `solve()` result dict gains two additive keys: `failure_diagnostics` (the **first** failing increment; `None` when converged) and `failure_hint` (`None` when converged). Every existing key is unchanged; a converged run's dict differs only by the two new `None` values.
- `_failure_hint(diag)` maps each `failure_reason` to one string naming the right knob and folding in the driving numbers (final `||R||`, iteration count, increment index / load %).

### `failure_reason` taxonomy
| reason | trigger | remedy the hint points at |
|---|---|---|
| `tangent_singular` | `spsolve` reported a singular/indefinite tangent | more `czm_n_load_increments` or smaller strain; displacement/arc-length control (roadmap) |
| `diverged` | non-finite `du`, or residual history strictly increasing | reduce applied strain or increase `czm_n_load_increments` |
| `stagnated` | max-iter with a roughly flat residual (final > 90 % of window start) | increase `czm_n_load_increments` or loosen `czm_newton_tol` |
| `iteration_cap` | max-iter while the residual was still decreasing | raise `max_newton_iter` or loosen `czm_newton_tol` |

### Example hint strings (iteration_cap vs diverged — they differ and name different knobs)
- **iteration_cap:** `Hit the Newton iteration cap (25) while the residual was still decreasing at increment 12/20 (60% load, ||R||=3.20e-03) — raise max_newton_iter or loosen czm_newton_tol.`
- **diverged:** `Residual diverged at increment 3/20 (15% load, ||R||=9.90e+03 after 7 iterations) — reduce the applied strain or increase czm_n_load_increments.`

### Surface (app / CLI)
- `AnalysisResults` gains `czm_failure_diagnostics` / `czm_failure_hint`, populated from the solver outcome in the CZM path.
- `AnalysisResults.summary()` appends a `Hint:` line under `Converged: False`.
- CLI prints the hint to **stderr** on a non-converged `--enable-czm` run (partial results are still returned — non-convergence is not a hard error, matching existing behavior).
- Streamlit CZM Results section shows the hint via `st.error` (both the normal and the no-damage-produced render paths), falling back to a generic message when no hint is attached.

## Non-goals
No arc-length / displacement-control implementation — the hint only points at that roadmap item. `ProgressiveDamageSolver`'s bare-bool result is a similar, separate gap and is left as a follow-up.

## Bit-identical guarantee
Converged runs are unaffected: the diagnostics list and dict are built only from already-computed norms and never feed the Newton update. `python scripts/validate.py` reports **zero drift** (all cases match the pinned baselines), and a converged unit test asserts `failure_diagnostics is None`, `failure_hint is None`, and a run-to-run bit-identical displacement.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (targeted: `tests/test_solver/` incl. new `test_newton_diagnostics.py`, `tests/integration/test_dcb_monotonic.py`, `tests/test_app_czm.py`, `tests/test_cli_czm.py`, `tests/test_analysis_czm.py` — CI runs the full matrix)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean
- [x] Docs/README updated (a "When a CZM solve fails to converge" note)
- [x] `CHANGELOG.md` `[Unreleased]` `### Added` updated (diagnostics only — no **Numerical results** entry)
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_