### PR TITLE
analysis: inverse goal-seek — find_critical_value / wrinklefe critical (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Analysis — **inverse goal-seek: maximum acceptable wrinkle amplitude**
+  (issue #280). New `wrinklefe.goalseek.find_critical_value(base_config, *,
+  parameter='amplitude', target_knockdown=…, …)` scans the resolved search
+  range, brackets the single sign change of `objective(parameter) - target`,
+  root-finds with `scipy.optimize.brentq`, and then **backs the answer off
+  to the safe side** so the returned value satisfies the criterion under a
+  real forward evaluation rather than merely to within the root tolerance.
+  Returns a `CriticalValueResult` with the critical value, the achieved
+  knockdown and strength, a ready-to-run `critical_config`, the full scan
+  curve and the evaluation ledger (`GoalSeekEvaluation` rows, with
+  `summary()` / `plot()`). The upper bound is derived from the laminate
+  thickness for amplitude and clamped by the tool_flat validation bound and
+  by `mesh_shear_diagnostics`' `amplitude_safe` on the FE path; search
+  direction and monotonicity are *measured* from a log-spaced scan, never
+  assumed; and the search refuses — with an actionable,
+  measurement-quoting message, never a scipy traceback — when the target is
+  never crossed (`no_crossing`), never met (`target_unreachable`), reached
+  by more than one root (`non_monotonic`, e.g. graded morphology vs
+  wavelength, whose measured curve is U-shaped with an interior minimum
+  near λ ≈ 3 mm), or unresolvable because the parameter is inert for the
+  configuration (`flat`). FE-only config features (CZM, resin pockets,
+  progressive damage, non-uniform transverse mode) force or refuse the FE
+  path rather than silently no-opping, and integer mesh/ply-count fields
+  are refused by name. Targets may be a knockdown factor or an absolute
+  strength in MPa. New `wrinklefe critical` subcommand
+  (`--parameter`/`--target-knockdown`/`--target-strength`/`--objective`/
+  `--bracket`/`--max-value`/`--scan-points`/`--rtol`/`--analytical-only`/
+  `--config`/`--save-config`/`--save-plot`/`--output-json`/`--output-csv`
+  plus the `converge`-style geometry flags), defaulting to the analytical
+  path (~25 evaluations, well under a second); exit 2 for bad input, 1 when
+  no acceptable limit exists in range. New `examples/09_acceptance_limit.py`.
+  The forward model is untouched (validation-ledger zero drift).
 - Solver — **iterative-solver controls reachable from `AnalysisConfig`**
   (issue #265). The CG/ILU knobs that were hardcoded in
   `StaticSolver._solve_iterative` are now config fields, plumbed through

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Public link, no account needed.
 - **Penetration gate (θ, D/T, z):** Closed-form two-parameter UD predictor `KD = 1 − (1 − KD_angle(θ))·S(D/T)·P(z)` with calibrated presets; zero FE cost (`wrinklefe.core.penetration_gate`)
 - **Linear buckling:** Geometric-stiffness eigenvalue solve (`LinearBucklingSolver`) with a microbuckling knockdown — verified structural-buckling infrastructure, but a homogenised-continuum eigenvalue does not capture the *fibre-scale* wrinkle knockdown (it gets the sign wrong: the bifurcation load *rises* with the wrinkle), so it is **not** the production UD predictor (the penetration gate is); see the [modelling findings](docs/wrinkle_modeling_findings.md)
 - **11 built-in laminate materials** (AS4/3501-6, IM7/8552, T300/914, T700/2510, AC318/S6C10 S-glass/epoxy, T800S/M21, IM10/8552, IM6G/3501-6 carbon/epoxy — the Hsiao & Daniel 1996 wavy-UD study, S-2 glass/epoxy, Kevlar-49/epoxy, plus `AC318_S6C10_vacbag` — the Li 2025 vacuum-bag realization, measured Xc=335.5 MPa, E1=50.8 GPa) plus an isotropic neat-epoxy card (`EPOXY_S6C10`) for the resin-pocket zone
+- **Inverse goal-seek (acceptance limits):** `wrinklefe.goalseek.find_critical_value` / `wrinklefe critical` answer the disposition question directly — the largest wrinkle amplitude (or any float config field) that still meets a target knockdown or allowable strength. The answer is backed off to the safe side and verified by a real forward run, and the search refuses with an actionable message when the curve admits no unique root
 - **Process-parallel sweeps:** `n_workers=N` on both sweep APIs and `wrinklefe sweep --parallel N` fan the independent per-point solves across CPU cores (results identical to and ordered like the sequential run)
 - **Comprehensive test suite** covering all modules (run `pytest` to see the current count)
 
@@ -509,6 +510,9 @@ wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
 # --max/--steps drive the variation over it. `compare` takes --config too.
 wrinklefe sweep --config ud_gate.json --parameter amplitude \
     --min 0.2 --max 0.9 --steps 6
+
+# Inverse: the largest amplitude that still meets a 0.85 knockdown
+wrinklefe critical --parameter amplitude --target-knockdown 0.85
 ```
 
 Through-width (transverse) wrinkle surfaces and the mesh/thickness knobs
@@ -639,6 +643,50 @@ wrinklefe stochastic --config case.json \
 
 These are model-**input-propagation** statistics, **not** CMH-17 A-/B-basis
 allowables (the printed summary carries the disclaimer).
+
+### Finding the maximum acceptable defect
+
+`wrinklefe critical` inverts the analysis: instead of "given this wrinkle,
+what is the knockdown?", it answers "given this allowable, what is the
+largest wrinkle we can accept?" — the number that goes into an inspection
+criterion or an NCR disposition. Pass `--target-knockdown` (a knockdown
+factor) or `--target-strength` (an absolute MPa allowable), optionally
+`--parameter` (any float `AnalysisConfig` field; default `amplitude`),
+`--objective`, `--bracket LO HI`, `--max-value`, `--scan-points` and
+`--rtol`. `--save-config` writes the config at the critical value — the
+run to attach to the disposition — and `--output-json` / `--output-csv`
+carry the scan curve and the full evaluation ledger.
+
+```bash
+# Compression: largest amplitude meeting a 0.85 knockdown
+wrinklefe critical --parameter amplitude --target-knockdown 0.85 \
+    --save-config limit.json
+
+# Tension, expressed as an absolute allowable instead
+wrinklefe critical --loading tension --target-strength 1020
+```
+
+**The returned value satisfies the criterion under a real forward
+evaluation, not merely to within the root tolerance.** `brentq` converges
+to a root, not to the side of it that satisfies the inequality, so the
+search backs the answer off toward safety and verifies it with an extra
+solve; the printed `Criterion satisfied:` line is that check.
+
+The search runs on the analytical path by default (about 25 forward
+evaluations, well under a second; `--bracket LO HI --scan-points 3` cuts
+it to about 15). `--no-analytical-only` forces the full FE pipeline, where
+each evaluation is 4 linear solves — minutes, not seconds. Root-finding is
+inherently sequential, so there is no `--parallel`.
+
+Neither monotonicity nor uniqueness is assumed: the direction is measured
+from a log-spaced scan of the search range, and when the target is never
+crossed (`no_crossing`), never met (`target_unreachable`), reached by more
+than one root (`non_monotonic` — e.g. `morphology="graded"` against
+`wavelength`, whose curve is U-shaped), or unresolvable because the
+parameter is inert for the configuration (`flat`), the search exits 1 with
+a message quoting the measurements behind the refusal — never a scipy
+traceback. "No crossing in range" is not an error: it means no defect size
+in range fails your criterion.
 
 ### Exporting results to CSV / JSON
 

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -3,8 +3,8 @@ wrinklefe.cli
 
 The ``wrinklefe`` command installed by the package
 (``[project.scripts]``). Subcommands: ``analyze``, ``compare``,
-``sweep``, ``converge``, ``materials``; run any of them with
-``--help`` for the full option reference.
+``sweep``, ``converge``, ``stochastic``, ``critical``, ``materials``;
+run any of them with ``--help`` for the full option reference.
 
 .. automodule:: wrinklefe.cli
    :members: main

--- a/docs/api/goalseek.rst
+++ b/docs/api/goalseek.rst
@@ -1,0 +1,7 @@
+wrinklefe.goalseek
+==================
+
+.. automodule:: wrinklefe.goalseek
+   :members: find_critical_value, CriticalValueResult, GoalSeekEvaluation
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -2,9 +2,9 @@ API reference
 =============
 
 The public surface of the package: the analysis orchestrator and its
-configuration, the convergence helper, the core geometry/material
-model, the finite-element solver layer, the failure criteria, export
-functions, and the CLI.
+configuration, the stochastic, convergence and goal-seek workflow
+helpers, the core geometry/material model, the finite-element solver
+layer, the failure criteria, export functions, and the CLI.
 
 .. toctree::
    :maxdepth: 1
@@ -12,6 +12,7 @@ functions, and the CLI.
    analysis
    stochastic
    convergence
+   goalseek
    core
    solver
    failure

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -83,6 +83,9 @@ wrinklefe analyze --amplitude 0.366 --wavelength 16 --morphology stack
 wrinklefe sweep --parameter amplitude --min 0.1 --max 0.5 --steps 8 \
     --no-analytical-only --parallel 4   # full-FE sweep on 4 processes
 wrinklefe converge --tolerance 0.01   # mesh-convergence study
+wrinklefe stochastic --distribution amplitude:normal:0.4:0.05 \
+    --n-samples 1000 --seed 11        # percentile knockdowns
+wrinklefe critical --target-knockdown 0.85   # maximum acceptable amplitude
 wrinklefe materials                   # list the material library
 ```
 
@@ -105,6 +108,7 @@ via `to_dict` / `from_dict` and `save_json` / `load_json`.
 The repository's `examples/` directory contains scripts for the common
 workflows — parametric sweeps, morphology comparison, CZM delamination,
 multi-wrinkle crest-to-crest delamination link-up, export round-trips,
-custom materials, mesh convergence — each with its
-expected runtime and output in the header. CI executes them all on
-every push.
+custom materials, mesh convergence, and deriving an acceptance limit
+(the maximum wrinkle amplitude that still meets a target knockdown) —
+each with its expected runtime and output in the header. CI executes
+them all on every push.

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -431,6 +431,50 @@ within ~15 %; the **DCB peak load over-predicts by ~35 %** (the bilinear
 law with no fibre-bridging R-curve), so that experimental test is marked
 `xfail` — an honest, documented partial match rather than a clean pass.
 
+### 5.2 Inverting the model — what monotonicity can and cannot be assumed
+
+The acceptance question ("what is the largest amplitude we can accept?")
+inverts every model above, and the inverse is only well posed where the
+forward curve is monotone. {func}`~wrinklefe.goalseek.find_critical_value`
+therefore **measures** the curve rather than assuming it.
+
+- **Amplitude.** $\mathrm{KD}(A)$ is monotonically decreasing at fixed
+  $\lambda$ on both pathways, so the acceptance limit is unique. For a
+  quasi-isotropic $[0/45/-45/90]_{3s}$ IM7/8552 laminate in compression
+  the curve also *saturates*: measured $\mathrm{KD} = 0.4242$ at
+  $A = 4.392$ mm, $0.4103$ at $A = 100$ mm and $0.4098$ at
+  $A = 10^{6}$ mm. That floor is a property of **this** layup — the
+  0° fraction $f_0$ bounds how much axial stiffness the misaligned plies
+  can lose — and is not a general law: on the same configuration
+  `modulus_knockdown` keeps falling well past it (0.332 at $A = 4.392$,
+  0.151 at $A = 10^{6}$), and a graded $[0]_{24}$ wrinkle at
+  $\lambda = 1$ mm, $A = 4.392$ mm reaches $\mathrm{KD} = 0.024$.
+- **Wavelength.** Monotonicity **fails** for `morphology="graded"`. The
+  through-thickness Gaussian widens with wavelength
+  ($\sigma_\text{eff} = \max(\lambda/2, A)$), so decreasing $\lambda$
+  raises $\theta_\text{eff}$ while narrowing the affected band. The
+  measured curve for $A = 0.5$ mm, $[0]_{24}$, `graded` is U-shaped with
+  an interior minimum near $\lambda \approx 3$ mm:
+
+  | $\lambda$ (mm) | 1 | 2 | 3 | 4 | 8 | 16 | 32 | 128 |
+  |---|---|---|---|---|---|---|---|---|
+  | KD | 0.443 | 0.144 | 0.123 | 0.134 | 0.228 | 0.508 | 0.796 | 0.955 |
+
+  A root-find that assumed monotonicity here would return whichever side
+  of the minimum it happened to bracket — a safe-sounding acceptance
+  limit for a configuration that fails catastrophically just inside it.
+- **Saturated parameters.** Under the penetration gate, knockdown can be
+  bit-exactly constant over a finite interval of `ply_thickness`, and a
+  near-surface wrinkle ($z = 0.042$) varies by only $1.4\times10^{-6}$
+  across three decades of amplitude. Neither admits a resolvable root.
+
+A scan proves neither monotonicity nor uniqueness — it only detects sign
+changes on the grid it evaluates. That is why the search refuses
+(`non_monotonic`, `flat`, `no_crossing`, `target_unreachable`) rather
+than returning a root it cannot justify, and why the grid is log-spaced:
+a linear grid over a wide range walks straight past an interior
+extremum.
+
 ## 6. Scope, calibration, and honest limitations
 
 - **Use the angle-based analytical models for multidirectional laminates,

--- a/examples/09_acceptance_limit.py
+++ b/examples/09_acceptance_limit.py
@@ -1,0 +1,104 @@
+"""Acceptance limit: the largest wrinkle amplitude that still passes.
+
+Inverts the forward model. Instead of "given this wrinkle, what is the
+knockdown?", this answers the question an NCR disposition is written
+around: "given this allowable, what is the largest wrinkle we can
+accept?" ``find_critical_value`` scans the resolved amplitude range,
+brackets the single crossing of ``knockdown - target``, root-finds it,
+and then backs the answer off to the safe side — so the value it returns
+satisfies the criterion under a real forward evaluation, not merely to
+within the root tolerance. The script re-runs the forward model at each
+answer to show that.
+
+Expected runtime: ~5 s (analytical-only).
+Expected output:  the scan table and the acceptance limit for KD >= 0.85
+                  and KD >= 0.60, each verified by a forward re-run, plus
+                  ``09_acceptance_limit.png``.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless-safe; remove to use an interactive backend
+import matplotlib.pyplot as plt
+import numpy as np
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.goalseek import find_critical_value
+
+base = AnalysisConfig(
+    amplitude=0.366, wavelength=16.0, width=12.0,
+    morphology="stack", loading="compression",
+)
+
+targets = (0.85, 0.60)
+answers = {}
+
+for target in targets:
+    result = find_critical_value(base, target_knockdown=target)
+    print("=" * 66)
+    print(f"Target: knockdown >= {target:.2f}")
+    print("=" * 66)
+    print(result.summary())
+    print()
+
+    if result.status != "converged":
+        # A refusal is a real outcome, not a crash: the message names the
+        # measurement behind it and the knob that has to move.
+        print(f"No acceptance limit returned ({result.status}).")
+        print(result.message)
+        print()
+        continue
+
+    # The guarantee, demonstrated: re-run the forward model at the
+    # returned config and check the criterion directly.
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    achieved = forward.analytical_knockdown
+    print(
+        f"Forward re-run at A = {result.critical_value:.6f} mm: "
+        f"knockdown {achieved:.6f} >= {target:.6f} -> "
+        f"{'PASS' if achieved >= target else 'FAIL'}"
+    )
+    print(
+        f"  (raw brentq root {result.critical_value_root:.6f} mm, "
+        f"backed off to the safe side)"
+    )
+    print(f"  predicted strength {forward.analytical_strength_MPa:.1f} MPa")
+    print()
+    answers[target] = result.critical_value
+
+# The inverse of example 02's figure: the same knockdown curve, read
+# horizontally from the allowable to the acceptance limit.
+amplitudes = np.linspace(0.0, 0.5, 41)
+curve = [
+    WrinkleAnalysis(
+        AnalysisConfig(
+            amplitude=float(a), wavelength=16.0, width=12.0,
+            morphology="stack", loading="compression",
+        )
+    ).run(analytical_only=True).analytical_knockdown
+    for a in amplitudes
+]
+
+fig, ax = plt.subplots(figsize=(7, 4.5))
+ax.plot(amplitudes, curve, "-", color="#1f77b4", label="knockdown")
+colors = {0.85: "#d62728", 0.60: "#2ca02c"}
+for target, amplitude in answers.items():
+    ax.axhline(target, color=colors[target], ls="--", lw=1.0)
+    ax.axvline(amplitude, color=colors[target], ls=":", lw=1.0)
+    ax.plot([amplitude], [target], "o", color=colors[target])
+    ax.annotate(
+        f"KD >= {target:.2f}  ->  A <= {amplitude:.4f} mm",
+        xy=(amplitude, target), xytext=(amplitude + 0.03, target + 0.03),
+        color=colors[target], fontsize=9,
+    )
+
+ax.set_xlabel("wrinkle half-amplitude A (mm)")
+ax.set_ylabel("strength knockdown")
+ax.set_title("Acceptance limit: largest amplitude meeting each allowable")
+ax.grid(True, alpha=0.3)
+ax.legend(loc="upper right", fontsize=9)
+fig.tight_layout()
+fig.savefig("09_acceptance_limit.png", dpi=150)
+print("Saved: 09_acceptance_limit.png")

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ so they cannot rot.
 | [`06_custom_material.py`](06_custom_material.py) | Defining an `OrthotropicMaterial` not in the preset library | ~1 s |
 | [`07_mesh_convergence.py`](07_mesh_convergence.py) | Mesh-convergence study (`mesh_convergence_study` / `wrinklefe converge`) | ~90 s |
 | [`08_multi_wrinkle_czm_linkup.py`](08_multi_wrinkle_czm_linkup.py) | Crest-to-crest delamination link-up between adjacent wrinkles (`wrinkles` + `enable_czm`) | ~5 s |
+| [`09_acceptance_limit.py`](09_acceptance_limit.py) | Maximum acceptable wrinkle amplitude for a target knockdown (`find_critical_value` / `wrinklefe critical`) | ~5 s |
 | [`transverse_wrinkle_knockdown.py`](transverse_wrinkle_knockdown.py) | Localized (through-width) vs uniform wrinkle knockdown (`transverse_mode`) | ~20 s |
 
 Run any of them from this directory with the package installed

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -2675,6 +2675,53 @@ def _sweep_run_one(
     return WrinkleAnalysis(cfg).run(analytical_only=analytical_only)
 
 
+def _replace_swept(
+    base_config: AnalysisConfig,
+    parameter: str,
+    value: float,
+    *,
+    analytical_only: bool | None = None,
+) -> AnalysisConfig:
+    """Clone *base_config* with *parameter* set to *value*.
+
+    Resets the ``domain_length`` sentinel when sweeping ``wavelength``
+    from a config that left it auto-derived (``domain_length ==
+    3 * wavelength``) — ``replace`` re-runs ``__post_init__`` but does
+    not clear un-passed fields, so a stale derived ``domain_length``
+    would silently hold the domain fixed while the wavelength moved.
+    An explicitly pinned ``domain_length`` is preserved untouched.
+
+    Shared by :meth:`WrinkleAnalysis.parametric_sweep` and
+    :mod:`wrinklefe.goalseek` so the two cannot diverge.
+
+    Parameters
+    ----------
+    base_config : AnalysisConfig
+        Configuration to clone.
+    parameter : str
+        Field name to override.
+    value : float
+        New value for *parameter*.
+    analytical_only : bool or None, optional
+        When not ``None``, bake this solve-path choice into the clone so
+        the returned config records the path it was actually run on.
+
+    Returns
+    -------
+    AnalysisConfig
+        Validated clone (``replace`` re-invokes ``__post_init__``).
+    """
+    overrides: dict[str, Any] = {parameter: value}
+    if (
+        parameter == "wavelength"
+        and base_config.domain_length == 3.0 * base_config.wavelength
+    ):
+        overrides["domain_length"] = 0.0
+    if analytical_only is not None:
+        overrides["analytical_only"] = analytical_only
+    return replace(base_config, **overrides)
+
+
 def _resolve_sweep_workers(n_workers: int) -> int:
     """Validate and resolve a sweep worker count (``0`` -> all cores)."""
     if not isinstance(n_workers, int) or isinstance(n_workers, bool):
@@ -3096,24 +3143,12 @@ class WrinkleAnalysis:
             )
         n_workers = _resolve_sweep_workers(n_workers)
 
-        # If domain_length was auto-derived from wavelength in the base
-        # config (i.e. user left it at the sentinel 0.0), we must reset
-        # it to the sentinel before each replace() so __post_init__
-        # re-derives it from the swept value. ``replace`` only invokes
-        # ``__post_init__``; it does not reset un-passed fields, so a
-        # previously-derived ``domain_length`` would otherwise stick.
-        reset_domain_length = (
-            parameter == "wavelength"
-            and "domain_length" in valid_field_names
-            and base_config.domain_length == 3.0 * base_config.wavelength
-        )
-
-        configs: list[AnalysisConfig] = []
-        for val in values:
-            overrides: dict[str, Any] = {parameter: val}
-            if reset_domain_length:
-                overrides["domain_length"] = 0.0
-            configs.append(replace(base_config, **overrides))
+        # ``_replace_swept`` owns the ``domain_length`` sentinel reset
+        # (auto-derived only — an explicitly pinned domain is kept), so
+        # the sweep and the goal-seek clone configs identically.
+        configs: list[AnalysisConfig] = [
+            _replace_swept(base_config, parameter, val) for val in values
+        ]
 
         if n_workers == 1:
             return [

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -12,6 +12,9 @@ Usage
     wrinklefe analyze --amplitude 0.366 --morphology concave --verbose
     wrinklefe compare --amplitude 0.366 --wavelength 16.0
     wrinklefe sweep --parameter amplitude --min 0.183 --max 0.549 --steps 5
+    wrinklefe converge --levels 4 --qoi max_fi
+    wrinklefe stochastic --distribution amplitude:normal:0.5:0.05
+    wrinklefe critical --parameter amplitude --target-knockdown 0.85
     wrinklefe materials
 """
 
@@ -53,6 +56,13 @@ _SWEEP_CONFIG_FLAGS = (
 _COMPARE_CONFIG_FLAGS = (
     "amplitude", "wavelength", "width", "amplitude_profile",
     "amplitude_profile_decay_length", "amplitude_profile_axis",
+)
+# Geometry flags on ``critical`` (issue #280). Same SUPPRESS invariant:
+# the search flags (--parameter/--target-*/--bracket/--rtol/...) are
+# runtime flags and keep ordinary defaults.
+_CRITICAL_CONFIG_FLAGS = (
+    "amplitude", "wavelength", "width", "morphology", "loading",
+    "material", "angles", "nx", "ny", "nz_per_ply", "applied_strain",
 )
 
 
@@ -949,6 +959,190 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # ------------------------------------------------------------------ #
+    # critical
+    # ------------------------------------------------------------------ #
+    p_critical = subparsers.add_parser(
+        "critical",
+        help="Inverse goal-seek: maximum acceptable defect size",
+        description=(
+            "Find the largest wrinkle amplitude (or any other float "
+            "AnalysisConfig field) that still meets a target knockdown or "
+            "allowable strength -- the number an inspection criterion or "
+            "an NCR disposition is written around. The answer is verified "
+            "by a real forward evaluation, and the search refuses with an "
+            "actionable message when the curve admits no unique root."
+        ),
+    )
+    p_critical.add_argument(
+        "--config", type=str, default=None, dest="config",
+        help=(
+            "Load the base AnalysisConfig from a JSON (or .yaml/.yml) file "
+            "-- laminate, material, mesh and gate. Any geometry flag given "
+            "on the same command line overrides the file value; flags left "
+            "off keep the file value."
+        ),
+    )
+    p_critical.add_argument(
+        "--amplitude", type=float, default=0.366,
+        help="Wrinkle half-amplitude A in mm (default: 0.366)",
+    )
+    p_critical.add_argument(
+        "--wavelength", type=float, default=16.0,
+        help="Wrinkle wavelength lambda in mm (default: 16.0)",
+    )
+    p_critical.add_argument(
+        "--width", type=float, default=12.0,
+        help="Wrinkle envelope width w in mm (default: 12.0)",
+    )
+    p_critical.add_argument(
+        "--morphology", type=str, default="stack",
+        choices=MORPHOLOGY_CHOICES,
+        help="Wrinkle morphology (default: stack)",
+    )
+    p_critical.add_argument(
+        "--loading", type=str, default="compression",
+        choices=["compression", "tension"],
+        help="Loading condition (default: compression)",
+    )
+    p_critical.add_argument(
+        "--material", type=str, default=None,
+        help="Material name from MaterialLibrary (default: IM7/8552)",
+    )
+    p_critical.add_argument(
+        "--angles", "--layup", type=str, default=None, dest="angles",
+        help="Layup, contracted (e.g. '[0/45/-45/90]s') or comma-separated",
+    )
+    p_critical.add_argument(
+        "--nx", type=int, default=12,
+        help="Elements along the length (default: 12; FE path only)",
+    )
+    p_critical.add_argument(
+        "--ny", type=int, default=6,
+        help="Elements across the width (default: 6; FE path only)",
+    )
+    p_critical.add_argument(
+        "--nz-per-ply", type=int, default=1, dest="nz_per_ply",
+        help="Elements per ply through-thickness (default: 1; FE path only)",
+    )
+    p_critical.add_argument(
+        "--strain", type=float, default=-0.01, dest="applied_strain",
+        help="Applied strain (default: -0.01)",
+    )
+    p_critical.add_argument(
+        "--parameter", type=str, default="amplitude",
+        help=(
+            "Float AnalysisConfig field to search (default: amplitude). "
+            "Integer mesh/ply-count fields are not root-findable -- use "
+            "'converge' or 'sweep' for those."
+        ),
+    )
+    _critical_target = p_critical.add_mutually_exclusive_group(required=True)
+    _critical_target.add_argument(
+        "--target-knockdown", type=float, default=None,
+        dest="target_knockdown",
+        help="Target knockdown factor in (0, 1), e.g. 0.85",
+    )
+    _critical_target.add_argument(
+        "--target-strength", type=float, default=None, metavar="MPA",
+        dest="target_strength_MPa",
+        help=(
+            "Target as an absolute strength in MPa; root-finds the "
+            "'strength_MPa' objective directly"
+        ),
+    )
+    p_critical.add_argument(
+        "--objective", type=str, default="knockdown",
+        choices=["knockdown", "strength_MPa", "modulus_knockdown",
+                 "onset_knockdown", "modulus_retention_global"],
+        help=(
+            "Quantity the target applies to (default: knockdown). "
+            "'onset_knockdown' is tension-only; "
+            "'modulus_retention_global' requires the FE path."
+        ),
+    )
+    p_critical.add_argument(
+        "--bracket", type=float, nargs=2, default=None, metavar=("LO", "HI"),
+        help=(
+            "Restrict the search to [LO, HI] instead of the auto-resolved "
+            "range. Both bounds are still clamped by the tool_flat and "
+            "mesh-inversion limits."
+        ),
+    )
+    p_critical.add_argument(
+        "--max-value", type=float, default=None, dest="max_value",
+        help="Upper search bound when --bracket is not given",
+    )
+    p_critical.add_argument(
+        "--scan-points", type=int, default=9, dest="scan_points",
+        help=(
+            "Points in the bounded scan that measures direction and "
+            "monotonicity (>= 3, default: 9)"
+        ),
+    )
+    p_critical.add_argument(
+        "--rtol", type=float, default=1e-3,
+        help="Relative tolerance on the searched parameter (default: 1e-3)",
+    )
+    p_critical.add_argument(
+        "--analytical-only", action=argparse.BooleanOptionalAction,
+        default=None, dest="analytical_only",
+        help=(
+            "Root-find on the analytical path only. Default: analytical "
+            "unless the config enables an FE-only feature (CZM, resin "
+            "pockets, progressive damage, non-uniform transverse mode), "
+            "which forces the FE path. Use --no-analytical-only to force "
+            "the full FE pipeline -- about 25 forward evaluations at the "
+            "default --scan-points 9, each one 4 linear solves. Pass "
+            "--bracket LO HI --scan-points 3 to cut that to about 15. "
+            "Root-finding is inherently sequential, so there is no "
+            "--parallel."
+        ),
+    )
+    p_critical.add_argument(
+        "--save-config", type=str, default=None, dest="save_config",
+        help=(
+            "Write the config at the critical value to this path -- the "
+            "run to attach to a disposition; the stdout summary is still "
+            "printed"
+        ),
+    )
+    p_critical.add_argument(
+        "--save-plot", type=str, default=None, dest="save_plot",
+        help=(
+            "Save the objective-vs-parameter scan plot to this path; the "
+            "stdout summary is still printed"
+        ),
+    )
+    p_critical.add_argument(
+        "--output-json", type=str, default=None, dest="output_json",
+        help=(
+            "Write the search result (critical value, scan curve, "
+            "evaluation ledger, critical_config) to a JSON file; the "
+            "stdout summary is still printed"
+        ),
+    )
+    p_critical.add_argument(
+        "--output-csv", type=str, default=None, dest="output_csv",
+        help=(
+            "Write one row per forward evaluation to a tidy CSV, matching "
+            "the 'sweep' schema; the stdout summary is still printed"
+        ),
+    )
+    p_critical.add_argument(
+        "-v", "--verbose", action="store_true", default=False,
+        help=(
+            "Show detailed pipeline progress (sets the 'wrinklefe' "
+            "logger to DEBUG with a stderr handler)"
+        ),
+    )
+    # Config-file precedence for the geometry flags (issue #375's
+    # invariant): a SUPPRESS default means ``vars(args)`` holds only the
+    # ones the user actually passed.
+    for _action in p_critical._actions:
+        if _action.dest in _CRITICAL_CONFIG_FLAGS:
+            _action.default = argparse.SUPPRESS
+
+    # ------------------------------------------------------------------ #
     # materials
     # ------------------------------------------------------------------ #
     subparsers.add_parser(
@@ -1784,6 +1978,313 @@ def _write_stochastic_outputs(prob, output_json, output_csv) -> None:
         print(f"\nResults written to: {path}")
 
 
+def _cmd_critical(args: argparse.Namespace) -> None:
+    """Handle the ``critical`` subcommand (issue #280).
+
+    Exit codes follow the file's convention: ``2`` when the user handed
+    us something we cannot use, ``1`` when the inputs were valid but the
+    search produced no answer (including a solver blow-up), ``0`` only
+    on a converged, forward-verified result.
+    """
+    import dataclasses
+
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.core.material import MaterialLibrary
+    from wrinklefe.goalseek import find_critical_value
+
+    # Pre-flight the search flags before burning any compute (#298).
+    if args.bracket is not None and args.bracket[0] >= args.bracket[1]:
+        print(
+            f"error: --bracket LO ({args.bracket[0]}) must be less than "
+            f"HI ({args.bracket[1]})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if args.scan_points < 3:
+        print(
+            f"error: --scan-points must be >= 3 (got {args.scan_points})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if args.analytical_only is False:
+        print(
+            "warning: FE root-finding runs about 25 full solves; expect "
+            "several minutes.",
+            file=sys.stderr,
+        )
+
+    present = vars(args)
+    geometry: dict = {}
+    for name in _CRITICAL_CONFIG_FLAGS:
+        if name not in present:
+            continue
+        value = getattr(args, name)
+        if name == "material":
+            geometry["material"] = (
+                None if value is None else MaterialLibrary().get(value)
+            )
+        elif name == "angles":
+            geometry["angles"] = _parse_angles(value)
+        else:
+            geometry[name] = value
+    geometry["verbose"] = args.verbose
+
+    try:
+        if args.config is not None:
+            base = AnalysisConfig.load(args.config)
+            config = dataclasses.replace(base, **geometry)
+        else:
+            config = AnalysisConfig(**geometry)
+    except (OSError, ValueError, KeyError, ImportError,
+            NotImplementedError) as exc:
+        print(f"error: invalid configuration: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # --output-csv needs the per-evaluation results; --output-json only
+    # embeds them on the analytical path, where they are cheap (an FE
+    # result carries mesh and field arrays).
+    keep_results = args.output_csv is not None or (
+        args.output_json is not None and args.analytical_only is not False
+    )
+    if args.output_csv is not None and args.analytical_only is False:
+        print(
+            "warning: --output-csv retains every FE result in memory "
+            "(~25 meshes).",
+            file=sys.stderr,
+        )
+
+    try:
+        result = find_critical_value(
+            config,
+            parameter=args.parameter,
+            target_knockdown=args.target_knockdown,
+            target_strength_MPa=args.target_strength_MPa,
+            objective=args.objective,
+            bracket=(
+                None if args.bracket is None
+                else (args.bracket[0], args.bracket[1])
+            ),
+            max_value=args.max_value,
+            scan_points=args.scan_points,
+            rtol=args.rtol,
+            analytical_only=args.analytical_only,
+            keep_results=keep_results,
+        )
+    except (AttributeError, TypeError, NotImplementedError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except ValueError as exc:
+        # Input errors from the goal-seek's validation phase are the
+        # user's problem (2); a LinAlgError from a forward solve is a
+        # ValueError subclass but is an analysis failure (1).
+        code = 1 if isinstance(exc, np.linalg.LinAlgError) else 2
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(code)
+    except Exception as exc:  # pragma: no cover - exercised via tests/CLI
+        print(f"error: critical-value search failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    _print_critical_banner(result, config)
+
+    if result.status != "converged":
+        print(f"error: {result.message}", file=sys.stderr)
+
+    if args.save_config is not None and result.critical_config is not None:
+        try:
+            result.critical_config.save(args.save_config)
+        except (OSError, ValueError, ImportError) as exc:
+            print(f"error: could not write --save-config: {exc}",
+                  file=sys.stderr)
+            sys.exit(2)
+        print(f"Critical configuration written to: {args.save_config}")
+
+    if args.save_plot is not None:
+        ax = result.plot()
+        ax.figure.savefig(args.save_plot)
+        print(f"\nSearch plot saved to: {args.save_plot}")
+
+    _write_critical_outputs(
+        result, config, args.output_json, args.output_csv
+    )
+
+    sys.exit(0 if result.status == "converged" else 1)
+
+
+def _print_critical_banner(result, config) -> None:
+    """Print the search banner, the scan table and the answer."""
+    path = "Analytical path" if result.analytical_only else "FE path"
+    print("=" * 60)
+    print(f"  WrinkleFE Critical-Value Search: {result.parameter}")
+    print(
+        f"  Morphology: {config.morphology} | Loading: {config.loading} "
+        f"| {path}"
+    )
+    print("=" * 60)
+    print()
+    unit = " MPa" if result.target_is_strength else ""
+    print(
+        f"  Objective: {result.objective_name} >= {result.target:.4f}"
+        f"{unit}   (direction: {result.direction})"
+    )
+    print(
+        f"  Range:     [{result.bounds[0]:.6f}, {result.bounds[1]:.6f}]  "
+        f"(lower: {result.bounds_source[0]}, "
+        f"upper: {result.bounds_source[1]})"
+    )
+    spacing = "log-spaced" if result.log_spaced else "linear-spaced"
+    print(
+        f"  Scan:      {len(result.scan_values)} points, {spacing}, "
+        f"{result.sign_changes} sign change"
+        f"{'' if result.sign_changes == 1 else 's'}"
+    )
+    print()
+    print(
+        f"  {result.parameter:>14} {'Knockdown':>12} "
+        f"{'Strength (MPa)':>16}   phase"
+    )
+    print("-" * 60)
+    for value, ev in zip(result.scan_values, result.scan_evaluations()):
+        print(
+            f"  {value:>14.4f} {ev.knockdown:>12.4f} "
+            f"{ev.strength_MPa:>16.1f}   {ev.phase}"
+        )
+    if result.critical_value is not None:
+        # The answer itself, marked so it stands out from the scan grid.
+        final = result.evaluations[-1]
+        print(
+            f"->{final.value:>14.4f} {final.knockdown:>12.4f} "
+            f"{final.strength_MPa:>16.1f}   {final.phase}"
+        )
+    print("-" * 60)
+    print()
+    if result.status == "converged":
+        extreme = "Largest" if result.direction == "decreasing" else "Smallest"
+        print(
+            f"  {extreme} acceptable {result.parameter}: "
+            f"{result.critical_value:.6f}"
+        )
+        print(
+            f"  Achieved {result.objective_name}:  "
+            f"{result.achieved_objective:.6f}  "
+            f"(target {result.target:.6f}, rtol {result.rtol:.1e})"
+        )
+        # The visible proof of the safe-side back-off: never format this
+        # to fewer digits than rtol implies.
+        print(
+            f"  Criterion satisfied: {result.objective_name} "
+            f"{result.achieved_objective:.6f} >= {result.target:.6f}"
+        )
+        if result.target_is_strength and result.pristine_reference_MPa:
+            print(
+                f"  Equivalent knockdown target: "
+                f"{result.target / result.pristine_reference_MPa:.6f} "
+                f"(pristine reference "
+                f"{result.pristine_reference_MPa:.1f} MPa)"
+            )
+    else:
+        print(f"  Status: {result.status} -- no acceptance limit returned")
+    print(
+        f"  Forward-model evaluations: {result.n_evaluations}   "
+        f"({result.runtime_s:.2f} s)"
+    )
+    print("=" * 60)
+
+
+def _write_critical_outputs(
+    result, config, output_json: str | None, output_csv: str | None
+) -> None:
+    """Write the critical-value search result to JSON and/or CSV."""
+    if output_json is None and output_csv is None:
+        return
+
+    import json
+    from pathlib import Path
+
+    from wrinklefe.io.export import analysis_results_to_dict
+
+    if output_json is not None:
+        payload = {
+            "parameter": result.parameter,
+            "objective": result.objective_name,
+            "target": float(result.target),
+            "target_is_strength": bool(result.target_is_strength),
+            "direction": result.direction,
+            "status": result.status,
+            "message": result.message,
+            "critical_value": (
+                None if result.critical_value is None
+                else float(result.critical_value)
+            ),
+            "critical_value_root": (
+                None if result.critical_value_root is None
+                else float(result.critical_value_root)
+            ),
+            "achieved_objective": (
+                None if result.achieved_objective is None
+                else float(result.achieved_objective)
+            ),
+            "achieved_knockdown": (
+                None if result.achieved_knockdown is None
+                else float(result.achieved_knockdown)
+            ),
+            "achieved_strength_MPa": (
+                None if result.achieved_strength_MPa is None
+                else float(result.achieved_strength_MPa)
+            ),
+            "pristine_reference_MPa": (
+                None if result.pristine_reference_MPa is None
+                else float(result.pristine_reference_MPa)
+            ),
+            "bounds": [float(b) for b in result.bounds],
+            "bounds_source": list(result.bounds_source),
+            "scan_values": [float(v) for v in result.scan_values],
+            "scan_objectives": [float(v) for v in result.scan_objectives],
+            "sign_changes": int(result.sign_changes),
+            "log_spaced": bool(result.log_spaced),
+            "rtol": float(result.rtol),
+            "analytical_only": bool(result.analytical_only),
+            "n_evaluations": int(result.n_evaluations),
+            "runtime_s": float(result.runtime_s),
+            "critical_config": (
+                None if result.critical_config is None
+                else result.critical_config.to_dict()
+            ),
+            "evaluations": [
+                {
+                    "index": int(ev.index),
+                    "value": float(ev.value),
+                    "objective": float(ev.objective),
+                    "knockdown": float(ev.knockdown),
+                    "strength_MPa": float(ev.strength_MPa),
+                    "residual": float(ev.residual),
+                    "phase": ev.phase,
+                    "runtime_s": float(ev.runtime_s),
+                }
+                for ev in result.evaluations
+            ],
+        }
+        if result.results is not None:
+            payload["runs"] = [
+                analysis_results_to_dict(r) for r in result.results
+            ]
+        path = Path(output_json)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nResults written to: {path}")
+
+    if output_csv is not None and result.results is not None:
+        # Delegate to the shared batch writer so the row schema matches
+        # 'sweep' / 'compare' / 'analyze' exactly.
+        _write_batch_outputs(
+            [
+                (result.parameter, float(ev.value), config.morphology, run)
+                for ev, run in zip(result.evaluations, result.results)
+            ],
+            None,
+            output_csv,
+        )
+
+
 def _configure_logging(verbose: bool) -> None:
     """Attach a stderr handler to the package logger for ``--verbose``.
 
@@ -1826,6 +2327,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         "sweep": _cmd_sweep,
         "converge": _cmd_converge,
         "stochastic": _cmd_stochastic,
+        "critical": _cmd_critical,
         "materials": _cmd_materials,
     }
 

--- a/src/wrinklefe/goalseek.py
+++ b/src/wrinklefe/goalseek.py
@@ -1,0 +1,1312 @@
+"""Inverse goal-seek: the largest defect that still meets a criterion.
+
+The whole analysis surface is forward-only — given a wrinkle, predict a
+knockdown.  The question a stress engineer is actually asked is the
+inverse: *"manufacturing found waviness here; what is the largest
+amplitude we can accept and still meet the allowable?"*  That number
+goes straight into an inspection criterion or an NCR disposition, so
+:func:`find_critical_value` automates the manual bisection loop it used
+to take — and, critically, **refuses to answer** when the answer would
+not be unique.
+
+The search is deliberately conservative.  ``brentq`` converges *to* a
+root, not to the side of it that satisfies the inequality, so the raw
+root routinely returns a value whose knockdown sits a hair *below* the
+target.  For an acceptance limit that is the wrong sign of wrong, so
+the search backs the answer off to the safe side and verifies it with a
+real forward evaluation: the reported ``critical_value`` satisfies
+``objective >= target`` under an actual solve, not merely to within the
+root tolerance.
+
+Neither monotonicity nor uniqueness is assumed.  The search direction is
+*measured* from a log-spaced scan of the resolved range, and when that
+scan shows more than one sign change, a direction reversal, or a curve
+too flat to resolve the target, the search returns a refusal status
+(``non_monotonic`` / ``flat`` / ``no_crossing`` / ``target_unreachable``)
+with an actionable, measurement-quoting message rather than an arbitrary
+root.  Knockdown *is* monotonically decreasing in amplitude, but it is
+**not** monotonic in wavelength for ``morphology='graded'`` — that curve
+is U-shaped with an interior minimum, and a naive root-find there would
+report a safe-sounding limit for a catastrophically failing geometry.
+
+Example
+-------
+>>> from wrinklefe.analysis import AnalysisConfig
+>>> from wrinklefe.goalseek import find_critical_value
+>>> result = find_critical_value(
+...     AnalysisConfig(amplitude=0.366, wavelength=16.0, width=12.0),
+...     parameter="amplitude", target_knockdown=0.85,
+... )                                                   # doctest: +SKIP
+>>> print(result.summary())                             # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field, fields
+
+import numpy as np
+from scipy.optimize import brentq
+
+from wrinklefe.analysis import (
+    AnalysisConfig,
+    AnalysisResults,
+    WrinkleAnalysis,
+    _replace_swept,
+)
+from wrinklefe.core.mesh import mesh_shear_diagnostics
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "GoalSeekEvaluation",
+    "CriticalValueResult",
+    "find_critical_value",
+]
+
+#: Number of scan points when *scan_points* is left at its default.
+DEFAULT_SCAN_POINTS: int = 9
+
+#: Log-spacing is used when the bound ratio exceeds this.
+LOG_SPACING_RATIO: float = 100.0
+
+#: SciPy's hard floor on ``rtol`` (``4 * eps``); validation clamps to it.
+MIN_RTOL: float = 4.0 * float(np.finfo(float).eps)
+
+#: Absolute floor on the ``brentq`` parameter tolerance.
+MIN_XTOL: float = 1e-12
+
+#: Maximum geometric back-off budget, as a fraction of the root.
+BACKOFF_BUDGET_RTOL_MULT: float = 1.0
+
+#: Config features that only exist on the FE path.  Each one either
+#: silently no-ops or raises under ``analytical_only=True``, so the
+#: solve-path resolution ladder treats them as FE-forcing (issue #346
+#: applies the same rule to ``wrinklefe analyze``).
+FE_ONLY_FEATURES: tuple[str, ...] = (
+    "enable_czm",
+    "enable_resin_pocket",
+    "enable_surface_resin_pockets",
+    "enable_progressive_damage",
+    "transverse_mode",
+)
+
+_EPS: float = float(np.finfo(float).eps)
+
+
+# ======================================================================
+# Objectives
+# ======================================================================
+
+def _obj_knockdown(results: AnalysisResults) -> float:
+    """Combined analytical strength knockdown (every solve path)."""
+    return float(results.analytical_knockdown)
+
+
+def _obj_strength_MPa(results: AnalysisResults) -> float:
+    """Predicted wrinkled strength in MPa (every solve path)."""
+    return float(results.analytical_strength_MPa)
+
+
+def _obj_modulus_knockdown(results: AnalysisResults) -> float:
+    """Analytical stiffness knockdown (every solve path)."""
+    return float(results.analytical_modulus_knockdown)
+
+
+def _obj_onset_knockdown(results: AnalysisResults) -> float:
+    """Delamination-onset knockdown; tension configurations only."""
+    value = results.analytical_onset_knockdown
+    if value is None:
+        raise ValueError(
+            "results.analytical_onset_knockdown is None — the "
+            "delamination-onset knockdown is computed on the tension "
+            "path only, and only when the material defines GIc and "
+            "GIIc. Use loading='tension' with a material that carries "
+            "both toughnesses, or pick objective='knockdown'."
+        )
+    return float(value)
+
+
+def _obj_modulus_retention_global(results: AnalysisResults) -> float:
+    """Global reaction-based modulus retention; FE path only."""
+    if results.mesh is None:
+        raise ValueError(
+            "results.modulus_retention_global requires the FE path (it "
+            "is measured from the global reaction response); this run "
+            "was analytical-only, where the field keeps its 1.0 "
+            "default. Pass analytical_only=False, or pick "
+            "objective='modulus_knockdown' for the analytical "
+            "stiffness knockdown."
+        )
+    if results.modulus_retention_global_failed:
+        raise ValueError(
+            "results.modulus_retention_global_failed is True — the "
+            "pristine reference solve did not converge, so the field "
+            "was forced to its 1.0 fallback and is not a usable "
+            "objective. Fix the solve (see the logged reason) or pick "
+            "objective='modulus_knockdown'."
+        )
+    return float(results.modulus_retention_global)
+
+
+_OBJECTIVES: dict[str, Callable[[AnalysisResults], float]] = {
+    "knockdown": _obj_knockdown,
+    "strength_MPa": _obj_strength_MPa,
+    "modulus_knockdown": _obj_modulus_knockdown,
+    "onset_knockdown": _obj_onset_knockdown,
+    "modulus_retention_global": _obj_modulus_retention_global,
+}
+
+#: Objectives that are deliberately not root-findable, with the reason.
+_REFUSED_OBJECTIVES: dict[str, str] = {
+    "modulus_retention": (
+        "'modulus_retention' is the wrinkle-region-averaged strain "
+        "measure whose own docstring records that it over-predicts "
+        "stiffness loss; use 'modulus_retention_global' (FE path) or "
+        "'modulus_knockdown' (analytical)."
+    ),
+    "retention_factors": (
+        "'retention_factors' is hard-clamped to 1.0 by the failure "
+        "evaluation, so as a function of a defect size it is a step, "
+        "not a continuous curve, and has no root to find."
+    ),
+    "progressive_knockdown": (
+        "'progressive_knockdown' is a constant 1.0 unless "
+        "enable_progressive_damage=True, and with it enabled each "
+        "forward evaluation costs ~30 load-stepped solves. Run "
+        "WrinkleAnalysis.parametric_sweep over an explicit value list "
+        "instead."
+    ),
+}
+
+#: Objectives that are only defined on the FE path.
+_FE_ONLY_OBJECTIVES: frozenset[str] = frozenset({"modulus_retention_global"})
+
+
+# ======================================================================
+# Result containers
+# ======================================================================
+
+@dataclass
+class GoalSeekEvaluation:
+    """One forward solve performed during the search."""
+
+    index: int
+    value: float
+    """Swept-parameter value at this evaluation."""
+    objective: float
+    """Objective (knockdown, strength, ...) returned by the forward model."""
+    knockdown: float
+    """``analytical_knockdown`` at this point, recorded regardless of
+    which objective drives the search."""
+    strength_MPa: float
+    residual: float
+    """``objective - target``, in the objective's own units."""
+    phase: str
+    """``'scan'`` | ``'root'`` | ``'verify'`` | ``'backoff'``."""
+    runtime_s: float
+
+
+@dataclass
+class CriticalValueResult:
+    """Result of :func:`find_critical_value`."""
+
+    parameter: str
+    objective_name: str
+    target: float
+    """Target in the objective's units (knockdown factor, or MPa when
+    *target_strength_MPa* was given)."""
+    target_is_strength: bool
+    direction: str
+    """``'decreasing'`` or ``'increasing'`` — measured from the scan
+    endpoints, never assumed from the parameter name."""
+    status: str
+    """``'converged'`` | ``'no_crossing'`` | ``'target_unreachable'`` |
+    ``'non_monotonic'`` | ``'flat'``."""
+    message: str
+    """One-paragraph, actionable explanation. Always populated; it is the
+    text the CLI prints for every non-``'converged'`` status."""
+
+    critical_value: float | None
+    """The **conservative** answer: for a decreasing objective, the
+    largest *parameter* value that still satisfies ``objective >=
+    target`` under a real forward evaluation; for an increasing one, the
+    smallest such value. ``None`` unless *status* is ``'converged'``."""
+    critical_value_root: float | None
+    """The raw ``brentq`` root, before the safe-side back-off. Reported
+    for transparency; ``critical_value`` is what a user must quote."""
+    achieved_objective: float | None
+    achieved_knockdown: float | None
+    achieved_strength_MPa: float | None
+    critical_config: AnalysisConfig | None
+    """``base_config`` cloned at *critical_value*, with the resolved
+    ``analytical_only`` baked in — ready to hand to
+    :class:`~wrinklefe.analysis.WrinkleAnalysis`. ``None`` when no
+    root."""
+
+    bounds: tuple[float, float]
+    """The resolved ``[lo, cap]`` actually scanned."""
+    bounds_source: tuple[str, str]
+    """Which rule set each bound: ``'user_bracket'`` | ``'zero'`` |
+    ``'scaled_base'`` | ``'laminate_thickness'`` | ``'tool_flat_bound'``
+    | ``'mesh_amplitude_safe'`` | ``'user_max_value'`` — so a refusal
+    message can point at the knob that has to move."""
+    scan_values: list[float]
+    scan_objectives: list[float]
+    """The scan grid and its measured objectives — the curve context, and
+    the evidence behind every refusal message."""
+    sign_changes: int
+    """Number of sign changes of ``objective - target`` across the scan.
+    ``1`` is the only value that admits a unique root."""
+    log_spaced: bool
+    """Whether the scan grid was log-spaced (drives the plot x-scale)."""
+
+    pristine_reference_MPa: float | None
+    """``achieved_strength_MPa / achieved_knockdown`` — the divisor that
+    expresses a MPa target as a knockdown factor. ``None`` when no
+    root."""
+
+    evaluations: list[GoalSeekEvaluation]
+    n_evaluations: int
+    rtol: float
+    analytical_only: bool
+    """The **resolved** value actually used, not the argument."""
+    runtime_s: float
+    results: list[AnalysisResults] | None = field(default=None, repr=False)
+    """Full per-evaluation results, only when ``keep_results=True`` (they
+    carry mesh and field arrays on the FE path)."""
+
+    def summary(self) -> str:
+        """Human-readable search report (the caller prints it)."""
+        unit = "MPa" if self.target_is_strength else ""
+        lines = [
+            f"Critical-value search: {self.parameter} "
+            f"({self.objective_name} >= {self.target:.6g}{unit})",
+            f"Direction: {self.direction}  |  range "
+            f"[{self.bounds[0]:.6g}, {self.bounds[1]:.6g}] "
+            f"(lower: {self.bounds_source[0]}, "
+            f"upper: {self.bounds_source[1]})",
+            f"Scan: {len(self.scan_values)} points, "
+            f"{'log' if self.log_spaced else 'linear'}-spaced, "
+            f"{self.sign_changes} sign change"
+            f"{'' if self.sign_changes == 1 else 's'}",
+            "",
+            f"{'value':>16} {'objective':>14} {'knockdown':>12} "
+            f"{'strength (MPa)':>16}",
+        ]
+        by_value = {ev.value: ev for ev in self.evaluations}
+        for value, obj in zip(self.scan_values, self.scan_objectives):
+            ev = by_value.get(value)
+            kd = ev.knockdown if ev is not None else float("nan")
+            mpa = ev.strength_MPa if ev is not None else float("nan")
+            lines.append(
+                f"{value:>16.6g} {obj:>14.6g} {kd:>12.4f} {mpa:>16.1f}"
+            )
+        lines.append("")
+        if self.status == "converged":
+            assert self.critical_value is not None
+            assert self.achieved_objective is not None
+            extreme = (
+                "largest" if self.direction == "decreasing" else "smallest"
+            )
+            lines.append(
+                f"{extreme.capitalize()} acceptable {self.parameter}: "
+                f"{self.critical_value:.6g}"
+            )
+            lines.append(
+                f"  raw root {self.critical_value_root:.6g}, backed off to "
+                f"the safe side"
+            )
+            lines.append(
+                f"Achieved {self.objective_name}: "
+                f"{self.achieved_objective:.6f} "
+                f"(target {self.target:.6f}, rtol {self.rtol:.1e})"
+            )
+            lines.append(
+                f"Criterion satisfied: {self.objective_name} "
+                f"{self.achieved_objective:.6f} >= {self.target:.6f}"
+            )
+            if self.target_is_strength and self.pristine_reference_MPa:
+                lines.append(
+                    f"Equivalent knockdown target: "
+                    f"{self.target / self.pristine_reference_MPa:.6f} "
+                    f"(pristine reference "
+                    f"{self.pristine_reference_MPa:.1f} MPa)"
+                )
+        else:
+            lines.append(f"Status: {self.status}")
+            lines.append(self.message)
+        lines.append(
+            f"Forward-model evaluations: {self.n_evaluations} "
+            f"({self.runtime_s:.2f} s, "
+            f"{'analytical' if self.analytical_only else 'FE'} path)"
+        )
+        return "\n".join(lines)
+
+    def plot(self, ax=None):
+        """Objective vs parameter with the target and the answer marked.
+
+        Returns the matplotlib Axes.
+        """
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            _, ax = plt.subplots(figsize=(6, 4))
+        ax.plot(self.scan_values, self.scan_objectives, "o-", label="scan")
+        ax.axhline(
+            self.target, color="crimson", ls="--",
+            label=f"target {self.target:.4g}",
+        )
+        if self.critical_value is not None:
+            ax.axvline(
+                self.critical_value, color="seagreen", ls=":",
+                label=f"critical {self.critical_value:.4g}",
+            )
+        if self.log_spaced and min(self.scan_values) > 0.0:
+            ax.set_xscale("log")
+        ax.set_xlabel(self.parameter)
+        ax.set_ylabel(self.objective_name)
+        ax.set_title(f"Critical-value search ({self.status})")
+        ax.grid(True, alpha=0.3)
+        ax.legend(fontsize=8)
+        return ax
+
+
+# ======================================================================
+# Private helpers
+# ======================================================================
+
+def _float_field_names(cfg: AnalysisConfig) -> list[str]:
+    """Names of the continuously-searchable (``float``) config fields."""
+    return sorted(
+        f.name
+        for f in fields(cfg)
+        if type(getattr(cfg, f.name)) is float
+    )
+
+
+def _fe_forcing_features(cfg: AnalysisConfig) -> list[str]:
+    """FE-only features enabled on *cfg*, in declaration order."""
+    active: list[str] = []
+    for name in FE_ONLY_FEATURES:
+        value = getattr(cfg, name)
+        if name == "transverse_mode":
+            if value != "uniform":
+                active.append(f"transverse_mode={value!r}")
+        elif bool(value):
+            active.append(name)
+    return active
+
+
+def _resolve_analytical_only(
+    cfg: AnalysisConfig, analytical_only: bool | None
+) -> bool:
+    """Resolve the solve path, refusing combinations that cannot run.
+
+    ``None`` means "analytical unless the config demands FE"; an
+    explicit ``True`` alongside an FE-only feature is an error rather
+    than a silent no-op.
+    """
+    if cfg.enable_progressive_damage:
+        raise ValueError(
+            "enable_progressive_damage=True is not supported by the "
+            "critical-value search: each forward evaluation costs ~30 "
+            "load-stepped solves, so a ~14-evaluation search runs for "
+            "hours. Run WrinkleAnalysis.parametric_sweep over an "
+            "explicit amplitude list instead, or disable progressive "
+            "damage for the search."
+        )
+    active = _fe_forcing_features(cfg)
+    if active:
+        listed = ", ".join(active)
+        if analytical_only is True:
+            raise ValueError(
+                f"analytical_only=True conflicts with FE-only config "
+                f"feature(s): {listed}. They have no analytical-path "
+                f"effect and would either silently no-op or raise "
+                f"mid-search. Either drop the feature(s) from the base "
+                f"config, or pass analytical_only=False (or leave it "
+                f"None) to run the search on the FE path."
+            )
+        if analytical_only is None:
+            logger.warning(
+                "FE-only config feature(s) %s force the FE path; the "
+                "search will run about 14 forward evaluations, each "
+                "performing 4 linear solves",
+                listed,
+            )
+        return False
+    resolved = True if analytical_only is None else bool(analytical_only)
+    if resolved and cfg.morphology == "tool_flat":
+        raise ValueError(
+            "morphology='tool_flat' cannot be searched on the "
+            "analytical path: the analytical knockdown for tool_flat "
+            "equals the 'uniform' result, and the FE path auto-enables "
+            "surface resin pockets, which AnalysisConfig rejects under "
+            "analytical_only=True. Pass analytical_only=False to search "
+            "tool_flat, or pick a different morphology."
+        )
+    return resolved
+
+
+def _scan_grid(lo: float, cap: float, n: int) -> tuple[list[float], bool]:
+    """Return *n* scan abscissae over ``[lo, cap]`` and the spacing flag.
+
+    Log spacing is used whenever the range spans more than
+    :data:`LOG_SPACING_RATIO`, because a wide linear grid can walk
+    straight past an interior extremum — the graded-morphology
+    wavelength curve is the measured case.  A zero lower bound (the
+    amplitude default) keeps the exact ``0.0`` endpoint and log-spaces
+    the rest over three decades.
+
+    Examples
+    --------
+    >>> values, log_spaced = _scan_grid(0.0, 4.0, 5)
+    >>> [round(v, 6) for v in values]
+    [0.0, 0.004, 0.04, 0.4, 4.0]
+    >>> log_spaced
+    True
+    >>> values, log_spaced = _scan_grid(1.0, 5.0, 5)
+    >>> [round(v, 6) for v in values]
+    [1.0, 2.0, 3.0, 4.0, 5.0]
+    >>> log_spaced
+    False
+    """
+    if lo > 0.0 and cap / lo > LOG_SPACING_RATIO:
+        grid = np.logspace(math.log10(lo), math.log10(cap), n)
+        return [float(v) for v in grid], True
+    if lo == 0.0 and cap > 0.0:
+        rest = np.logspace(math.log10(cap) - 3.0, math.log10(cap), n - 1)
+        return [0.0] + [float(v) for v in rest], True
+    grid = np.linspace(lo, cap, n)
+    return [float(v) for v in grid], False
+
+
+def _sign(x: float) -> int:
+    """Sign of *x* as ``-1`` / ``0`` / ``+1``."""
+    if x > 0.0:
+        return 1
+    if x < 0.0:
+        return -1
+    return 0
+
+
+def _count_reversals(f: list[float], tol: float) -> int:
+    """Direction reversals in *f*, ignoring moves no larger than *tol*.
+
+    A bit-exact plateau (or any move inside the tolerance) is a tie, not
+    a reversal — otherwise a saturating-but-well-posed curve would be
+    refused.
+    """
+    reversals = 0
+    previous = 0
+    for a, b in zip(f, f[1:]):
+        delta = b - a
+        if abs(delta) <= tol:
+            continue
+        current = 1 if delta > 0.0 else -1
+        if previous != 0 and current != previous:
+            reversals += 1
+        previous = current
+    return reversals
+
+
+def _classify_scan(
+    f: list[float], g: list[float], target: float, rtol: float
+) -> tuple[str, int, tuple[int, int] | None]:
+    """Choose the terminal status from the measured scan.
+
+    This is the **only** place a terminal status is decided, and it runs
+    before any "no crossing" exit — otherwise a scan whose interior sits
+    far below the target could be reported as "nothing in range fails
+    your criterion".
+
+    Returns ``(status, sign_changes, bracket_indices)`` where *status*
+    is ``'ok'`` when exactly one sign change and no direction reversal
+    were found (the only case that admits a unique root).
+    """
+    tol = max(rtol * abs(target), MIN_RTOL)
+
+    # (a) Flat, relative to the target — an inert parameter for this
+    #     configuration cannot resolve the target at all.
+    if max(f) - min(f) < tol:
+        return "flat", 0, None
+
+    # (b) A bit-exact plateau sitting on the target value.
+    for a, b in zip(f, f[1:]):
+        if a == b and abs(a - target) <= tol:
+            return "flat", 0, None
+
+    # (c) Sign changes over the non-zero residuals (an exact zero
+    #     matches either neighbour), plus tie-tolerant reversals.
+    nonzero = [(i, _sign(gi)) for i, gi in enumerate(g) if _sign(gi) != 0]
+    sign_changes = 0
+    bracket: tuple[int, int] | None = None
+    for (i0, s0), (i1, s1) in zip(nonzero, nonzero[1:]):
+        if s0 != s1:
+            sign_changes += 1
+            if bracket is None:
+                bracket = (i0, i1)
+    reversals = _count_reversals(f, tol)
+
+    if sign_changes > 1 or (reversals > 0 and sign_changes >= 1):
+        return "non_monotonic", sign_changes, bracket
+    if sign_changes == 0:
+        # (d) Direction-independent joint table: everything above the
+        #     target means nothing in range violates the criterion;
+        #     everything below means nothing in range meets it.
+        if all(gi > 0.0 for gi in g):
+            return "no_crossing", 0, None
+        return "target_unreachable", 0, None
+    return "ok", sign_changes, bracket
+
+
+def _clip(x: float, lo: float, hi: float) -> float:
+    """Clamp *x* into ``[lo, hi]``."""
+    return min(max(x, lo), hi)
+
+
+def _resolve_bounds(
+    cfg: AnalysisConfig,
+    parameter: str,
+    bracket: tuple[float, float] | None,
+    max_value: float | None,
+    analytical_only: bool,
+) -> tuple[float, float, tuple[str, str]]:
+    """Resolve the ``[lo, cap]`` search range and record its provenance.
+
+    Both bounds are sign-aware (``applied_strain`` is negative for
+    compression, so a scaled range must stay on the negative half-line),
+    and the upper bound is clamped by every validation limit that
+    applies so the search cannot die mid-run on a legal-looking probe.
+    """
+    p0 = float(getattr(cfg, parameter))
+    source_lo = "user_bracket"
+    source_hi = "user_bracket"
+
+    if bracket is not None:
+        lo, cap = float(bracket[0]), float(bracket[1])
+    else:
+        if max_value is not None:
+            cap, source_hi = float(max_value), "user_max_value"
+        elif parameter == "amplitude":
+            n_plies = max(len(cfg.angles or ()), 1)
+            cap = float(n_plies * cfg.ply_thickness)
+            source_hi = "laminate_thickness"
+        elif p0 > 0.0:
+            cap, source_hi = 256.0 * p0, "scaled_base"
+        elif p0 < 0.0:
+            cap, source_hi = p0 / 256.0, "scaled_base"
+        else:
+            raise ValueError(
+                f"cannot derive a search range from "
+                f"AnalysisConfig.{parameter} = 0.0 — a scaled range "
+                f"around zero is degenerate. Pass an explicit "
+                f"bracket=(lo, hi) or max_value."
+            )
+        if parameter == "amplitude":
+            lo, source_lo = 0.0, "zero"
+        elif p0 > 0.0:
+            lo, source_lo = p0 / 256.0, "scaled_base"
+        elif p0 < 0.0:
+            lo, source_lo = 256.0 * p0, "scaled_base"
+        else:
+            lo, source_lo = 0.0, "zero"
+
+    if parameter == "amplitude":
+        if cfg.morphology == "tool_flat":
+            bound = (
+                0.999
+                * 0.8
+                * cfg.surface_transition_plies
+                * cfg.ply_thickness
+                / cfg.nz_per_ply
+            )
+            if bound < cap:
+                if bracket is not None:
+                    logger.warning(
+                        "requested upper bound %.6g exceeds the "
+                        "tool_flat element-inversion limit %.6g mm; "
+                        "clamping",
+                        cap, bound,
+                    )
+                cap, source_hi = float(bound), "tool_flat_bound"
+        if not analytical_only:
+            diagnostics = mesh_shear_diagnostics(
+                amplitude=(
+                    cfg.amplitude if cfg.amplitude > 0.0 else cfg.ply_thickness
+                ),
+                wavelength=cfg.wavelength,
+                ply_thickness=cfg.ply_thickness,
+                nx=cfg.nx,
+                nz_per_ply=cfg.nz_per_ply,
+                Lx=cfg.domain_length,
+            )
+            bound = diagnostics.amplitude_safe
+            if bound < cap:
+                if bracket is not None:
+                    logger.warning(
+                        "requested upper bound %.6g exceeds the "
+                        "mesh-inversion limit %.6g mm "
+                        "(2.5 * ply_thickness / nz_per_ply); clamping",
+                        cap, bound,
+                    )
+                cap, source_hi = float(bound), "mesh_amplitude_safe"
+
+    if not lo < cap:
+        raise ValueError(
+            f"empty search range for '{parameter}': resolved bounds "
+            f"[{lo:.6g}, {cap:.6g}] (lower: {source_lo}, upper: "
+            f"{source_hi}). A validation clamp inverted the range — "
+            f"lower the bracket, or relax nz_per_ply / "
+            f"surface_transition_plies."
+        )
+    return lo, cap, (source_lo, source_hi)
+
+
+def _bound_clause(
+    source: str, cap: float, cfg: AnalysisConfig
+) -> str:
+    """One sentence naming the knob that set the upper bound."""
+    if source == "mesh_amplitude_safe":
+        return (
+            f"The upper bound came from 'mesh_amplitude_safe' "
+            f"({cap:.6g} mm = 2.5 * ply_thickness / nz_per_ply); above "
+            f"it the hex mesh inverts. Reduce nz_per_ply, or run with "
+            f"the analytical path."
+        )
+    if source == "tool_flat_bound":
+        return (
+            f"The upper bound came from 'tool_flat_bound' ({cap:.6g} "
+            f"mm); above it the crest-side transition elements invert. "
+            f"Increase surface_transition_plies or reduce nz_per_ply."
+        )
+    if source == "user_bracket":
+        return "The upper bound came from the explicit bracket."
+    if source == "user_max_value":
+        return "The upper bound came from the explicit max_value."
+    if source == "laminate_thickness":
+        return (
+            f"The upper bound came from 'laminate_thickness' "
+            f"({cap:.6g} mm = len(angles) * ply_thickness). To search "
+            f"further raise max_value or pass an explicit bracket."
+        )
+    return f"The upper bound came from '{source}'."
+
+
+def _flat_message(
+    parameter: str,
+    objective_name: str,
+    target: float,
+    values: list[float],
+    f: list[float],
+    rtol: float,
+) -> str:
+    """Explain a curve too flat (or too plateaued) to resolve a target."""
+    span = max(f) - min(f)
+    i_min, i_max = f.index(min(f)), f.index(max(f))
+    return (
+        f"'{objective_name}' does not resolve the target over the "
+        f"searched range of '{parameter}': across "
+        f"{len(values)} scan points it spans only {span:.6g} "
+        f"({f[i_min]:.10g} at {parameter}={values[i_min]:.6g} to "
+        f"{f[i_max]:.10g} at {parameter}={values[i_max]:.6g}), which is "
+        f"below the resolution rtol * |target| = "
+        f"{max(rtol * abs(target), MIN_RTOL):.3g}, or it is bit-exactly "
+        f"constant at the target value. The parameter is effectively "
+        f"inert for this configuration (a saturated penetration gate "
+        f"and a decayed-away wrinkle are the usual causes). Search a "
+        f"different parameter, widen the bracket, or check that the "
+        f"configuration actually responds to '{parameter}'."
+    )
+
+
+def _non_monotonic_message(
+    parameter: str,
+    objective_name: str,
+    values: list[float],
+    f: list[float],
+    sign_changes: int,
+    log_spaced: bool,
+    cfg: AnalysisConfig,
+) -> str:
+    """Explain a refusal caused by a non-unique root."""
+    i_min = f.index(min(f))
+    message = (
+        f"'{objective_name}' is not monotonic in '{parameter}' over "
+        f"[{values[0]:.6g}, {values[-1]:.6g}]: the {len(values)}-point "
+        f"{'log' if log_spaced else 'linear'}-spaced scan shows "
+        f"{sign_changes} sign change"
+        f"{'' if sign_changes == 1 else 's'} of (objective - target) "
+        f"and a direction reversal — it reaches {f[i_min]:.6g} at "
+        f"{parameter}={values[i_min]:.6g} between the endpoint values "
+        f"{f[0]:.6g} at {values[0]:.6g} and {f[-1]:.6g} at "
+        f"{values[-1]:.6g}. A root is not unique, so the search refuses "
+        f"rather than returning an arbitrary one."
+    )
+    if cfg.morphology == "graded" and parameter == "wavelength":
+        message += (
+            " Known cause for this configuration: morphology='graded' "
+            "widens the through-thickness Gaussian as wavelength grows "
+            "(decay_scale_eff = max(wavelength/2, amplitude)), "
+            "producing a U-shaped curve with an interior minimum near "
+            "lambda ~ 3 mm. Pin through_thickness_decay_scale, or "
+            "narrow the bracket to one side of the minimum."
+        )
+    message += (
+        " Narrow the bracket to a monotone sub-range, or run "
+        "WrinkleAnalysis.parametric_sweep over the bracket to see the "
+        "whole curve first."
+    )
+    return message
+
+
+def _no_crossing_message(
+    parameter: str,
+    objective_name: str,
+    target: float,
+    values: list[float],
+    f: list[float],
+    source_hi: str,
+    cap: float,
+    cfg: AnalysisConfig,
+) -> str:
+    """Explain that nothing in range violates the criterion."""
+    i_min = f.index(min(f))
+    return (
+        f"no value of '{parameter}' in [{values[0]:.6g}, "
+        f"{values[-1]:.6g}] violates the criterion '{objective_name} >= "
+        f"{target:.6g}'. The objective was scanned at {len(values)} "
+        f"points over that range; its minimum is {f[i_min]:.6g} at "
+        f"{parameter} = {values[i_min]:.6g} — still above the target. "
+        f"{_bound_clause(source_hi, cap, cfg)} Otherwise pick a target "
+        f"above {f[i_min]:.6g}. This is not necessarily an error: it "
+        f"means no defect size in range fails your criterion."
+    )
+
+
+def _unreachable_message(
+    parameter: str,
+    objective_name: str,
+    target: float,
+    values: list[float],
+    f: list[float],
+    source_hi: str,
+    cap: float,
+    cfg: AnalysisConfig,
+) -> str:
+    """Explain that nothing in range meets the criterion."""
+    i_max = f.index(max(f))
+    return (
+        f"no value of '{parameter}' in [{values[0]:.6g}, "
+        f"{values[-1]:.6g}] meets the criterion '{objective_name} >= "
+        f"{target:.6g}'. The objective was scanned at {len(values)} "
+        f"points over that range; even its maximum, {f[i_max]:.6g} at "
+        f"{parameter} = {values[i_max]:.6g}, falls short. "
+        f"{_bound_clause(source_hi, cap, cfg)} The configuration cannot "
+        f"meet this target at any searched defect size — lower the "
+        f"target, or change the laminate."
+    )
+
+
+def _validate_target(
+    target_knockdown: float | None, target_strength_MPa: float | None
+) -> tuple[float, bool]:
+    """Validate the mutually exclusive target pair; return (target, is_MPa)."""
+    if (target_knockdown is None) == (target_strength_MPa is None):
+        raise ValueError(
+            "exactly one of target_knockdown and target_strength_MPa "
+            f"is required, got target_knockdown={target_knockdown!r} "
+            f"and target_strength_MPa={target_strength_MPa!r}"
+        )
+    if target_knockdown is not None:
+        value = float(target_knockdown)
+        if not math.isfinite(value) or not 0.0 < value < 1.0:
+            if value == 1.0:
+                raise ValueError(
+                    "target_knockdown=1.0 asks for the largest defect "
+                    "that causes no knockdown at all. That is "
+                    "degenerate: the analytical knockdown is "
+                    "bit-exactly 1.0 at amplitude 0 for both loadings, "
+                    "and on the tension path it stays 1.0 over a finite "
+                    "interval, so the answer is an interval, not a "
+                    "value. Pick a target strictly below 1.0 (e.g. "
+                    "0.99)."
+                )
+            raise ValueError(
+                f"target_knockdown must be a finite value in (0.0, "
+                f"1.0), got {target_knockdown!r}"
+            )
+        return value, False
+    assert target_strength_MPa is not None
+    value = float(target_strength_MPa)
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(
+            f"target_strength_MPa must be a finite value > 0, got "
+            f"{target_strength_MPa!r}"
+        )
+    return value, True
+
+
+def _validate_parameter(cfg: AnalysisConfig, parameter: str) -> None:
+    """Refuse anything ``brentq`` cannot legally probe."""
+    names = {f.name for f in fields(cfg)}
+    if parameter not in names:
+        raise ValueError(
+            f"AnalysisConfig has no continuously-searchable field "
+            f"{parameter!r} — expected one of "
+            f"{_float_field_names(cfg)} (float fields only; integer "
+            f"mesh/ply-count fields are not root-findable)"
+        )
+    value = getattr(cfg, parameter)
+    if type(value) is float:
+        return
+    if type(value) is bool:
+        raise ValueError(
+            f"{parameter!r} is a boolean AnalysisConfig field; a "
+            f"continuous root-find over it is meaningless. Search a "
+            f"float field, or compare two explicit runs."
+        )
+    if type(value) is int:
+        raise ValueError(
+            f"{parameter!r} is an integer AnalysisConfig field. brentq "
+            f"is a continuous solver and AnalysisConfig._validate "
+            f"rejects non-integral values, so a goal-seek over it would "
+            f"fail on the first fractional probe. Use "
+            f"wrinklefe.convergence.mesh_convergence_study for "
+            f"mesh-density questions, or "
+            f"WrinkleAnalysis.parametric_sweep over an explicit integer "
+            f"list."
+        )
+    if value is None:
+        raise ValueError(
+            f"AnalysisConfig.{parameter} is None on this config, so the "
+            f"search has no value to scale a range from. Set it to a "
+            f"float first, or pass an explicit bracket for a different "
+            f"parameter."
+        )
+    raise ValueError(
+        f"AnalysisConfig.{parameter} is a "
+        f"{type(value).__name__}, not a float — expected one of "
+        f"{_float_field_names(cfg)}"
+    )
+
+
+def _resolve_objective(
+    objective: str | Callable[[AnalysisResults], float],
+    target_is_strength: bool,
+) -> tuple[Callable[[AnalysisResults], float], str]:
+    """Resolve the objective extractor and its reported name."""
+    if callable(objective):
+        if target_is_strength:
+            raise ValueError(
+                "target_strength_MPa selects the built-in 'strength_MPa' "
+                "objective; it cannot be combined with a callable "
+                "objective. Use target_knockdown with the callable, and "
+                "have the callable return the quantity being targeted."
+            )
+        return objective, getattr(objective, "__name__", "custom")
+    if target_is_strength:
+        if objective not in ("knockdown", "strength_MPa"):
+            raise ValueError(
+                f"target_strength_MPa root-finds the 'strength_MPa' "
+                f"objective directly, so it cannot be combined with "
+                f"objective={objective!r}. Drop the objective argument, "
+                f"or express the target as a knockdown factor."
+            )
+        objective = "strength_MPa"
+    if objective in _REFUSED_OBJECTIVES:
+        raise ValueError(_REFUSED_OBJECTIVES[objective])
+    if objective not in _OBJECTIVES:
+        raise ValueError(
+            f"unknown objective {objective!r}; expected one of "
+            f"{sorted(_OBJECTIVES)} or a callable"
+        )
+    return _OBJECTIVES[objective], objective
+
+
+def _check_objective_available(
+    cfg: AnalysisConfig, objective_name: str, analytical_only: bool
+) -> None:
+    """Refuse an objective the resolved solve path cannot produce."""
+    if objective_name in _FE_ONLY_OBJECTIVES and analytical_only:
+        raise ValueError(
+            f"objective={objective_name!r} is measured from the FE "
+            f"global reaction response and keeps its 1.0 default on the "
+            f"analytical path. Pass analytical_only=False, or pick "
+            f"objective='modulus_knockdown' for the analytical "
+            f"stiffness knockdown."
+        )
+    if objective_name == "onset_knockdown" and cfg.loading != "tension":
+        raise ValueError(
+            f"objective='onset_knockdown' is computed on the tension "
+            f"path only; this config has loading={cfg.loading!r}. Use "
+            f"loading='tension', or pick objective='knockdown'."
+        )
+
+
+def _backoff_to_safe_side(
+    probe: Callable[[float, str], GoalSeekEvaluation],
+    row: GoalSeekEvaluation,
+    root: float,
+    target: float,
+    direction: str,
+    xtol: float,
+    rtol: float,
+    lo: float,
+    cap: float,
+) -> GoalSeekEvaluation:
+    """Walk off the root until a real forward solve meets the criterion.
+
+    ``brentq`` converges to a root, not to the side of it that satisfies
+    ``objective >= target``; on measured cases the raw root violates the
+    criterion in three runs out of four.  The walk is geometric,
+    direction-aware and budgeted by ``rtol * |root|``, so the returned
+    value stays inside the tolerance contract.
+    """
+    step_sign = -1.0 if direction == "decreasing" else 1.0
+    step0 = max(xtol, 8.0 * _EPS * abs(root))
+    budget = max(BACKOFF_BUDGET_RTOL_MULT * rtol * abs(root), 16.0 * step0)
+    offset = 0.0
+    previous = root
+    k = 0
+    while row.objective < target and offset <= budget and k < 24:
+        offset = (2.0**k) * step0
+        candidate = _clip(root + step_sign * offset, lo, cap)
+        k += 1
+        if candidate == previous:
+            break
+        previous = candidate
+        row = probe(candidate, "backoff")
+    return row
+
+
+# ======================================================================
+# Public driver
+# ======================================================================
+
+def find_critical_value(
+    base_config: AnalysisConfig,
+    *,
+    parameter: str = "amplitude",
+    target_knockdown: float | None = None,
+    target_strength_MPa: float | None = None,
+    objective: str | Callable[[AnalysisResults], float] = "knockdown",
+    bracket: tuple[float, float] | None = None,
+    max_value: float | None = None,
+    scan_points: int = DEFAULT_SCAN_POINTS,
+    rtol: float = 1e-3,
+    analytical_only: bool | None = None,
+    keep_results: bool = False,
+) -> CriticalValueResult:
+    """Find the largest defect size that still meets a target criterion.
+
+    The acceptable set is always ``{x : objective(x) >= target}`` (a
+    larger objective is safer — true for knockdown, strength and modulus
+    knockdown, and the contract a user-supplied callable must honour).
+    For a decreasing objective the answer is the **largest** acceptable
+    value; for an increasing one it is the **smallest**.  The returned
+    ``critical_value`` is verified by a real forward evaluation, not
+    merely by the root tolerance.
+
+    Parameters
+    ----------
+    base_config : AnalysisConfig
+        Configuration to clone at every trial value.
+    parameter : str, optional
+        Float :class:`~wrinklefe.analysis.AnalysisConfig` field to
+        search. Default ``'amplitude'``. Integer mesh/ply-count fields
+        are refused by name.
+    target_knockdown : float, optional
+        Target as a knockdown factor in ``(0, 1)``. Exactly one of
+        *target_knockdown* and *target_strength_MPa* is required.
+    target_strength_MPa : float, optional
+        Target as an absolute strength in MPa; selects the
+        ``'strength_MPa'`` objective and root-finds it directly.
+    objective : str or callable, optional
+        One of ``'knockdown'`` (default), ``'strength_MPa'``,
+        ``'modulus_knockdown'``, ``'onset_knockdown'`` (tension only),
+        ``'modulus_retention_global'`` (FE only) — or a callable
+        ``f(AnalysisResults) -> float``.
+    bracket : tuple of float, optional
+        Explicit ``(lo, hi)`` search range. Still clamped by the
+        tool_flat and mesh-inversion limits.
+    max_value : float, optional
+        Upper bound when *bracket* is not given.
+    scan_points : int, optional
+        Points in the bounded scan that measures direction and
+        monotonicity (>= 3). Default 9.
+    rtol : float, optional
+        Relative tolerance on the parameter, passed to
+        :func:`scipy.optimize.brentq`. Default ``1e-3``.
+    analytical_only : bool or None, optional
+        ``None`` (default) means "analytical unless the base config
+        enables an FE-only feature". ``True`` with such a feature is an
+        error rather than a silent no-op. Root-finding is inherently
+        sequential, so there is no worker-count knob.
+    keep_results : bool, optional
+        Retain the full :class:`~wrinklefe.analysis.AnalysisResults` per
+        evaluation (they carry mesh and field arrays on the FE path).
+
+    Returns
+    -------
+    CriticalValueResult
+        The critical value plus the scan curve, the evaluation ledger
+        and — for every refusal — an actionable message.
+
+    Raises
+    ------
+    ValueError
+        On any invalid input: an unknown, integer or boolean
+        *parameter*, a missing/ambiguous target, an unavailable
+        objective, a degenerate range, or an FE-only config feature
+        combined with ``analytical_only=True``. Search *outcomes* (no
+        crossing, non-monotonic, flat) are **returned** with a status,
+        not raised.
+
+    Notes
+    -----
+    ``run()`` resolves ``analytical_only=None`` to ``cfg.analytical_only``;
+    the ladder here overrides that, and the resolved value is baked into
+    every cloned config so a saved result records the path it ran on.
+    """
+    t_start = time.perf_counter()
+
+    target, target_is_strength = _validate_target(
+        target_knockdown, target_strength_MPa
+    )
+    _validate_parameter(base_config, parameter)
+
+    if not math.isfinite(rtol) or not MIN_RTOL <= rtol < 0.1:
+        raise ValueError(
+            f"rtol must be a finite value in [{MIN_RTOL:.6g}, 0.1) — "
+            f"scipy's own floor is 4 * eps — got {rtol!r}"
+        )
+    if scan_points < 3:
+        raise ValueError(
+            f"scan_points must be >= 3 (both endpoints plus at least "
+            f"one interior point), got {scan_points!r}"
+        )
+    if bracket is not None:
+        if len(tuple(bracket)) != 2:
+            raise ValueError(
+                f"bracket must be a (lo, hi) pair, got {bracket!r}"
+            )
+        b_lo, b_hi = float(bracket[0]), float(bracket[1])
+        if not (math.isfinite(b_lo) and math.isfinite(b_hi)):
+            raise ValueError(f"bracket bounds must be finite, got {bracket!r}")
+        if not b_lo < b_hi:
+            raise ValueError(
+                f"bracket must satisfy lo < hi, got lo={b_lo!r}, hi={b_hi!r}"
+            )
+        if b_lo < 0.0 and parameter in ("amplitude", "wavelength", "width"):
+            raise ValueError(
+                f"bracket lower bound must be >= 0 for {parameter!r}, "
+                f"got {b_lo!r}"
+            )
+        bracket = (b_lo, b_hi)
+
+    resolved_analytical = _resolve_analytical_only(base_config, analytical_only)
+    extract, objective_name = _resolve_objective(objective, target_is_strength)
+    if not callable(objective):
+        _check_objective_available(
+            base_config, objective_name, resolved_analytical
+        )
+
+    if base_config.wrinkles is not None and parameter in (
+        "amplitude", "wavelength",
+    ):
+        raise ValueError(
+            f"AnalysisConfig.{parameter} is ignored when 'wrinkles' is "
+            f"set — both analytical pathways read only the per-spec "
+            f"values. Goal-seek on wrinkles[i].{parameter} is not "
+            f"supported; drop 'wrinkles', or search a different field."
+        )
+
+    if resolved_analytical is False and objective_name in (
+        "knockdown", "strength_MPa", "modulus_knockdown", "onset_knockdown",
+    ):
+        logger.warning(
+            "objective %r is computed analytically before the FE branch, "
+            "so the FE path costs 4 linear solves per evaluation without "
+            "changing the number being searched",
+            objective_name,
+        )
+    if (
+        parameter == "wavelength"
+        and base_config.domain_length != 3.0 * base_config.wavelength
+    ):
+        logger.warning(
+            "goal-seek on 'wavelength' with an explicitly pinned "
+            "domain_length=%s: the domain is held fixed while the "
+            "wavelength varies, so the number of wrinkle periods in the "
+            "domain changes across the search. Set domain_length=0.0 to "
+            "auto-derive 3 * wavelength if that is not intended",
+            base_config.domain_length,
+        )
+
+    lo, cap, bounds_source = _resolve_bounds(
+        base_config, parameter, bracket, max_value, resolved_analytical
+    )
+
+    evaluations: list[GoalSeekEvaluation] = []
+    kept: list[AnalysisResults] = []
+
+    def probe(value: float, phase: str) -> GoalSeekEvaluation:
+        t0 = time.perf_counter()
+        cfg = _replace_swept(
+            base_config,
+            parameter,
+            float(value),
+            analytical_only=resolved_analytical,
+        )
+        results = WrinkleAnalysis(cfg).run(analytical_only=resolved_analytical)
+        runtime = time.perf_counter() - t0
+        measured = float(extract(results))
+        row = GoalSeekEvaluation(
+            index=len(evaluations),
+            value=float(value),
+            objective=measured,
+            knockdown=float(results.analytical_knockdown),
+            strength_MPa=float(results.analytical_strength_MPa),
+            residual=measured - target,
+            phase=phase,
+            runtime_s=runtime,
+        )
+        evaluations.append(row)
+        if keep_results:
+            kept.append(results)
+        logger.info(
+            "goal-seek %s: %s=%.6g -> %s=%.6g (residual %+.3e)",
+            phase, parameter, row.value, objective_name, measured,
+            row.residual,
+        )
+        return row
+
+    grid, log_spaced = _scan_grid(lo, cap, scan_points)
+    scan_rows = [probe(value, "scan") for value in grid]
+    f = [row.objective for row in scan_rows]
+    g = [row.residual for row in scan_rows]
+    direction = "decreasing" if f[-1] < f[0] else "increasing"
+
+    status, sign_changes, bracket_indices = _classify_scan(f, g, target, rtol)
+
+    def _build(
+        status: str,
+        message: str,
+        row: GoalSeekEvaluation | None = None,
+        value: float | None = None,
+        root: float | None = None,
+    ) -> CriticalValueResult:
+        reference: float | None = None
+        if row is not None and row.knockdown > 0.0:
+            reference = row.strength_MPa / row.knockdown
+        result = CriticalValueResult(
+            parameter=parameter,
+            objective_name=objective_name,
+            target=target,
+            target_is_strength=target_is_strength,
+            direction=direction,
+            status=status,
+            message=message,
+            critical_value=value,
+            critical_value_root=root,
+            achieved_objective=None if row is None else row.objective,
+            achieved_knockdown=None if row is None else row.knockdown,
+            achieved_strength_MPa=None if row is None else row.strength_MPa,
+            critical_config=(
+                None
+                if value is None
+                else _replace_swept(
+                    base_config, parameter, value,
+                    analytical_only=resolved_analytical,
+                )
+            ),
+            bounds=(lo, cap),
+            bounds_source=bounds_source,
+            scan_values=list(grid),
+            scan_objectives=list(f),
+            sign_changes=sign_changes,
+            log_spaced=log_spaced,
+            pristine_reference_MPa=reference,
+            evaluations=evaluations,
+            n_evaluations=len(evaluations),
+            rtol=float(rtol),
+            analytical_only=resolved_analytical,
+            runtime_s=time.perf_counter() - t_start,
+            results=kept if keep_results else None,
+        )
+        logger.info(
+            "critical-value search finished: status=%s, %s=%s",
+            status, parameter, value,
+        )
+        return result
+
+    if status == "flat":
+        return _build(
+            "flat",
+            _flat_message(
+                parameter, objective_name, target, grid, f, rtol
+            ),
+        )
+    if status == "non_monotonic":
+        return _build(
+            "non_monotonic",
+            _non_monotonic_message(
+                parameter, objective_name, grid, f, sign_changes,
+                log_spaced, base_config,
+            ),
+        )
+    if status == "no_crossing":
+        return _build(
+            "no_crossing",
+            _no_crossing_message(
+                parameter, objective_name, target, grid, f,
+                bounds_source[1], cap, base_config,
+            ),
+        )
+    if status == "target_unreachable":
+        return _build(
+            "target_unreachable",
+            _unreachable_message(
+                parameter, objective_name, target, grid, f,
+                bounds_source[1], cap, base_config,
+            ),
+        )
+
+    assert bracket_indices is not None  # guaranteed by _classify_scan
+    i0, i1 = bracket_indices
+    a, b = grid[i0], grid[i1]
+    xtol = max(MIN_XTOL, 1e-6 * (b - a))
+
+    def residual(x: float) -> float:
+        return probe(float(x), "root").residual
+
+    root = float(
+        brentq(residual, a, b, xtol=xtol, rtol=rtol, maxiter=100)
+    )
+    row = probe(root, "verify")
+    row = _backoff_to_safe_side(
+        probe, row, root, target, direction, xtol, rtol, lo, cap
+    )
+
+    if row.objective >= target and abs(row.objective - target) <= rtol * abs(
+        target
+    ):
+        return _build("converged", "", row, row.value, root)
+    return _build(
+        "flat",
+        f"the safe-side back-off could not satisfy '{objective_name} >= "
+        f"{target:.6g}' within rtol * |root| of the root "
+        f"{root:.6g}: the closest real evaluation gave "
+        f"{row.objective:.10g} at {parameter}={row.value:.6g}. The "
+        f"objective is near-degenerate there (a near-vertical or "
+        f"near-flat curve). Widen rtol, or narrow the bracket around "
+        f"the crossing.",
+        row,
+        None,
+        root,
+    )

--- a/src/wrinklefe/goalseek.py
+++ b/src/wrinklefe/goalseek.py
@@ -279,6 +279,15 @@ class CriticalValueResult:
     """Full per-evaluation results, only when ``keep_results=True`` (they
     carry mesh and field arrays on the FE path)."""
 
+    def scan_evaluations(self) -> list[GoalSeekEvaluation]:
+        """The scan rows of the ledger, in grid order.
+
+        ``brentq`` re-evaluates the bracketing grid points, so matching
+        scan values against the whole ledger by value would relabel them
+        with a later phase.
+        """
+        return [ev for ev in self.evaluations if ev.phase == "scan"]
+
     def summary(self) -> str:
         """Human-readable search report (the caller prints it)."""
         unit = "MPa" if self.target_is_strength else ""
@@ -297,13 +306,12 @@ class CriticalValueResult:
             f"{'value':>16} {'objective':>14} {'knockdown':>12} "
             f"{'strength (MPa)':>16}",
         ]
-        by_value = {ev.value: ev for ev in self.evaluations}
-        for value, obj in zip(self.scan_values, self.scan_objectives):
-            ev = by_value.get(value)
-            kd = ev.knockdown if ev is not None else float("nan")
-            mpa = ev.strength_MPa if ev is not None else float("nan")
+        for value, obj, ev in zip(
+            self.scan_values, self.scan_objectives, self.scan_evaluations()
+        ):
             lines.append(
-                f"{value:>16.6g} {obj:>14.6g} {kd:>12.4f} {mpa:>16.1f}"
+                f"{value:>16.6g} {obj:>14.6g} {ev.knockdown:>12.4f} "
+                f"{ev.strength_MPa:>16.1f}"
             )
         lines.append("")
         if self.status == "converged":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1184,3 +1184,267 @@ def test_compare_config_uses_files_laminate(tmp_path):
     cfg = captured["base_config"]
     assert cfg.angles == [0.0] * 8
     assert cfg.ply_thickness == pytest.approx(0.25)
+
+
+# --------------------------------------------------------------------------- #
+# critical subcommand (issue #280)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_critical_result(**overrides):
+    """A minimal ``CriticalValueResult`` stand-in for handler tests."""
+    from wrinklefe.analysis import AnalysisConfig
+    from wrinklefe.goalseek import CriticalValueResult, GoalSeekEvaluation
+
+    rows = [
+        GoalSeekEvaluation(
+            index=i, value=v, objective=o, knockdown=o,
+            strength_MPa=1200.0 * o, residual=o - 0.85, phase="scan",
+            runtime_s=0.0,
+        )
+        for i, (v, o) in enumerate([(0.0, 1.0), (0.1, 0.8), (0.2, 0.6)])
+    ]
+    defaults = dict(
+        parameter="amplitude", objective_name="knockdown", target=0.85,
+        target_is_strength=False, direction="decreasing",
+        status="converged", message="", critical_value=0.0665,
+        critical_value_root=0.0666, achieved_objective=0.8500007,
+        achieved_knockdown=0.8500007, achieved_strength_MPa=1020.0,
+        critical_config=AnalysisConfig(amplitude=0.0665),
+        bounds=(0.0, 4.392), bounds_source=("zero", "laminate_thickness"),
+        scan_values=[r.value for r in rows],
+        scan_objectives=[r.objective for r in rows],
+        sign_changes=1, log_spaced=True, pristine_reference_MPa=1200.0,
+        evaluations=rows, n_evaluations=len(rows), rtol=1e-3,
+        analytical_only=True, runtime_s=0.5,
+    )
+    defaults.update(overrides)
+    return CriticalValueResult(**defaults)
+
+
+def _capture_critical():
+    """Patch the engine and record the kwargs the handler passes it."""
+    captured: dict = {}
+
+    def fake(base_config, **kwargs):
+        captured["config"] = base_config
+        captured.update(kwargs)
+        return _fake_critical_result()
+
+    return captured, patch("wrinklefe.goalseek.find_critical_value", new=fake)
+
+
+def test_critical_defaults_reach_the_engine():
+    """T-60: the documented defaults are what the engine actually sees."""
+    captured, patcher = _capture_critical()
+    with patcher, pytest.raises(SystemExit) as excinfo:
+        cli_main(["critical", "--target-knockdown", "0.85"])
+    assert excinfo.value.code == 0
+    assert captured["parameter"] == "amplitude"
+    assert captured["target_knockdown"] == pytest.approx(0.85)
+    assert captured["target_strength_MPa"] is None
+    assert captured["analytical_only"] is None
+    assert captured["rtol"] == pytest.approx(1e-3)
+    assert captured["scan_points"] == 9
+    assert captured["bracket"] is None
+
+
+def test_critical_no_analytical_only_warns(capsys):
+    """T-61: the FE opt-in reaches the engine and is announced."""
+    captured, patcher = _capture_critical()
+    with patcher, pytest.raises(SystemExit):
+        cli_main([
+            "critical", "--target-knockdown", "0.85", "--no-analytical-only",
+        ])
+    assert captured["analytical_only"] is False
+    assert "warning:" in capsys.readouterr().err
+
+
+def test_critical_config_file_precedence(tmp_path):
+    """T-62: an explicit geometry flag beats the file; an omitted one
+    inherits it (the SUPPRESS invariant)."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    base = AnalysisConfig(
+        angles=[0.0] * 8, interface_1=3, interface_2=4,
+        ply_thickness=0.25, wavelength=20.0, loading="compression",
+    )
+    path = tmp_path / "base.json"
+    base.save_json(path)
+
+    captured, patcher = _capture_critical()
+    with patcher, pytest.raises(SystemExit):
+        cli_main([
+            "critical", "--config", str(path),
+            "--target-knockdown", "0.85", "--loading", "tension",
+        ])
+    cfg = captured["config"]
+    assert cfg.angles == [0.0] * 8          # inherited from the file
+    assert cfg.ply_thickness == pytest.approx(0.25)
+    assert cfg.wavelength == pytest.approx(20.0)
+    assert cfg.loading == "tension"         # overridden on the command line
+
+
+def test_critical_tension_without_a_config_file():
+    """T-63: tension is reachable from plain flags, not only via JSON."""
+    captured, patcher = _capture_critical()
+    with patcher, pytest.raises(SystemExit):
+        cli_main([
+            "critical", "--target-knockdown", "0.9", "--loading", "tension",
+        ])
+    assert captured["config"].loading == "tension"
+
+
+@pytest.mark.parametrize("argv", [
+    ["critical"],
+    ["critical", "--target-knockdown", "0.85",
+     "--target-strength", "1020.0"],
+])
+def test_critical_target_flags_are_exclusive_and_required(argv):
+    """T-64: argparse enforces exactly one target."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main(argv)
+    assert excinfo.value.code == 2
+
+
+def test_critical_unknown_parameter_exits_2(capsys):
+    """T-65: a bad field name is a clean exit 2, not a traceback."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main([
+            "critical", "--parameter", "amplitud",
+            "--target-knockdown", "0.85",
+        ])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
+def test_critical_integer_parameter_exits_2(capsys):
+    """T-66: integer fields are refused by name."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main([
+            "critical", "--parameter", "nz_per_ply",
+            "--target-knockdown", "0.85",
+        ])
+    assert excinfo.value.code == 2
+    assert "integer AnalysisConfig field" in capsys.readouterr().err
+
+
+def test_critical_inverted_bracket_exits_before_compute(capsys):
+    """T-67."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main([
+            "critical", "--target-knockdown", "0.85",
+            "--bracket", "0.5", "0.1",
+        ])
+    assert excinfo.value.code == 2
+    assert "--bracket" in capsys.readouterr().err
+
+
+def test_critical_no_crossing_exits_1_with_the_table(capsys):
+    """T-68: a shallow target still prints the curve context."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main(["critical", "--target-knockdown", "0.30"])
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Critical-Value Search" in captured.out
+    assert "Knockdown" in captured.out
+    assert "no_crossing" in captured.out
+    assert "not necessarily an error" in captured.err
+
+
+@pytest.mark.parametrize("exc", ["memory", "runtime", "linalg"])
+def test_critical_solver_failure_exits_1(capsys, exc):
+    """T-69: a blown-up forward solve is exit 1, never a traceback."""
+    import numpy as np
+
+    errors = {
+        "memory": MemoryError("out of memory"),
+        "runtime": RuntimeError("solver diverged"),
+        "linalg": np.linalg.LinAlgError("singular matrix"),
+    }
+
+    def boom(base_config, **kwargs):
+        raise errors[exc]
+
+    with patch("wrinklefe.goalseek.find_critical_value", new=boom):
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main(["critical", "--target-knockdown", "0.85"])
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
+def test_critical_converged_run_prints_the_criterion_line(capsys):
+    """T-70: the visible proof of the safe-side back-off."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main(["critical", "--target-knockdown", "0.85"])
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "Largest acceptable amplitude" in out
+    assert "Criterion satisfied: knockdown" in out
+    assert "Strength (MPa)" in out
+
+
+def test_critical_save_config_round_trips(tmp_path):
+    """T-71: the saved config is the run to attach to a disposition."""
+    from wrinklefe.analysis import AnalysisConfig
+
+    path = tmp_path / "critical.json"
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main([
+            "critical", "--target-knockdown", "0.85",
+            "--save-config", str(path),
+        ])
+    assert excinfo.value.code == 0
+    restored = AnalysisConfig.load(path)
+    assert 0.05 < restored.amplitude < 0.09
+    assert restored.analytical_only is True
+
+
+def test_critical_save_plot(tmp_path, monkeypatch):
+    """T-72."""
+    monkeypatch.setenv("MPLBACKEND", "Agg")
+    path = tmp_path / "critical.png"
+    with pytest.raises(SystemExit):
+        cli_main([
+            "critical", "--target-knockdown", "0.85",
+            "--save-plot", str(path),
+        ])
+    assert path.exists() and path.stat().st_size > 0
+
+
+def test_critical_json_and_csv_outputs(tmp_path, capsys):
+    """T-73: both payloads land and the stdout summary still prints."""
+    import csv
+    import json
+
+    json_path = tmp_path / "critical.json"
+    csv_path = tmp_path / "critical.csv"
+    with pytest.raises(SystemExit):
+        cli_main([
+            "critical", "--target-knockdown", "0.85",
+            "--output-json", str(json_path), "--output-csv", str(csv_path),
+        ])
+
+    payload = json.loads(json_path.read_text())
+    assert isinstance(payload, dict)
+    for key in (
+        "parameter", "objective", "target", "status", "critical_value",
+        "critical_value_root", "achieved_knockdown", "bounds",
+        "bounds_source", "scan_values", "scan_objectives", "sign_changes",
+        "critical_config", "evaluations", "runs",
+    ):
+        assert key in payload
+    assert payload["status"] == "converged"
+    assert payload["critical_config"]["amplitude"] == pytest.approx(
+        payload["critical_value"]
+    )
+
+    rows = list(csv.DictReader(csv_path.open()))
+    assert len(rows) == payload["n_evaluations"]
+    assert {"parameter_name", "parameter_value", "morphology",
+            "knockdown", "predicted_strength_MPa"} <= set(rows[0])
+    assert "Critical-Value Search" in capsys.readouterr().out

--- a/tests/test_goalseek.py
+++ b/tests/test_goalseek.py
@@ -1,0 +1,764 @@
+"""Tests for the inverse goal-seek helper (issue #280).
+
+The load-bearing property under test is *not* "brentq finds a root" — it
+is that the returned value satisfies the criterion under a real forward
+evaluation, and that a curve which does not admit a unique root is
+refused rather than answered.  Assertions are on structure (status,
+direction, sign_changes, bounds_source) and on the forward round-trip
+inequality; physics constants appear only as loose sanity bounds,
+because the repo's sanctioned pinning mechanism is
+``tests/test_validation/ledger.json`` + ``scripts/validate.py --update``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import wrinklefe.goalseek as gs
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis, WrinkleSpec
+from wrinklefe.core.penetration_gate import GATE_LI2025_VACBAG
+from wrinklefe.goalseek import find_critical_value
+
+# --------------------------------------------------------------------------- #
+# Stubbed forward model (fast, deterministic, closed-form root)
+# --------------------------------------------------------------------------- #
+
+#: Law parameters, monkeypatched per test.
+_LAW: dict[str, object] = {}
+
+
+@dataclass
+class _FakeResults:
+    config: AnalysisConfig
+    analytical_knockdown: float
+    analytical_modulus_knockdown: float = 1.0
+    analytical_onset_knockdown: float | None = None
+    analytical_strength_MPa: float = 0.0
+    modulus_retention_global: float = 1.0
+    modulus_retention_global_failed: bool = False
+    mesh: object | None = None
+
+
+class _FakeAnalysis:
+    """Evaluates the law registered in ``_LAW`` at ``cfg.amplitude``."""
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def run(self, analytical_only=None):
+        law = _LAW["law"]
+        parameter = _LAW.get("parameter", "amplitude")
+        value = getattr(self.cfg, parameter)
+        kd = float(law(value))  # type: ignore[operator]
+        return _FakeResults(
+            config=self.cfg,
+            analytical_knockdown=kd,
+            analytical_modulus_knockdown=kd,
+            analytical_strength_MPa=1200.0 * kd,
+        )
+
+
+@pytest.fixture()
+def stubbed(monkeypatch):
+    """Route every forward solve to ``_LAW['law']``."""
+    monkeypatch.setattr(gs, "WrinkleAnalysis", _FakeAnalysis)
+    _LAW.clear()
+    _LAW["law"] = _decreasing_law()
+    yield _LAW
+    _LAW.clear()
+
+
+def _decreasing_law(floor: float = 0.0, a0: float = 0.2):
+    """``kd(A) = floor + (1 - floor) / (1 + A / a0)`` — root in closed form."""
+
+    def law(value: float) -> float:
+        return floor + (1.0 - floor) / (1.0 + value / a0)
+
+    return law
+
+
+def _decreasing_root(target: float, floor: float = 0.0, a0: float = 0.2) -> float:
+    """Exact inverse of :func:`_decreasing_law`."""
+    return a0 * ((1.0 - floor) / (target - floor) - 1.0)
+
+
+def _increasing_law(a0: float = 0.2):
+    """Mirror of the decreasing law: safer as the parameter grows."""
+
+    def law(value: float) -> float:
+        return 1.0 - 1.0 / (1.0 + value / a0)
+
+    return law
+
+
+def _increasing_root(target: float, a0: float = 0.2) -> float:
+    return a0 * (1.0 / (1.0 - target) - 1.0)
+
+
+def _base(**overrides) -> AnalysisConfig:
+    defaults = dict(
+        amplitude=0.366, wavelength=16.0, width=12.0,
+        morphology="stack", loading="compression",
+    )
+    defaults.update(overrides)
+    return AnalysisConfig(**defaults)
+
+
+# --------------------------------------------------------------------------- #
+# T-1..T-13: stubbed logic
+# --------------------------------------------------------------------------- #
+
+
+def test_closed_form_root_decreasing(stubbed):
+    """T-1: the answer matches the analytic root within rtol."""
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status == "converged"
+    assert result.direction == "decreasing"
+    assert result.critical_value == pytest.approx(
+        _decreasing_root(0.5), rel=1e-3
+    )
+
+
+def test_closed_form_root_increasing(stubbed):
+    """T-2: an increasing objective returns the *smallest* safe value."""
+    stubbed["law"] = _increasing_law()
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status == "converged"
+    assert result.direction == "increasing"
+    assert result.critical_value == pytest.approx(
+        _increasing_root(0.5), rel=1e-3
+    )
+    assert "Smallest acceptable amplitude" in result.summary()
+
+
+@pytest.mark.parametrize(
+    "target", [0.95, 0.9, 0.85, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3]
+)
+@pytest.mark.parametrize("increasing", [False, True])
+def test_safe_side_guarantee(stubbed, target, increasing):
+    """T-3: the returned value satisfies the criterion, never merely
+    approaches it — the guarantee the whole feature rests on."""
+    stubbed["law"] = _increasing_law() if increasing else _decreasing_law()
+    result = find_critical_value(_base(), target_knockdown=target)
+    assert result.status == "converged"
+    assert result.achieved_objective >= target
+    assert abs(result.achieved_objective - target) <= result.rtol * target
+
+
+def test_backoff_actually_runs(stubbed):
+    """T-3 (cont.): at least one target needs a real back-off step."""
+    backed_off = 0
+    for target in (0.95, 0.9, 0.85, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3):
+        result = find_critical_value(_base(), target_knockdown=target)
+        if result.critical_value != result.critical_value_root:
+            backed_off += 1
+            assert any(
+                ev.phase == "backoff" for ev in result.evaluations
+            )
+    assert backed_off >= 1
+
+
+def test_backoff_budget_exhausted_is_flat(stubbed):
+    """T-4: a near-vertical law cannot be resolved — refuse, don't hang."""
+
+    def cliff(value: float) -> float:
+        return 0.9 if value < 1.0 else 0.1
+
+    stubbed["law"] = cliff
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status in {"flat", "non_monotonic"}
+    assert result.critical_value is None
+
+
+def test_target_below_floor_is_no_crossing(stubbed):
+    """T-5: nothing in range violates the criterion."""
+    stubbed["law"] = _decreasing_law(floor=0.4)
+    result = find_critical_value(_base(), target_knockdown=0.3)
+    assert result.status == "no_crossing"
+    assert result.critical_value is None
+    assert result.bounds_source[1] == "laminate_thickness"
+    assert "laminate_thickness" in result.message
+    assert f"{min(result.scan_objectives):.6g}" in result.message
+
+
+@pytest.mark.parametrize("increasing", [False, True])
+def test_target_above_everything_is_unreachable(stubbed, increasing):
+    """T-6: the (sign, direction) table is direction-independent."""
+    # Both laws stay well below the target across the whole range, so
+    # the residual never changes sign in either direction.
+    stubbed["law"] = (
+        (lambda value: 0.20 + 0.02 * value)
+        if increasing
+        else (lambda value: 0.30 - 0.02 * value)
+    )
+    result = find_critical_value(_base(), target_knockdown=0.95)
+    assert result.status == "target_unreachable"
+    assert result.critical_value is None
+    assert "meets the criterion" in result.message
+
+
+def test_constant_law_is_flat(stubbed):
+    """T-7: a parameter with no effect is refused, not root-found."""
+    stubbed["law"] = lambda value: 0.7
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status == "flat"
+    assert result.critical_value is None
+
+
+def test_bit_exact_plateau_at_target_is_flat(stubbed):
+    """T-8: a plateau sitting on the target has no unique root."""
+
+    def plateau(value: float) -> float:
+        if value < 1.0:
+            return 0.5
+        return 0.5 - 0.3 * (value - 1.0)
+
+    stubbed["law"] = plateau
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status == "flat"
+    assert "0.5" in result.message
+
+
+def test_plateau_away_from_target_still_converges(stubbed):
+    """T-9: a bit-exact tie is not a direction reversal."""
+
+    def plateau(value: float) -> float:
+        if value < 0.5:
+            return 0.9
+        return max(0.9 - 1.5 * (value - 0.5), 0.05)
+
+    stubbed["law"] = plateau
+    result = find_critical_value(_base(), target_knockdown=0.6)
+    assert result.status == "converged"
+    assert result.achieved_objective >= 0.6
+
+
+def _u_shaped(value: float) -> float:
+    """Minimum at 0.05 — inside the first 2 % of a [0, 4.392] range.
+
+    The curve dips to 0.1 and has fully recovered by 0.4, so a linear
+    grid over the same range never sees the dip at all.
+    """
+    if value <= 0.05:
+        return 1.0 - 18.0 * value
+    return min(0.1 + 2.4 * (value - 0.05), 0.95)
+
+
+def test_u_shape_is_non_monotonic(stubbed):
+    """T-10: an interior minimum is detected and refused."""
+    stubbed["law"] = _u_shaped
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status == "non_monotonic"
+    assert result.sign_changes >= 2
+    assert result.critical_value is None
+    assert "not monotonic" in result.message
+
+
+def test_linear_spacing_would_miss_the_u_shape(stubbed, monkeypatch):
+    """T-11: pins the reason the scan is log-spaced.
+
+    With a linear grid over ``[0, 4.392]`` the first interior probe sits
+    at 0.549, well past the minimum at 0.05 and past the recovery, so
+    the scan sees a monotone curve and the refusal above never fires.
+    """
+    stubbed["law"] = _u_shaped
+
+    def linear_grid(lo, cap, n):
+        import numpy as np
+
+        return [float(v) for v in np.linspace(lo, cap, n)], False
+
+    monkeypatch.setattr(gs, "_scan_grid", linear_grid)
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    assert result.status != "non_monotonic"
+    assert result.sign_changes <= 1
+
+
+def test_explicit_bracket_is_respected(stubbed):
+    """T-12: no evaluation escapes an explicit bracket."""
+    result = find_critical_value(
+        _base(), target_knockdown=0.5, bracket=(0.05, 0.5)
+    )
+    assert result.bounds_source == ("user_bracket", "user_bracket")
+    assert result.bounds == (0.05, 0.5)
+    for ev in result.evaluations:
+        assert 0.05 <= ev.value <= 0.5
+
+
+def test_evaluation_ledger(stubbed):
+    """T-13: the ledger is complete, ordered and phase-tagged."""
+    result = find_critical_value(
+        _base(), target_knockdown=0.5, scan_points=7
+    )
+    assert result.n_evaluations == len(result.evaluations)
+    assert [ev.index for ev in result.evaluations] == list(
+        range(result.n_evaluations)
+    )
+    assert {ev.phase for ev in result.evaluations} <= {
+        "scan", "root", "verify", "backoff"
+    }
+    assert any(ev.phase == "verify" for ev in result.evaluations)
+    assert len(result.scan_values) == 7
+    assert len(result.scan_objectives) == 7
+
+
+# --------------------------------------------------------------------------- #
+# T-14..T-18: validation
+# --------------------------------------------------------------------------- #
+
+_INTEGER_FIELDS = [
+    "interface_1",
+    "interface_2",
+    "nx",
+    "ny",
+    "nz_per_ply",
+    "iterative_maxiter",
+    "surface_transition_plies",
+    "progressive_n_increments",
+    "czm_n_load_increments",
+]
+
+
+@pytest.mark.parametrize("parameter", _INTEGER_FIELDS)
+def test_integer_fields_are_refused_by_name(parameter):
+    """T-14a: every integer field gets the integer-specific message."""
+    with pytest.raises(ValueError, match="integer AnalysisConfig field"):
+        find_critical_value(
+            _base(), parameter=parameter, target_knockdown=0.9
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (dict(parameter="amplitud", target_knockdown=0.9),
+         "no continuously-searchable field"),
+        (dict(parameter="morphology", target_knockdown=0.9),
+         "is a str, not a float"),
+        (dict(parameter="analytical_only", target_knockdown=0.9),
+         "boolean AnalysisConfig field"),
+        (dict(parameter="phase", target_knockdown=0.9), "is None"),
+        (dict(), "exactly one of"),
+        (dict(target_knockdown=0.9, target_strength_MPa=1000.0),
+         "exactly one of"),
+        (dict(target_knockdown=1.0), "degenerate"),
+        (dict(target_knockdown=1.5), r"\(0.0, 1.0\)"),
+        (dict(target_knockdown=0.0), r"\(0.0, 1.0\)"),
+        (dict(target_strength_MPa=-1.0), "must be a finite value > 0"),
+        (dict(target_knockdown=0.9, rtol=0.0), "rtol must be"),
+        (dict(target_knockdown=0.9, rtol=1e-16), "rtol must be"),
+        (dict(target_knockdown=0.9, rtol=0.5), "rtol must be"),
+        (dict(target_knockdown=0.9, scan_points=2), "scan_points must be"),
+        (dict(target_knockdown=0.9, objective="bogus"), "unknown objective"),
+        (dict(target_knockdown=0.9, objective="modulus_retention"),
+         "over-predicts"),
+        (dict(target_knockdown=0.9, objective="retention_factors"),
+         "hard-clamped"),
+        (dict(target_knockdown=0.9, objective="progressive_knockdown"),
+         "load-stepped"),
+        (dict(target_knockdown=0.9, bracket=(0.5, 0.1)), "lo < hi"),
+        (dict(target_knockdown=0.9, bracket=(-1.0, 0.1)), "must be >= 0"),
+        (dict(target_strength_MPa=100.0, objective="modulus_knockdown"),
+         "cannot be combined"),
+    ],
+)
+def test_validation_table(kwargs, match):
+    """T-14b: every input error raises ValueError before any compute."""
+    with pytest.raises(ValueError, match=match):
+        find_critical_value(_base(), **kwargs)
+
+
+def test_zero_valued_base_parameter_needs_a_bracket():
+    """T-15: a scaled range around zero is degenerate."""
+    with pytest.raises(ValueError, match="bracket"):
+        find_critical_value(
+            _base(), parameter="decay_floor", target_knockdown=0.9
+        )
+
+
+def test_negative_base_parameter_stays_negative(stubbed):
+    """T-16: applied_strain defaults to -0.01; the range must not flip
+    to the tension half-line."""
+    _LAW["parameter"] = "applied_strain"
+    _LAW["law"] = lambda value: 0.5
+    result = find_critical_value(
+        _base(), parameter="applied_strain", target_knockdown=0.9
+    )
+    lo, cap = result.bounds
+    assert lo < 0.0 and cap < 0.0 and lo < cap
+    assert all(ev.value < 0.0 for ev in result.evaluations)
+
+
+def test_fe_feature_ladder_refuses_analytical_only():
+    """T-17a: an FE-only feature plus analytical_only=True is an error."""
+    with pytest.raises(ValueError, match="enable_czm"):
+        find_critical_value(
+            _base(enable_czm=True), target_knockdown=0.9,
+            analytical_only=True,
+        )
+
+
+def test_fe_feature_ladder_resolves_none_to_fe(caplog):
+    """T-17b: analytical_only=None resolves to the FE path, loudly."""
+    cfg = _base(enable_czm=True)
+    with caplog.at_level("WARNING"):
+        assert gs._resolve_analytical_only(cfg, None) is False
+    assert "enable_czm" in caplog.text
+
+
+def test_transverse_mode_refusal_names_both_remedies():
+    """T-17c: the through-width mode is FE-only too."""
+    cfg = _base(transverse_mode="gaussian_decay", transverse_width=6.0)
+    with pytest.raises(ValueError) as excinfo:
+        find_critical_value(cfg, target_knockdown=0.9, analytical_only=True)
+    message = str(excinfo.value)
+    assert "transverse_mode" in message
+    assert "analytical_only=False" in message
+
+
+@pytest.mark.parametrize("analytical_only", [None, True, False])
+def test_progressive_damage_is_refused_outright(analytical_only):
+    """T-17d: ~30 load-stepped solves per evaluation is hours."""
+    cfg = _base(enable_progressive_damage=True)
+    with pytest.raises(ValueError, match="parametric_sweep"):
+        find_critical_value(
+            cfg, target_knockdown=0.9, analytical_only=analytical_only
+        )
+
+
+def test_tool_flat_cannot_be_searched_analytically():
+    """T-17e: tool_flat is an FE morphology (it auto-enables surface
+    resin pockets, which AnalysisConfig rejects analytically)."""
+    cfg = _base(amplitude=0.05, morphology="tool_flat")
+    with pytest.raises(ValueError, match="analytical_only"):
+        find_critical_value(cfg, target_knockdown=0.9, analytical_only=True)
+
+
+def test_wrinkles_list_makes_amplitude_inert():
+    """T-18: cfg.amplitude is ignored when 'wrinkles' is set."""
+    cfg = _base(
+        wrinkles=[
+            WrinkleSpec(
+                amplitude=0.3, wavelength=16.0, width=12.0, ply_interface=11
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="is ignored when 'wrinkles' is set"):
+        find_critical_value(cfg, target_knockdown=0.9)
+
+
+def test_summary_contains_the_search_evidence(stubbed):
+    """T-19: summary() is the text a user quotes in a disposition."""
+    result = find_critical_value(_base(), target_knockdown=0.5)
+    text = result.summary()
+    assert "amplitude" in text
+    assert "Criterion satisfied:" in text
+    assert "0.500000" in text
+    assert result.status == "converged"
+    for value in result.scan_values:
+        assert f"{value:.6g}" in text
+
+
+def test_replace_swept_parity_with_parametric_sweep():
+    """T-20: the shared clone helper matches the sweep it was lifted from."""
+    from wrinklefe.analysis import _replace_swept
+
+    base = _base()
+    assert base.domain_length == pytest.approx(48.0)
+    cloned = _replace_swept(base, "wavelength", 64.0)
+    assert cloned.domain_length == pytest.approx(192.0)
+
+    pinned = _base(domain_length=99.0)
+    kept = _replace_swept(pinned, "wavelength", 64.0)
+    assert kept.domain_length == pytest.approx(99.0)
+
+
+def test_resolved_analytical_only_reaches_every_clone(stubbed):
+    """T-21: a saved result records the path it actually ran on."""
+    result = find_critical_value(
+        _base(), target_knockdown=0.5, keep_results=True
+    )
+    assert result.analytical_only is True
+    assert result.results is not None
+    assert len(result.results) == result.n_evaluations
+    for run in result.results:
+        assert run.config.analytical_only is True
+    assert result.critical_config.analytical_only is True
+
+
+# --------------------------------------------------------------------------- #
+# T-30..T-44: the real analytical model (~40 ms per forward evaluation)
+# --------------------------------------------------------------------------- #
+
+
+def _readme_default(**overrides) -> AnalysisConfig:
+    return _base(**overrides)
+
+
+def test_readme_default_reaches_the_target():
+    """T-30 (AC1): a forward run at the answer reproduces the target."""
+    result = find_critical_value(_readme_default(), target_knockdown=0.9)
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    assert forward.analytical_knockdown >= 0.9
+    assert forward.analytical_knockdown == pytest.approx(0.9, rel=1e-3)
+    assert result.critical_value == pytest.approx(0.040, rel=0.05)
+
+
+def test_compression_acceptance_limit():
+    """T-31 (AC3a)."""
+    result = find_critical_value(_readme_default(), target_knockdown=0.85)
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    assert forward.analytical_knockdown >= 0.85
+    assert result.critical_value == pytest.approx(0.0665, rel=0.05)
+
+
+def test_tension_acceptance_limit():
+    """T-32 (AC3b): the same question on the tension path."""
+    result = find_critical_value(
+        _readme_default(loading="tension"), target_knockdown=0.9
+    )
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    assert forward.analytical_knockdown >= 0.9
+
+
+def test_no_crossing_is_clean_not_a_traceback():
+    """T-33 (AC2): a shallow target refuses cleanly."""
+    result = find_critical_value(_readme_default(), target_knockdown=0.30)
+    assert result.status == "no_crossing"
+    assert result.critical_value is None
+    assert result.bounds_source[1] == "laminate_thickness"
+    assert min(result.scan_objectives) == pytest.approx(0.41, rel=0.05)
+    assert "not necessarily an error" in result.message
+
+
+@pytest.mark.parametrize("target", [0.9, 0.85, 0.6, 0.5])
+def test_safe_side_on_the_real_model(target):
+    """T-34: regression for the measured 3-of-4 raw-root violation."""
+    result = find_critical_value(
+        _readme_default(), target_knockdown=target
+    )
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    assert forward.analytical_knockdown >= target
+
+
+def test_strength_target_matches_the_knockdown_target():
+    """T-35: an MPa target is the same question in strength units."""
+    by_mpa = find_critical_value(
+        _readme_default(), target_strength_MPa=1020.0
+    )
+    by_kd = find_critical_value(_readme_default(), target_knockdown=0.85)
+    assert by_mpa.status == "converged"
+    assert by_mpa.target_is_strength is True
+    assert by_mpa.objective_name == "strength_MPa"
+    assert by_mpa.critical_value == pytest.approx(
+        by_kd.critical_value, rel=1e-3
+    )
+    assert by_mpa.pristine_reference_MPa == pytest.approx(1200.0, rel=1e-6)
+
+
+def test_modulus_knockdown_objective():
+    """T-36: a stiffness-driven acceptance limit."""
+    result = find_critical_value(
+        _readme_default(), objective="modulus_knockdown",
+        target_knockdown=0.8,
+    )
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    assert forward.analytical_modulus_knockdown >= 0.8
+
+
+def test_fe_only_objective_refused_on_the_analytical_path():
+    """T-37."""
+    with pytest.raises(ValueError, match="modulus_retention_global"):
+        find_critical_value(
+            _readme_default(), objective="modulus_retention_global",
+            target_knockdown=0.9,
+        )
+
+
+def test_onset_objective_refused_under_compression():
+    """T-38."""
+    with pytest.raises(ValueError, match="tension"):
+        find_critical_value(
+            _readme_default(), objective="onset_knockdown",
+            target_knockdown=0.9,
+        )
+
+
+def test_wavelength_goal_seek_resets_the_domain_sentinel():
+    """T-39: the auto-derived domain follows the swept wavelength."""
+    result = find_critical_value(
+        _readme_default(), parameter="wavelength", target_knockdown=0.8
+    )
+    assert result.status == "converged"
+    assert result.direction == "increasing"
+    assert result.critical_config.domain_length == pytest.approx(
+        3.0 * result.critical_config.wavelength
+    )
+
+
+def test_graded_wavelength_u_shape_is_refused():
+    """T-40: the measured counterexample to #280's monotonicity premise.
+
+    Configuration: amplitude=0.5, angles=[0]*24, morphology='graded'.
+    The through-thickness Gaussian widens with wavelength, so the
+    knockdown curve has an interior minimum near lambda ~ 3 mm.
+    Reporting a root here would hand back a safe-sounding limit for a
+    catastrophically failing geometry.
+    """
+    cfg = _base(
+        amplitude=0.5, angles=[0.0] * 24, morphology="graded"
+    )
+    result = find_critical_value(
+        cfg, parameter="wavelength", bracket=(1.0, 128.0),
+        target_knockdown=0.40,
+    )
+    assert result.status == "non_monotonic"
+    assert result.sign_changes >= 2
+    assert result.critical_value is None
+    assert min(result.scan_objectives) < 0.20
+    assert "graded" in result.message
+
+
+def test_saturated_penetration_gate_is_flat():
+    """T-41: a near-surface wrinkle under the gate barely responds."""
+    cfg = _base(
+        morphology="graded", penetration_gate=GATE_LI2025_VACBAG,
+        wrinkle_z_position=0.042,
+    )
+    result = find_critical_value(cfg, target_knockdown=0.9)
+    assert result.status == "flat"
+    assert result.critical_value is None
+    span = max(result.scan_objectives) - min(result.scan_objectives)
+    assert span < result.rtol * 0.9
+
+
+def test_gate_ply_thickness_plateau_still_converges():
+    """T-42: a plateau of exact ties away from the target is not a
+    reversal, so the well-posed problem is answered, not refused."""
+    cfg = _base(angles=[0.0] * 24, penetration_gate=GATE_LI2025_VACBAG)
+    result = find_critical_value(
+        cfg, parameter="ply_thickness", bracket=(0.001, 0.183),
+        target_knockdown=0.90,
+    )
+    assert result.status == "converged"
+    assert result.critical_value == pytest.approx(0.147, rel=0.10)
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=True
+    )
+    assert forward.analytical_knockdown >= 0.90
+
+
+def test_tension_knockdown_is_monotone_in_amplitude():
+    """T-43: pins the compression cap that keeps the tension analytical
+    knockdown monotone over a dense amplitude scan."""
+    cfg = _base(angles=[0.0] * 24, loading="tension")
+    previous = 2.0
+    for i in range(25):
+        amplitude = 0.02 * (i + 1)
+        run = WrinkleAnalysis(
+            AnalysisConfig(
+                amplitude=amplitude, wavelength=16.0, width=12.0,
+                angles=cfg.angles, loading="tension",
+            )
+        ).run(analytical_only=True)
+        assert run.analytical_knockdown <= previous + 1e-12
+        previous = run.analytical_knockdown
+
+
+def test_search_is_deterministic():
+    """T-44: no RNG, no cache, no module state."""
+    first = find_critical_value(_readme_default(), target_knockdown=0.85)
+    second = find_critical_value(_readme_default(), target_knockdown=0.85)
+    assert first.critical_value == second.critical_value
+    assert first.scan_objectives == second.scan_objectives
+
+
+# --------------------------------------------------------------------------- #
+# T-50..T-52: the real FE path
+# --------------------------------------------------------------------------- #
+
+# Each of these runs ~19 forward evaluations, and one FE evaluation is 4
+# full linear solves (~1.1 s on the 8-ply mesh below), so budget ~25 s
+# each plus the verifying re-run. They are the only place the FE clause
+# of acceptance criterion 3 is non-vacuous: 'modulus_retention_global'
+# is the one listed objective whose value differs between the analytical
+# and FE paths (analytical_knockdown is computed before the
+# analytical_only branch, so it is bit-identical on both).
+
+
+def _fe_config(**overrides) -> AnalysisConfig:
+    defaults = dict(
+        amplitude=0.05, wavelength=16.0, width=12.0,
+        angles=[0.0, 90.0, 90.0, 0.0, 0.0, 90.0, 90.0, 0.0],
+        nx=8, ny=2, nz_per_ply=1, analytical_only=False,
+    )
+    defaults.update(overrides)
+    return AnalysisConfig(**defaults)
+
+
+@pytest.mark.slow
+def test_fe_path_compression_acceptance_limit():
+    """T-50 (AC3c): a real FE round-trip on the FE-only objective."""
+    result = find_critical_value(
+        _fe_config(), objective="modulus_retention_global",
+        target_knockdown=0.99, bracket=(0.01, 0.45), scan_points=3,
+        rtol=1e-2, analytical_only=False,
+    )
+    assert result.analytical_only is False
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=False
+    )
+    assert forward.modulus_retention_global >= 0.99
+
+
+@pytest.mark.slow
+def test_fe_path_tension_acceptance_limit():
+    """T-51 (AC3d): the same question with loading='tension'.
+
+    The global stiffness retention is load-direction independent, so the
+    answer matches the compression case; what this covers is that the
+    whole tension config path survives an FE goal-seek.
+    """
+    result = find_critical_value(
+        _fe_config(loading="tension"),
+        objective="modulus_retention_global", target_knockdown=0.99,
+        bracket=(0.01, 0.45), scan_points=3, rtol=1e-2,
+        analytical_only=False,
+    )
+    assert result.status == "converged"
+    forward = WrinkleAnalysis(result.critical_config).run(
+        analytical_only=False
+    )
+    assert forward.modulus_retention_global >= 0.99
+
+
+def test_fe_path_clamps_the_amplitude_bound(monkeypatch):
+    """T-52: the mesh-inversion limit caps the search on the FE path.
+
+    The bound resolution is pure arithmetic, so this needs no solve.
+    """
+    cfg = _readme_default(analytical_only=False)
+    lo, cap, source = gs._resolve_bounds(
+        cfg, "amplitude", None, None, analytical_only=False
+    )
+    assert source[1] == "mesh_amplitude_safe"
+    assert cap == pytest.approx(2.5 * cfg.ply_thickness / cfg.nz_per_ply)
+    assert lo == 0.0


### PR DESCRIPTION
## Linked issue

Part of #280 (engine + CLI slice). The Streamlit "Find acceptable limit" mode and the NCR-summary field land in a follow-up PR that closes the issue — the same split #375 shipped with (`6c29c81` CLI slice, then `6d62457` app slice).

## Summary

Inverts the analysis. Instead of "given this wrinkle, what is the knockdown?", `wrinklefe.goalseek.find_critical_value` / `wrinklefe critical` answer "given this allowable, what is the largest wrinkle we can accept?" — the number an inspection criterion or an NCR disposition is written around.

```
wrinklefe critical --parameter amplitude --target-knockdown 0.85
```

Two properties are load-bearing, and both are corrections to the naive `brentq` wrapper the issue describes.

### 1. The answer is verified, not merely converged

`brentq` converges *to* a root, not to the side of it that satisfies the inequality. Measured on the README default with a plain `brentq(kd - t, 0, 5, rtol=1e-3)`, the raw root **violates** its own criterion in three targets out of four (0.899998556 for a 0.90 target, 0.849999472 for 0.85, 0.499996136 for 0.50). For an acceptance limit that is the wrong sign of wrong, so the search backs the answer off toward safety and verifies it with an extra forward solve. Acceptance is an inequality plus a conservatism bound, and the printed `Criterion satisfied:` line is that check made visible.

### 2. The issue's monotonicity premise is refuted in general — so the search refuses

> "knockdown is monotonically decreasing in amplitude ... so the root is unique over the bracket"

True for **amplitude**. Not true in general, and the counterexamples are measured, not hypothetical:

- **`morphology="graded"` vs wavelength is U-shaped.** For `amplitude=0.5`, `angles=[0]*24`, `graded`, the through-thickness Gaussian widens with wavelength, giving an interior minimum near λ ≈ 3 mm: KD = 0.443 (λ=1), **0.123 (λ=3)**, 0.228 (λ=8), 0.955 (λ=128). A root-find that assumed monotonicity returns whichever side it happened to bracket — a safe-sounding limit for a configuration that fails catastrophically just inside it.
- **Bit-identical plateaus.** Under `GATE_LI2025_VACBAG`, `ply_thickness ∈ [0.001, 0.125]` all give KD = 0.8132152973395818 to the last bit; a near-surface wrinkle (`wrinkle_z_position=0.042`) varies by 1.4e-06 across three decades of amplitude.

So the engine **measures** direction from a log-spaced scan of the resolved range and classifies the curve *before* any terminal status is chosen. `brentq` is unreachable unless the scan found exactly one sign change and no direction reversal. Otherwise the search returns a refusal with an actionable, measurement-quoting message — never a scipy traceback, and never an arbitrary root:

| status | meaning |
|---|---|
| `no_crossing` | nothing in range violates the criterion (**not necessarily an error**) |
| `target_unreachable` | nothing in range meets it |
| `non_monotonic` | more than one root / a direction reversal — refuses rather than guessing |
| `flat` | the parameter is inert for this configuration; no resolvable root |

Log spacing is load-bearing, not cosmetic: a linear grid over a wide range walks straight past an interior extremum, and there is a test that pins exactly that.

### Measured examples

**A converged acceptance limit** — README default `AnalysisConfig(amplitude=0.366, wavelength=16.0, width=12.0)`, `target_knockdown=0.85`:

```
->        0.0665       0.8500           1020.0   backoff

  Largest acceptable amplitude: 0.066516
  Achieved knockdown:  0.850000  (target 0.850000, rtol 1.0e-03)
  Criterion satisfied: knockdown 0.850000 >= 0.850000
  Forward-model evaluations: 24   (0.81 s)
```

Raw `brentq` root 0.06652953; backed off to 0.06651592. A **forward re-run** of the returned `critical_config` gives `analytical_knockdown = 0.8500000719548825 >= 0.85` — the guarantee, checked against the real model rather than the root tolerance.

**A refusal** — same config, `target_knockdown=0.30`, exit 1:

```
error: no value of 'amplitude' in [0, 4.392] violates the criterion
'knockdown >= 0.3'. The objective was scanned at 9 points over that range;
its minimum is 0.424172 at amplitude = 4.392 — still above the target. The
upper bound came from 'laminate_thickness' (4.392 mm = len(angles) *
ply_thickness). To search further raise max_value or pass an explicit
bracket. Otherwise pick a target above 0.424172. This is not necessarily an
error: it means no defect size in range fails your criterion.
```

The other three statuses were exercised the same way: `non_monotonic` on the graded-wavelength case (2 sign changes, scanned minimum 0.126196 at λ = 3.36), `flat` on the saturated gate (span 1.38e-06), `target_unreachable` on `bracket=(1, 4)` with a 0.99 target (scanned maximum 0.490625).

### Also

- Bounds are **sign-aware** — `applied_strain` defaults to −0.01, so a scaled range must stay on the negative half-line — and the upper bound is clamped by the `tool_flat` validation limit and by `mesh_shear_diagnostics`' `amplitude_safe` on the FE path, so the search cannot die mid-run on a legal-looking probe.
- Integer, boolean and string config fields are refused **by name** with the right remedy (`nz_per_ply` points at `mesh_convergence_study`), because `AnalysisConfig._validate` rejects a fractional probe.
- FE-only config features (CZM, resin pockets, progressive damage, non-uniform `transverse_mode`) force or refuse the FE path rather than silently no-opping — the same precedence rule #346 applied to `analyze`. `enable_progressive_damage` is refused outright (~30 load-stepped solves per evaluation).
- Targets may be a knockdown factor or an absolute MPa allowable (verified: `Xc = 1200.0`, so 1020 MPa and KD 0.85 find the same root).
- `_replace_swept` is lifted out of `parametric_sweep` so the sweep and the goal-seek clone configs identically. **The guard is preserved verbatim**: the `domain_length` sentinel resets only when the base config left it auto-derived; an explicitly pinned domain is untouched (already covered by `test_wavelength_sweep_respects_explicit_domain_length`).

### Notes on the checks

- **Adds no field to `AnalysisResults`** (the #345 export drift guard walks `fields(AnalysisResults)`) and **no field to `AnalysisConfig`** (the #259 round-trip guard) — every knob is a function argument, and the result is its own `CriticalValueResult`, exactly as `convergence` returns `ConvergenceStudy`.
- README material is a **new** `###` section; the pinned "Wrinkle geometry parameters" table and every default are untouched, so `test_param_docs_match.py` is unaffected.
- `goalseek.py` uses module-level `logging` only, with lazy `%`-formatting and zero `print()` — all user-facing output lives in `cli.py`.
- The forward model is untouched: `python scripts/validate.py` shows **zero drift** on all pinned cases.
- Cost: the plan quoted ~14 evaluations; the measured default is **~24** (9 scan + ~5 root + 1 verify + ~9 back-off). Every doc, help string and CHANGELOG line quotes the measured number (~25, or ~15 with `--bracket LO HI --scan-points 3`), not the estimate.

## Checklist

- [x] Tests added or updated for the change — 96 in `tests/test_goalseek.py` (2 `slow`, real FE) + 14 CLI cases
- [x] `pytest` green — `tests/test_goalseek.py` full (96 passed incl. `slow`), `tests/test_cli.py` (84), and the guard set (`test_export_results`, `test_config_io`, `test_param_docs_match`, `test_logging_conventions`, `test_analysis_sweep`, `test_validation`, `test_changelog`, `test_analysis_config_no_dead_fields`) all pass locally
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean
- [x] Docs/README updated — new `docs/api/goalseek.rst` + toctree, README section, `docs/theory.md` §5.2 on what monotonicity can and cannot be assumed, `docs/getting_started.md`, `examples/09_acceptance_limit.py` (~5 s, verified under a minimal `pip install -e .`). Also backfills `stochastic` in the four places it was never added.
- [x] `sphinx-build -W docs docs/_build` clean
- [x] `pytest --doctest-modules src/wrinklefe -q` clean (25 passed)
- [x] `CHANGELOG.md` `[Unreleased]` updated — `### Added` only; **no Numerical results entry**, the change is purely additive
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_