### PR TITLE
app: "Find acceptable limit" mode + acceptance limit on the NCR summary (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- App — **"Find acceptable limit" mode and the acceptance limit on the NCR
+  attachment** (issue #280, app slice — *Fixes #280*, completing the issue).
+  The Streamlit sidebar gains a **Find acceptable limit** button directly
+  under *Run analysis* (it searches the same inputs) plus an
+  *Acceptable-limit settings* expander: the searched parameter (amplitude
+  or wavelength), the target as either a knockdown factor or an absolute
+  MPa allowable, and — in Expert mode — the bracket, scan-point count and
+  root tolerance. The cost is stated before the click: the search runs on
+  the analytical path (~25 evaluations, well under a second) unless the
+  config enables an FE-only feature, in which case the expander warns that
+  it will spend ~25 FE solves. A converged search renders the limit, the
+  objective achieved at it and the evaluation count, and says plainly that
+  the reported value is the **conservative** one — backed off from the raw
+  `brentq` root and verified by an extra forward run — with the raw root
+  quoted only for transparency. A refusal renders the engine's own message
+  **verbatim** (`no_crossing` as a warning, since it can simply mean
+  nothing in range fails the criterion; `non_monotonic` / `flat` /
+  `target_unreachable` as errors), and the scanned curve and evaluation
+  ledger are shown either way because the curve is the diagnosis. **Apply
+  this limit to the sidebar** seeds the geometry widget through the #375
+  pending-seed mechanism, and the stored search is flagged stale by the
+  same payload hash-compare the run results use (#374).
+  `io.export.build_analysis_summary` gains an optional `critical_limit=`
+  mapping (additive; existing callers unaffected) that adds a
+  `critical_limit` block to the summary and an *Acceptance limit
+  (goal-seek)* sub-block to the Markdown and PDF attachments, carrying the
+  same non-binding MRB language as the rest of the summary. The app
+  attaches it **only** when the stored search converged *and* its config
+  payload equals the payload the displayed results were computed from — an
+  acceptance limit derived for different inputs must never ride along on an
+  NCR — and captions the omission when it does not.
 - Analysis — **inverse goal-seek: maximum acceptable wrinkle amplitude**
   (issue #280). New `wrinklefe.goalseek.find_critical_value(base_config, *,
   parameter='amplitude', target_knockdown=…, …)` scans the resolved search

--- a/README.md
+++ b/README.md
@@ -91,7 +91,23 @@ mode also exposes the through-width `transverse_mode` envelope, and the
 sidebar **Config file** section can **download** the current settings as a
 portable `AnalysisConfig` JSON — round-tripping with the CLI `--config` /
 `--save-config` flags — or **load** a saved case (JSON/YAML) back into the
-sidebar. See
+sidebar.
+
+A second sidebar button, **Find acceptable limit**, runs the inverse
+search on those same inputs — the browser form of
+[`wrinklefe critical`](#finding-the-maximum-acceptable-defect). Set a
+target knockdown (or an absolute MPa allowable) in the
+*Acceptable-limit settings* expander and the app reports the largest
+amplitude the laminate can carry and still meet it, together with the
+scanned knockdown curve and the per-evaluation ledger. The reported
+number is the conservative one — backed off from the root and verified
+by a real forward run — and one click applies it back to the sidebar so
+you can run the full analysis at the limit. When the search converged
+for the *same* configuration a run was made on, the limit is carried
+onto the NCR validation summary on the **Export** tab; a limit searched
+against different inputs is deliberately left off. If the curve admits
+no unique answer the app shows the engine's diagnosis and the measured
+curve instead of a number. See
 [`DEPLOYMENT_STREAMLIT.md`](docs/internal/DEPLOYMENT_STREAMLIT.md) for the full feature
 tour and instructions for self-hosting.
 
@@ -687,6 +703,11 @@ parameter is inert for the configuration (`flat`), the search exits 1 with
 a message quoting the measurements behind the refusal — never a scipy
 traceback. "No crossing in range" is not an error: it means no defect size
 in range fails your criterion.
+
+The same search is a button in the Streamlit app — **Find acceptable
+limit**, directly under *Run analysis* — which additionally carries the
+limit onto the NCR validation summary when the search and the run were
+made on the same configuration.
 
 ### Exporting results to CSV / JSON
 

--- a/app.py
+++ b/app.py
@@ -45,6 +45,11 @@ from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial  # noqa
 from wrinklefe.core.mesh import mesh_shear_diagnostics  # noqa: E402
 from wrinklefe.core.morphology import WrinkleConfiguration  # noqa: E402
 from wrinklefe.core.wrinkle import GaussianSinusoidal  # noqa: E402
+from wrinklefe.goalseek import (  # noqa: E402
+    DEFAULT_SCAN_POINTS,
+    CriticalValueResult,
+    find_critical_value,
+)
 from wrinklefe.io.export import (  # noqa: E402
     build_analysis_summary,
     render_summary_markdown,
@@ -189,6 +194,30 @@ DEFAULT_SURFACE_POCKET_SIDE = _CFG_DEFAULTS.surface_pocket_side
 # pinned flat surface. Mirrors ``AnalysisConfig`` so the UI cannot drift.
 DEFAULT_SURFACE_TRANSITION_PLIES = _CFG_DEFAULTS.surface_transition_plies
 
+# --- Inverse goal-seek ("Find acceptable limit", issue #280) -----------------
+# The two ways a target can be expressed. Knockdown is the headline case (it
+# is what a disposition is usually written against); an absolute MPa allowable
+# maps onto the engine's ``target_strength_MPa``.
+GS_TARGET_KNOCKDOWN = "Knockdown factor"
+GS_TARGET_STRENGTH = "Strength (MPa)"
+# Searchable parameters offered in the UI. ``find_critical_value`` accepts any
+# float ``AnalysisConfig`` field, but these two are the ones a disposition is
+# actually written around, and both have a sidebar widget to seed back.
+GS_PARAMETERS = ("amplitude", "wavelength")
+GS_PARAMETER_UNITS = {"amplitude": "mm", "wavelength": "mm"}
+DEFAULT_GS_PARAMETER = "amplitude"
+DEFAULT_GS_TARGET_MODE = GS_TARGET_KNOCKDOWN
+DEFAULT_GS_TARGET = 0.85
+DEFAULT_GS_TARGET_STRENGTH = 1000.0
+# 0.0 is the "auto" sentinel for both bracket bounds — Streamlit's
+# ``number_input`` cannot represent an empty value, and the engine derives a
+# far better range (laminate thickness, tool_flat and mesh-inversion clamps)
+# than a user typically would.
+DEFAULT_GS_BRACKET_LO = 0.0
+DEFAULT_GS_BRACKET_HI = 0.0
+DEFAULT_GS_SCAN_POINTS = DEFAULT_SCAN_POINTS
+DEFAULT_GS_RTOL = 1e-3
+
 # Single source of truth used by the "Reset to defaults" button: maps each
 # sidebar widget ``key=`` argument to the value it should hold after a reset.
 # Keep this aligned with the ``key=`` strings on the widgets below.
@@ -230,6 +259,15 @@ DEFAULTS: dict[str, object] = {
     "sb_enable_surface_pockets": DEFAULT_ENABLE_SURFACE_POCKETS,
     "sb_surface_pocket_side": DEFAULT_SURFACE_POCKET_SIDE,
     "sb_surface_transition_plies": DEFAULT_SURFACE_TRANSITION_PLIES,
+    # Inverse goal-seek — "Find acceptable limit" (issue #280).
+    "sb_gs_parameter": DEFAULT_GS_PARAMETER,
+    "sb_gs_target_mode": DEFAULT_GS_TARGET_MODE,
+    "sb_gs_target": DEFAULT_GS_TARGET,
+    "sb_gs_target_strength": DEFAULT_GS_TARGET_STRENGTH,
+    "sb_gs_bracket_lo": DEFAULT_GS_BRACKET_LO,
+    "sb_gs_bracket_hi": DEFAULT_GS_BRACKET_HI,
+    "sb_gs_scan_points": DEFAULT_GS_SCAN_POINTS,
+    "sb_gs_rtol": DEFAULT_GS_RTOL,
 }
 
 
@@ -243,13 +281,19 @@ def reset_inputs() -> None:
     dynamic custom-material editor keys (``custom_*``), which are seeded from
     the chosen material on each rerun and would otherwise survive the reset
     (issue #374).
+
+    The stored goal-seek result (issue #280) is dropped for the same reason:
+    an acceptance limit belongs to the configuration it was searched against,
+    and a Reset replaces that configuration wholesale.
     """
     for key, value in DEFAULTS.items():
         st.session_state[key] = value
     # Drop the results and the payload they were computed from so a Reset
     # returns the Analyze tab to its empty state instead of showing a stale
     # run against default inputs.
-    for run_key in ("results", "cfg_payload"):
+    for run_key in (
+        "results", "cfg_payload", "goalseek_result", "goalseek_payload",
+    ):
         st.session_state.pop(run_key, None)
     # st.session_state keys are ``str | int``; annotate so the reused loop
     # variable type-checks under the app's mypy gate.
@@ -893,6 +937,22 @@ with st.sidebar:
         for _run_key in ("results", "cfg_payload"):
             st.session_state.pop(_run_key, None)
         st.session_state["_config_loaded_toast"] = True
+
+    # Same mechanism for "Apply this limit to the sidebar" (issue #280): the
+    # Analyze tab stages ``(parameter, value)`` and reruns, and the geometry
+    # widget key is seeded here, before the widget exists. Values are clamped
+    # to the widget's own range so a limit outside it cannot raise.
+    _pending_gs_apply = st.session_state.pop("_pending_gs_apply", None)
+    if _pending_gs_apply is not None:
+        _gs_apply_param, _gs_apply_value = _pending_gs_apply
+        if _gs_apply_param == "amplitude":
+            st.session_state["sb_amplitude"] = _clamp(
+                float(_gs_apply_value), 0.0, 5.0
+            )
+        elif _gs_apply_param == "wavelength":
+            st.session_state["sb_wavelength"] = _clamp(
+                float(_gs_apply_value), 1.0, 200.0
+            )
 
     expert_mode = st.toggle(
         "Expert mode", value=DEFAULT_EXPERT_MODE, key="expert_mode",
@@ -1716,6 +1776,161 @@ with st.sidebar:
         ),
     )
 
+    # ------------------------------------------------------------------
+    # Inverse goal-seek — "Find acceptable limit" (issue #280).
+    #
+    # Run analysis answers "given this wrinkle, what is the knockdown?".
+    # A disposition is written around the inverse: "what is the largest
+    # wrinkle we can accept?". The button sits directly under Run
+    # analysis because it consumes exactly the same sidebar inputs — only
+    # the target and the searched parameter are extra, and those live in
+    # the settings expander below so the common case stays one click.
+    #
+    # The engine resolves the solve path itself (analytical unless the
+    # config enables an FE-only feature), so the cost note below is
+    # driven by the same flags the run handler uses and is shown BEFORE
+    # anything is spent.
+    # ------------------------------------------------------------------
+    goalseek_clicked = st.button(
+        "Find acceptable limit",
+        width="stretch",
+        disabled=run_disabled,
+        help=(
+            "Fix the mesh-inversion warning above before searching."
+            if run_disabled
+            else (
+                "Inverse search: the largest wrinkle these inputs can carry "
+                "while still meeting a target knockdown (or an absolute "
+                "MPa allowable). The answer is verified by a real forward "
+                "run on the safe side. Settings are in the expander below."
+            )
+        ),
+    )
+    with st.expander("Acceptable-limit settings", expanded=False):
+        gs_parameter = st.selectbox(
+            "Search parameter",
+            GS_PARAMETERS,
+            key="sb_gs_parameter",
+            help=(
+                "Which wrinkle dimension to solve for. **amplitude** is the "
+                "headline case — the number an inspection criterion is "
+                "written around. Knockdown is monotonic in amplitude but "
+                "*not* in wavelength for every morphology; the search "
+                "measures that and refuses rather than guessing."
+            ),
+        )
+        gs_target_mode = st.radio(
+            "Express the target as",
+            (GS_TARGET_KNOCKDOWN, GS_TARGET_STRENGTH),
+            key="sb_gs_target_mode",
+            horizontal=True,
+            help=(
+                "A knockdown factor (residual fraction of pristine "
+                "strength) or an absolute allowable in MPa. Both drive the "
+                "same search; the MPa form root-finds on strength directly."
+            ),
+        )
+        _gs_strength_mode = gs_target_mode == GS_TARGET_STRENGTH
+        gs_target = st.number_input(
+            "Target knockdown",
+            min_value=0.01, max_value=0.99,
+            value=DEFAULT_GS_TARGET, step=0.01, format="%.2f",
+            key="sb_gs_target",
+            disabled=_gs_strength_mode,
+            help=(
+                "Acceptance threshold as a residual-strength fraction: "
+                "0.85 means 'still carries 85 % of pristine strength'."
+            ),
+        )
+        gs_target_strength = st.number_input(
+            "Target strength [MPa]",
+            min_value=1.0, max_value=10000.0,
+            value=DEFAULT_GS_TARGET_STRENGTH, step=10.0,
+            key="sb_gs_target_strength",
+            disabled=not _gs_strength_mode,
+            help=(
+                "Acceptance threshold as an absolute predicted strength — "
+                "the design allowable for the affected location."
+            ),
+        )
+        if expert_mode:
+            st.markdown("**Advanced**")
+            gs_bracket_lo = st.number_input(
+                "Bracket lower bound (0 = auto)",
+                min_value=0.0, value=DEFAULT_GS_BRACKET_LO, step=0.01,
+                key="sb_gs_bracket_lo",
+                help=(
+                    "Leave both bounds at 0 to let the search derive the "
+                    "range (for amplitude: 0 to the laminate thickness, "
+                    "clamped by the tool_flat and mesh-inversion limits). "
+                    "A bracket is applied only when the upper bound is "
+                    "greater than 0."
+                ),
+            )
+            gs_bracket_hi = st.number_input(
+                "Bracket upper bound (0 = auto)",
+                min_value=0.0, value=DEFAULT_GS_BRACKET_HI, step=0.01,
+                key="sb_gs_bracket_hi",
+                help=(
+                    "Upper end of an explicit search range. Still clamped "
+                    "by the validation limits that would otherwise make a "
+                    "probe fail mid-search."
+                ),
+            )
+            gs_scan_points = st.number_input(
+                "Scan points", min_value=3, max_value=33,
+                value=DEFAULT_GS_SCAN_POINTS, step=2,
+                key="sb_gs_scan_points",
+                help=(
+                    "Points in the bounded scan that measures the search "
+                    "direction and monotonicity before any root-finding. "
+                    "Fewer points is cheaper but can walk past an interior "
+                    "minimum."
+                ),
+            )
+            gs_rtol = st.number_input(
+                "Root tolerance (rtol)",
+                min_value=1e-8, max_value=1e-2,
+                value=DEFAULT_GS_RTOL, step=1e-4, format="%.1e",
+                key="sb_gs_rtol",
+                help=(
+                    "Relative tolerance on the searched parameter, passed "
+                    "to scipy's brentq. The reported limit is then backed "
+                    "off to the safe side and re-verified, so this sets "
+                    "precision, not conservatism."
+                ),
+            )
+        else:
+            gs_bracket_lo = DEFAULT_GS_BRACKET_LO
+            gs_bracket_hi = DEFAULT_GS_BRACKET_HI
+            gs_scan_points = DEFAULT_GS_SCAN_POINTS
+            gs_rtol = DEFAULT_GS_RTOL
+
+        # Cost note, before the click. The search runs analytical unless
+        # the config enables an FE-only feature — the same flags the run
+        # handler resolves ``analytical_only`` from.
+        _gs_forces_fe = bool(
+            enable_czm
+            or _surface_pockets_active
+            or _transverse_threaded
+            or _is_tool_flat_selected
+        )
+        if _gs_forces_fe:
+            st.warning(
+                ":hourglass_flowing_sand: This configuration enables an "
+                "FE-only feature, so the search runs on the **full FE "
+                "path**: about 25 forward solves — minutes, not seconds. "
+                "Turn the FE-only feature off for a sub-second analytical "
+                "search."
+            )
+        else:
+            st.caption(
+                "About 25 forward evaluations on the analytical path — "
+                "well under a second. Enabling CZM, surface resin pockets "
+                "or a non-uniform transverse mode switches the search to "
+                "the FE path (minutes)."
+            )
+
     st.divider()
     # Reset via an on_click callback (not an inline handler): the callback
     # fires at the start of the next rerun, BEFORE the sidebar widgets are
@@ -2285,6 +2500,201 @@ def _current_config_json() -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Inverse goal-seek helpers (issue #280).
+# ---------------------------------------------------------------------------
+
+
+def _gs_unit_suffix(parameter: str) -> str:
+    """`` mm`` for a length parameter, empty otherwise (never a guess)."""
+    unit = GS_PARAMETER_UNITS.get(parameter)
+    return f" {unit}" if unit else ""
+
+
+def _critical_limit_block(
+    result: CriticalValueResult | None,
+    goalseek_payload: tuple | None,
+    run_payload: tuple | None,
+) -> dict | None:
+    """The NCR ``critical_limit`` block for a stored goal-seek result.
+
+    Returns ``None`` unless the search **converged** *and* it was run
+    against exactly the configuration the displayed results were computed
+    from — the stored goal-seek payload and the run payload are the same
+    hashable fingerprint ``_assemble_cfg_payload`` builds, so equality is
+    the whole test.
+
+    The guard is deliberately strict. An acceptance limit is a number a
+    Material Review Board reads off an official attachment; a limit
+    derived for a *different* laminate, loading or morphology riding
+    along on someone else's NCR is a wrong-number-on-a-controlled-
+    document hazard, and the search range itself is derived from the base
+    config (for ``wavelength`` it is scaled from the base value), so the
+    result genuinely does not transfer between configurations.
+    """
+    if result is None or goalseek_payload is None or run_payload is None:
+        return None
+    if result.status != "converged" or result.critical_value is None:
+        return None
+    if tuple(goalseek_payload) != tuple(run_payload):
+        return None
+    return {
+        "parameter": result.parameter,
+        "parameter_units": GS_PARAMETER_UNITS.get(result.parameter),
+        "objective": result.objective_name,
+        "target": float(result.target),
+        "target_units": "MPa" if result.target_is_strength else None,
+        "critical_value": float(result.critical_value),
+        "achieved_knockdown": (
+            None if result.achieved_knockdown is None
+            else float(result.achieved_knockdown)
+        ),
+        "achieved_strength_MPa": (
+            None if result.achieved_strength_MPa is None
+            else float(result.achieved_strength_MPa)
+        ),
+        "method": "analytical" if result.analytical_only else "fe",
+        "n_evaluations": int(result.n_evaluations),
+        "rtol": float(result.rtol),
+    }
+
+
+def _render_goalseek_result(
+    result: CriticalValueResult, stale: bool
+) -> None:
+    """Render a stored goal-seek result: the answer, or the refusal.
+
+    Refusal messages are shown **verbatim**. The engine's messages quote
+    the measurements behind the refusal and name the knob that has to
+    move; paraphrasing them loses the diagnosis.
+    """
+    st.subheader("Acceptable limit (inverse goal-seek)")
+    if stale:
+        st.warning(
+            "⚠️ **Inputs have changed since this search.** The limit below "
+            "was computed for the previous configuration. Click **Find "
+            "acceptable limit** to search again.",
+            icon="⚠️",
+        )
+
+    unit = _gs_unit_suffix(result.parameter)
+    target_unit = " MPa" if result.target_is_strength else ""
+    if result.status == "converged" and result.critical_value is not None:
+        extreme = (
+            "Largest" if result.direction == "decreasing" else "Smallest"
+        )
+        g1, g2, g3 = st.columns(3)
+        g1.metric(
+            f"{extreme} acceptable {result.parameter}",
+            f"{result.critical_value:.4g}{unit}",
+            help=(
+                "The conservative answer: the value on the *acceptable* "
+                "side of the root. Quote this number, not the raw root."
+            ),
+        )
+        _achieved = result.achieved_objective
+        _root = result.critical_value_root
+        g2.metric(
+            f"Achieved {result.objective_name}",
+            "—" if _achieved is None else f"{_achieved:.4f}{target_unit}",
+            help=(
+                f"Measured at the reported limit by a real forward run "
+                f"(target {result.target:.4g}{target_unit})."
+            ),
+        )
+        g3.metric(
+            "Forward evaluations",
+            f"{result.n_evaluations}",
+            help=(
+                "Full forward solves spent on the scan, the root-find and "
+                "the safe-side verification."
+            ),
+        )
+        st.success(
+            f"**{result.critical_value:.4g}{unit}** is the {extreme.lower()} "
+            f"{result.parameter} these inputs can carry with "
+            f"{result.objective_name} ≥ {result.target:.4g}{target_unit}. "
+            f"`brentq` converges *to* the root, not to the acceptable side "
+            f"of it, so the search backs the answer off toward safety and "
+            f"**verifies it with an extra forward run** — the achieved "
+            f"value above is that check, not an interpolation. The raw "
+            f"root was "
+            f"{'—' if _root is None else format(_root, '.6g')}{unit}; the "
+            f"conservative value is the one to quote."
+        )
+    elif result.status == "no_crossing":
+        st.warning(result.message, icon="ℹ️")
+        st.caption(
+            "*No crossing in range* is not necessarily an error: it can "
+            "simply mean no defect size in the searched range fails your "
+            "criterion."
+        )
+    else:
+        st.error(result.message, icon="🚫")
+
+    # The scanned curve is the evidence behind both the answer and every
+    # refusal, so it is drawn whenever there are measurements to draw.
+    if result.scan_values:
+        fig, ax = plt.subplots(figsize=(6.5, 3.6))
+        result.plot(ax=ax)
+        fig.tight_layout()
+        st.pyplot(fig, clear_figure=True)
+        st.caption(
+            f"Scan over [{result.bounds[0]:.4g}, {result.bounds[1]:.4g}]"
+            f"{unit} "
+            f"(lower bound: {result.bounds_source[0]}, upper: "
+            f"{result.bounds_source[1]}) · direction measured: "
+            f"{result.direction} · {result.sign_changes} sign change"
+            f"{'' if result.sign_changes == 1 else 's'} · "
+            f"{'analytical' if result.analytical_only else 'FE'} path"
+        )
+
+    if result.evaluations:
+        with st.expander("Evaluation ledger", expanded=False):
+            st.dataframe(
+                [
+                    {
+                        "#": ev.index,
+                        result.parameter: ev.value,
+                        result.objective_name: ev.objective,
+                        "knockdown": ev.knockdown,
+                        "strength (MPa)": ev.strength_MPa,
+                        "residual": ev.residual,
+                        "phase": ev.phase,
+                        "runtime (s)": round(ev.runtime_s, 4),
+                    }
+                    for ev in result.evaluations
+                ],
+                width="stretch",
+                hide_index=True,
+            )
+            st.caption(
+                "Phases: `scan` measures direction and monotonicity, "
+                "`root` is the bracketed root-find, `backoff` steps to the "
+                "safe side, `verify` is the confirming forward run."
+            )
+
+    if (
+        result.status == "converged"
+        and result.critical_value is not None
+        and result.parameter in GS_PARAMETERS
+    ):
+        if st.button(
+            f"Apply this {result.parameter} to the sidebar",
+            help=(
+                f"Seed the sidebar **{result.parameter}** with "
+                f"{result.critical_value:.4g}{unit} so you can run the "
+                f"full analysis at the limit. The search above is then "
+                f"flagged as computed for the previous inputs — which it "
+                f"was."
+            ),
+        ):
+            st.session_state["_pending_gs_apply"] = (
+                result.parameter, float(result.critical_value)
+            )
+            st.rerun()
+
+
+# ---------------------------------------------------------------------------
 # Config file I/O UI (issue #375). Rendered as a second sidebar block — it
 # lives after ``_live_cfg_payload`` / ``_config_from_payload`` are defined so
 # the download can serialise the live effective config. Appears at the bottom
@@ -2477,6 +2887,126 @@ if run_clicked or _demo_pending:
         )
 
 
+# Goal-seek handler (issue #280) — like the run handler above, it executes
+# BEFORE the tabs render so the search status appears above the tab strip and
+# the Analyze tab sees the finished result on the same rerun.
+if goalseek_clicked:
+    try:
+        _gs_layup = parse_layup(layup_str)
+    except ValueError as _gs_exc:
+        st.error(f"Could not parse layup: {_gs_exc}")
+        st.stop()
+    try:
+        OrthotropicMaterial.from_dict(material_dict)
+    except ValueError as _gs_exc:
+        st.error(f"Invalid custom material: {_gs_exc}")
+        st.stop()
+
+    # Same effective-path resolution as a run, so the searched config is
+    # bit-identical to the one Run analysis would solve. ``analytical_only``
+    # is then passed to the engine as None: its own ladder decides, and an
+    # FE-forcing feature can neither be silently dropped nor silently cost
+    # the user a 25-solve FE search without the warning shown in the sidebar.
+    _gs_effective_analytical_only = (
+        bool(analytical_only)
+        and not bool(enable_czm)
+        and not _surface_pockets_active
+        and not _transverse_threaded
+    )
+    _gs_payload = _assemble_cfg_payload(
+        _gs_layup, _gs_effective_analytical_only
+    )
+
+    _gs_bracket: tuple[float, float] | None = None
+    if float(gs_bracket_hi) > 0.0:
+        _gs_bracket = (float(gs_bracket_lo), float(gs_bracket_hi))
+        if _gs_bracket[0] >= _gs_bracket[1]:
+            st.error(
+                "Bracket lower bound must be less than the upper bound "
+                f"(got {_gs_bracket[0]:g} and {_gs_bracket[1]:g}). Leave "
+                "both at 0 to derive the range automatically."
+            )
+            st.stop()
+
+    with st.status(
+        "Searching for the acceptable limit…", expanded=True
+    ) as _gs_status:
+        st.write(
+            f"Scanning **{gs_parameter}** over the resolved range, then "
+            f"root-finding on the target…"
+        )
+        st.caption(
+            "About 25 forward evaluations, ending in a verification run "
+            "on the safe side of the root."
+        )
+        try:
+            _gs_result = find_critical_value(
+                _config_from_payload(_gs_payload),
+                parameter=str(gs_parameter),
+                target_knockdown=(
+                    None if _gs_strength_mode else float(gs_target)
+                ),
+                target_strength_MPa=(
+                    float(gs_target_strength) if _gs_strength_mode else None
+                ),
+                bracket=_gs_bracket,
+                scan_points=int(gs_scan_points),
+                rtol=float(gs_rtol),
+                analytical_only=None,
+            )
+        except ValueError as _gs_exc:
+            # Input-shaped refusals (an FE-only feature under an analytical
+            # request, tool_flat, a degenerate range). The engine's message
+            # names the knob that has to move — show it verbatim.
+            _gs_status.update(
+                label="Search refused", state="error", expanded=True
+            )
+            st.error(str(_gs_exc))
+            st.stop()
+        except MemoryError:
+            _gs_status.update(
+                label="Out of memory", state="error", expanded=True
+            )
+            st.error(
+                "Out of memory during the search. Reduce nx, ny, or "
+                "nz_per_ply, or turn off the FE-only feature that forces "
+                "the FE path."
+            )
+            st.stop()
+        except Exception as _gs_exc:  # noqa: BLE001 — surface to the user
+            _gs_status.update(
+                label="Search failed", state="error", expanded=True
+            )
+            st.error(f"Critical-value search failed: {_gs_exc}")
+            with st.expander("Traceback"):
+                st.exception(_gs_exc)
+            st.stop()
+        _gs_converged = _gs_result.status == "converged"
+        _gs_status.update(
+            label=(
+                "Acceptable limit found" if _gs_converged
+                else f"No unique limit ({_gs_result.status})"
+            ),
+            state="complete" if _gs_converged else "error",
+            expanded=False,
+        )
+
+    st.session_state["goalseek_result"] = _gs_result
+    st.session_state["goalseek_payload"] = _gs_payload
+
+    # Best-effort usage log (fail-soft; see usage_tracking).
+    usage_tracking.log_event(
+        "goalseek",
+        props={
+            "parameter": _gs_result.parameter,
+            "objective": _gs_result.objective_name,
+            "status": _gs_result.status,
+            "analytical_only": _gs_result.analytical_only,
+            "n_evaluations": _gs_result.n_evaluations,
+        },
+    )
+
+
 tab_analyze, tab_export, tab_help = st.tabs(
     ["Analyze", "Export", "Help"]
 )
@@ -2629,6 +3159,27 @@ with tab_analyze:
             f"Closed-form approx arctan(2πA/λ) = "
             f"{np.degrees(profile.max_angle_approx()):.2f}°"
         )
+
+    # ----------------------------------------------------------------------
+    # Acceptable limit (issue #280). Rendered above the run results and
+    # independently of them: the search is its own answer and is useful
+    # before any forward run has been made. Staleness is the same
+    # hash-compare the run results use (#374) — the live sidebar payload
+    # against the payload the search was performed on.
+    # ----------------------------------------------------------------------
+    _gs_stored = st.session_state.get("goalseek_result")
+    if _gs_stored is not None:
+        _gs_stored_payload = st.session_state.get("goalseek_payload")
+        _gs_live_payload = _live_cfg_payload()
+        _render_goalseek_result(
+            _gs_stored,
+            stale=bool(
+                _gs_stored_payload is not None
+                and _gs_live_payload is not None
+                and _gs_live_payload != _gs_stored_payload
+            ),
+        )
+        st.divider()
 
     if "results" not in st.session_state:
         st.markdown(

--- a/app.py
+++ b/app.py
@@ -2540,6 +2540,7 @@ def _critical_limit_block(
     return {
         "parameter": result.parameter,
         "parameter_units": GS_PARAMETER_UNITS.get(result.parameter),
+        "direction": result.direction,
         "objective": result.objective_name,
         "target": float(result.target),
         "target_units": "MPa" if result.target_is_strength else None,
@@ -3859,6 +3860,34 @@ with tab_export:
         _angles = list(_cfg.get("angles_tuple", ()))
         _res = st.session_state["results"]
 
+        # Acceptance limit (issue #280). Attached ONLY when the stored
+        # goal-seek converged against exactly the configuration these
+        # results were computed from — an acceptance limit derived for a
+        # different laminate, loading or morphology riding along on an NCR
+        # attachment is a wrong-number-on-a-controlled-document hazard, so
+        # the guard is payload equality, not a heuristic.
+        _summary_critical_limit = _critical_limit_block(
+            st.session_state.get("goalseek_result"),
+            st.session_state.get("goalseek_payload"),
+            st.session_state.get("cfg_payload"),
+        )
+        if _summary_critical_limit is not None:
+            st.caption(
+                "✓ The acceptance limit found for this exact configuration "
+                f"(**{_summary_critical_limit['critical_value']:.4g} "
+                f"{_summary_critical_limit['parameter_units'] or ''}** "
+                f"{_summary_critical_limit['parameter']}) is included in the "
+                "summary below."
+            )
+        elif st.session_state.get("goalseek_result") is not None:
+            st.caption(
+                "The stored acceptable-limit search is **not** included: it "
+                "either did not converge or was run against different "
+                "inputs. Re-run **Find acceptable limit** and **Run "
+                "analysis** on the same configuration to carry the limit "
+                "onto this attachment."
+            )
+
         with st.form("summary_form"):
             summary_reference = st.text_input(
                 "Reference (optional)",
@@ -3919,6 +3948,7 @@ with tab_export:
                 prepared_by=summary_prepared_by,
                 notes=summary_notes,
                 tool_version=_wrinklefe_version,
+                critical_limit=_summary_critical_limit,
             )
 
             _dr = summary["disposition_recommendation"]

--- a/docs/internal/DEPLOYMENT_STREAMLIT.md
+++ b/docs/internal/DEPLOYMENT_STREAMLIT.md
@@ -158,10 +158,11 @@ an analysis. The required `gspread` / `google-auth` packages are already in
 
 ## App features
 
-Once the app is running, the sidebar offers three features worth calling out
-that aren't exposed through the Python API. All three live in `app.py` and
-are available in both the hosted Streamlit instance and a local
-`streamlit run app.py`.
+Once the app is running, the sidebar offers four features worth calling out:
+three that aren't exposed through the Python API at all, and the
+acceptable-limit search, which is the browser form of the `wrinklefe
+critical` subcommand. All four live in `app.py` and are available in both
+the hosted Streamlit instance and a local `streamlit run app.py`.
 
 ### Morphology schematics
 
@@ -223,3 +224,49 @@ free-text **Material name** field and used for the current run only;
 **custom materials do not persist across sessions** (the app's filesystem
 is ephemeral on Streamlit Cloud and the session state resets on reload).
 For permanent additions to the library see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+### Acceptable-limit mode ("Find acceptable limit")
+
+**Run analysis** answers *"given this wrinkle, what is the knockdown?"*.
+The button directly beneath it inverts the question — *"what is the largest
+wrinkle these inputs can carry?"* — which is the number an inspection
+criterion or an NCR disposition is written around. It runs
+`wrinklefe.goalseek.find_critical_value` on exactly the configuration a run
+would solve; the *Acceptable-limit settings* expander holds the searched
+parameter (`amplitude` or `wavelength`), the target (a knockdown factor or
+an absolute MPa allowable) and, in Expert mode, the bracket, scan-point
+count and root tolerance.
+
+Cost is stated before the click. The search runs on the analytical path —
+about 25 forward evaluations, well under a second — unless the
+configuration enables an FE-only feature (CZM, surface resin pockets, a
+non-uniform transverse mode, `tool_flat`), in which case the expander warns
+that the same 25 evaluations become full FE solves.
+
+Three things about the result are worth knowing:
+
+- **The reported value is the conservative one.** `brentq` converges *to*
+  the root, not to the acceptable side of it, so the search backs the
+  answer off toward safety and confirms it with an extra forward run. The
+  achieved knockdown shown next to the limit is that confirming
+  measurement, not an interpolation; the raw root is quoted only for
+  transparency and should never be the number that leaves the app.
+- **A refusal is shown verbatim.** When the scanned curve admits no unique
+  answer the app prints the engine's own message, which quotes the
+  measurements behind the refusal and names the knob that has to move.
+  `no_crossing` renders as a warning rather than an error — it can simply
+  mean that no defect size in range fails the criterion. The scan curve and
+  the per-evaluation ledger are rendered either way, because the curve *is*
+  the diagnosis.
+- **The limit only reaches an NCR when it belongs to that NCR.** The
+  Export tab attaches an *Acceptance limit (goal-seek)* block to the
+  validation summary only when the search converged **and** its
+  configuration payload equals the payload the displayed results were
+  computed from. A limit derived for a different laminate, loading or
+  morphology is left off, and the tab says so rather than omitting it
+  silently.
+
+**Apply this limit to the sidebar** seeds the geometry widget with the
+limit (clamped to the widget's range) so the full analysis can be run at
+it. Doing so changes the inputs, so the search above is then correctly
+flagged as computed for the previous configuration.

--- a/src/wrinklefe/io/export.py
+++ b/src/wrinklefe/io/export.py
@@ -557,6 +557,24 @@ def recommend_disposition(
     }
 
 
+# Disclaimer carried on the acceptance-limit block (issue #280). Composed
+# from the two sentences this module already uses -- the disposition note's
+# opening and the closing clause of ``criteria_cited`` -- so a goal-seek
+# limit inherits exactly the MRB language the rest of the summary is
+# written in, rather than new legal wording of its own.
+_CRITICAL_LIMIT_NOTE = (
+    "Decision support only. This limit is advisory and is superseded by "
+    "the program-specific allowables, drawing requirements, and process "
+    "specifications applied by the MRB."
+)
+
+_CRITICAL_LIMIT_BASIS = (
+    "Largest value still satisfying the target under a real forward "
+    "evaluation: the root-find is backed off to the safe side and "
+    "re-verified, so this is not an interpolation of the scan curve."
+)
+
+
 def build_analysis_summary(
     *,
     defect: dict,
@@ -565,6 +583,7 @@ def build_analysis_summary(
     prepared_by: str | None = None,
     notes: str | None = None,
     tool_version: str | None = None,
+    critical_limit: dict | None = None,
 ) -> dict:
     """Assemble a wrinkle-analysis validation summary for an NCR.
 
@@ -602,6 +621,20 @@ def build_analysis_summary(
         WrinkleFE version string, recorded for traceability. Defaults to
         the real installed version (``wrinklefe.__version__``); pass an
         explicit value only to override it (e.g. in tests).
+    critical_limit : dict, optional
+        Acceptance limit from an inverse goal-seek
+        (:func:`wrinklefe.goalseek.find_critical_value`, issue #280) —
+        the largest defect size that still meets the target.  Recognised
+        keys: ``parameter``, ``parameter_units``, ``direction``,
+        ``objective``, ``target``, ``target_units``, ``critical_value``,
+        ``achieved_knockdown``, ``achieved_strength_MPa``, ``method``
+        (``'analytical'`` | ``'fe'``), ``n_evaluations``, ``rtol``.
+        Omitted entirely when ``None`` (the default), so a summary only
+        carries a limit when one was actually computed **for this
+        configuration** — a limit derived for different inputs must never
+        ride along on an NCR attachment.  ``critical_value`` must be the
+        engine's conservative, forward-verified value, never the raw
+        ``brentq`` root.
 
     Returns
     -------
@@ -664,6 +697,42 @@ def build_analysis_summary(
             "prediction — peak carried nominal stress, wrinkled vs "
             "pristine coupon."
         )
+
+    critical_block: dict | None = None
+    if critical_limit:
+        critical_block = {
+            "parameter": critical_limit.get("parameter"),
+            "parameter_units": critical_limit.get("parameter_units"),
+            "direction": critical_limit.get("direction"),
+            "objective": critical_limit.get("objective"),
+            "target": critical_limit.get("target"),
+            "target_units": critical_limit.get("target_units"),
+            "critical_value": critical_limit.get("critical_value"),
+            "achieved_knockdown": critical_limit.get("achieved_knockdown"),
+            "achieved_strength_MPa": critical_limit.get(
+                "achieved_strength_MPa"
+            ),
+            "method": critical_limit.get("method"),
+            "n_evaluations": critical_limit.get("n_evaluations"),
+            "rtol": critical_limit.get("rtol"),
+            "basis": _CRITICAL_LIMIT_BASIS,
+            "note": _CRITICAL_LIMIT_NOTE,
+        }
+        _limit_units = critical_block["parameter_units"]
+        _target_units = critical_block["target_units"]
+        criteria.append(
+            "Inverse goal-seek acceptance limit — bracketed root-find on "
+            f"{_fmt(critical_block['objective'])} against "
+            f"{_fmt(critical_block['parameter'])}, target "
+            f"{_fmt(critical_block['target'])}"
+            + (f" {_target_units}" if _target_units else "")
+            + f", answer backed off to the safe side and verified by a "
+            f"forward evaluation ({_fmt(critical_block['method'])} path, "
+            f"{_fmt(critical_block['n_evaluations'])} evaluations, rtol "
+            f"{_fmt(critical_block['rtol'])})"
+            + (f"; limit in {_limit_units}." if _limit_units else ".")
+        )
+
     criteria.append(
         "Generic severity banding in this summary is advisory only and is "
         "superseded by the program-specific allowables, drawing "
@@ -715,6 +784,10 @@ def build_analysis_summary(
             "finite_element": fe_block,
             "progressive_damage": progressive_block,
         },
+        # Acceptance limit from an inverse goal-seek (issue #280). Always
+        # present as a key, ``None`` unless a limit was computed for THIS
+        # configuration — same convention as ``finite_element``.
+        "critical_limit": critical_block,
         "criteria_cited": criteria,
         "disposition_recommendation": {
             "severity": disposition["severity"],
@@ -880,6 +953,50 @@ def render_summary_markdown(summary: dict) -> str:
             f"- Pristine strength: "
             f"{_fmt(prog_block['pristine_strength_MPa'])} MPa"
         )
+    # Acceptance limit (issue #280). Rendered as a sub-block of section 3
+    # rather than a section of its own: it is only present when a limit was
+    # computed, and a conditionally-renumbered section would make two
+    # attachments of the same case cite different section numbers.
+    cl_block = summary.get("critical_limit")
+    if cl_block:
+        p_unit = (
+            f" {cl_block['parameter_units']}"
+            if cl_block.get("parameter_units") else ""
+        )
+        t_unit = (
+            f" {cl_block['target_units']}"
+            if cl_block.get("target_units") else ""
+        )
+        extreme = (
+            "Smallest" if cl_block.get("direction") == "increasing"
+            else "Largest"
+        )
+        lines.append("")
+        lines.append("**Acceptance limit (goal-seek)**")
+        lines.append("")
+        lines.append(
+            f"- {extreme} acceptable {_fmt(cl_block['parameter'])}: "
+            f"**{_fmt(cl_block['critical_value'])}**{p_unit}"
+        )
+        lines.append(
+            f"- Criterion: {_fmt(cl_block['objective'])} ≥ "
+            f"{_fmt(cl_block['target'])}{t_unit}"
+        )
+        achieved = f"- Achieved at that value: knockdown " \
+                   f"{_fmt(cl_block['achieved_knockdown'])}"
+        if cl_block.get("achieved_strength_MPa") is not None:
+            achieved += (
+                f"  ·  {_fmt(cl_block['achieved_strength_MPa'])} MPa"
+            )
+        lines.append(achieved)
+        lines.append(
+            f"- Method: {_fmt(cl_block['method'])} path, "
+            f"{_fmt(cl_block['n_evaluations'])} forward evaluations, "
+            f"rtol {_fmt(cl_block['rtol'])}"
+        )
+        lines.append(f"- Basis: {_fmt(cl_block['basis'])}")
+        lines.append("")
+        lines.append(f"> {cl_block['note']}")
     lines.append("")
     lines.append("## 4. Criteria cited")
     lines.append("")

--- a/tests/test_app_goalseek.py
+++ b/tests/test_app_goalseek.py
@@ -1,0 +1,437 @@
+"""Coverage for the Streamlit app's "Find acceptable limit" mode (#280).
+
+The engine (:func:`wrinklefe.goalseek.find_critical_value`) has its own
+tests in ``tests/test_goalseek.py``; this module covers the *app surface*
+around it:
+
+1. Pure-function coverage of the DEFAULTS registration, the Reset
+   behaviour, and ``_critical_limit_block`` — the hash guard that decides
+   whether an acceptance limit may ride along on an NCR attachment.
+2. ``AppTest`` runs against a **stubbed** engine (converged and refused),
+   so the smoke tests never pay for a real solve, plus one **real**
+   analytical end-to-end search on the app's own defaults (~0.5 s) that
+   pins the number the UI actually shows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``app.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+pytest.importorskip(
+    "streamlit.testing.v1", reason="Streamlit testing API not available."
+)
+
+import matplotlib  # noqa: E402
+
+pytestmark = pytest.mark.viz
+
+matplotlib.use("Agg")
+
+_GS_BUTTON = "Find acceptable limit"
+_APPLY_BUTTON = "Apply this amplitude to the sidebar"
+_STALE_MARKER = "Inputs have changed since this search"
+
+
+def _app_path() -> str:
+    return str(_REPO_ROOT / "app.py")
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    import app as app_module  # noqa: WPS433 - test-time import.
+    return app_module
+
+
+def _click(at, label: str) -> None:
+    for b in at.button:
+        if b.label == label:
+            b.click()
+            return
+    raise AssertionError(
+        f"button {label!r} not found; have {[b.label for b in at.button]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result builders (stubbed engine).
+# ---------------------------------------------------------------------------
+
+
+def _evaluation(index: int, value: float, objective: float, phase: str):
+    from wrinklefe.goalseek import GoalSeekEvaluation
+
+    return GoalSeekEvaluation(
+        index=index,
+        value=value,
+        objective=objective,
+        knockdown=objective,
+        strength_MPa=objective * 1200.0,
+        residual=objective - 0.85,
+        phase=phase,
+        runtime_s=0.02,
+    )
+
+
+def _make_result(**overrides):
+    """A converged ``CriticalValueResult`` with every field populated."""
+    from wrinklefe.goalseek import CriticalValueResult
+
+    scan_values = [0.0, 0.05, 0.1, 0.4]
+    scan_objectives = [1.0, 0.88, 0.80, 0.60]
+    evaluations = [
+        _evaluation(i, v, o, "scan")
+        for i, (v, o) in enumerate(zip(scan_values, scan_objectives))
+    ]
+    evaluations.append(_evaluation(len(evaluations), 0.0665, 0.8501, "verify"))
+    fields = {
+        "parameter": "amplitude",
+        "objective_name": "knockdown",
+        "target": 0.85,
+        "target_is_strength": False,
+        "direction": "decreasing",
+        "status": "converged",
+        "message": "converged",
+        "critical_value": 0.0665,
+        "critical_value_root": 0.06653,
+        "achieved_objective": 0.8501,
+        "achieved_knockdown": 0.8501,
+        "achieved_strength_MPa": 1020.0,
+        "critical_config": None,
+        "bounds": (0.0, 4.392),
+        "bounds_source": ("zero", "laminate_thickness"),
+        "scan_values": scan_values,
+        "scan_objectives": scan_objectives,
+        "sign_changes": 1,
+        "log_spaced": False,
+        "pristine_reference_MPa": 1200.0,
+        "evaluations": evaluations,
+        "n_evaluations": len(evaluations),
+        "rtol": 1e-3,
+        "analytical_only": True,
+        "runtime_s": 0.5,
+    }
+    fields.update(overrides)
+    return CriticalValueResult(**fields)
+
+
+_NON_MONOTONIC_MESSAGE = (
+    "the scan of 'wavelength' reversed direction 2 times, so the target "
+    "is met on more than one interval and no single limit exists"
+)
+
+
+def _stub_engine(monkeypatch, result):
+    """Patch the engine the app imports on every script execution."""
+    def _fake(base_config, **kwargs):
+        return result
+
+    monkeypatch.setattr("wrinklefe.goalseek.find_critical_value", _fake)
+
+
+# ---------------------------------------------------------------------------
+# 1. DEFAULTS / Reset.
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_include_goalseek_keys(app_module):
+    """Every ``sb_gs_*`` widget key must round-trip through DEFAULTS."""
+    d = app_module.DEFAULTS
+    assert d["sb_gs_parameter"] == "amplitude"
+    assert d["sb_gs_target_mode"] == app_module.GS_TARGET_KNOCKDOWN
+    assert d["sb_gs_target"] == 0.85
+    assert isinstance(d["sb_gs_target_strength"], float)
+    assert d["sb_gs_bracket_lo"] == 0.0
+    assert d["sb_gs_bracket_hi"] == 0.0
+    assert d["sb_gs_scan_points"] >= 3
+    assert 0.0 < d["sb_gs_rtol"] < 0.1
+
+
+def test_goalseek_scan_points_default_matches_engine(app_module):
+    """The UI default must not drift from the engine's own default."""
+    from wrinklefe.goalseek import DEFAULT_SCAN_POINTS
+
+    assert app_module.DEFAULTS["sb_gs_scan_points"] == DEFAULT_SCAN_POINTS
+
+
+def test_reset_inputs_clears_goalseek_state(app_module, monkeypatch):
+    """A Reset drops the stored search: the limit belongs to the config it
+    was searched against, and Reset replaces that config wholesale."""
+    fake_state: dict[str, object] = {
+        "sb_gs_target": 0.5,
+        "goalseek_result": object(),
+        "goalseek_payload": (("amplitude", 0.4),),
+        "unrelated": "keep me",
+    }
+    monkeypatch.setattr(app_module.st, "session_state", fake_state)
+
+    app_module.reset_inputs()
+
+    assert "goalseek_result" not in fake_state
+    assert "goalseek_payload" not in fake_state
+    assert fake_state["sb_gs_target"] == app_module.DEFAULTS["sb_gs_target"]
+    assert fake_state["unrelated"] == "keep me"
+
+
+# ---------------------------------------------------------------------------
+# 2. The NCR hash guard.
+# ---------------------------------------------------------------------------
+
+
+def test_critical_limit_block_matching_payload(app_module):
+    """A converged search against the run's own payload yields the block."""
+    payload = (("amplitude", 0.366), ("loading", "compression"))
+    block = app_module._critical_limit_block(_make_result(), payload, payload)
+
+    assert block is not None
+    assert block["parameter"] == "amplitude"
+    assert block["parameter_units"] == "mm"
+    assert block["direction"] == "decreasing"
+    assert block["objective"] == "knockdown"
+    assert block["target"] == pytest.approx(0.85)
+    assert block["target_units"] is None
+    assert block["critical_value"] == pytest.approx(0.0665)
+    assert block["achieved_knockdown"] == pytest.approx(0.8501)
+    assert block["method"] == "analytical"
+    assert block["n_evaluations"] == 5
+    assert block["rtol"] == pytest.approx(1e-3)
+    # The conservative value, never the raw root.
+    assert block["critical_value"] != pytest.approx(0.06653)
+
+
+def test_critical_limit_block_refuses_mismatched_payload(app_module):
+    """A limit searched against different inputs must never be attached."""
+    searched = (("amplitude", 0.366), ("loading", "compression"))
+    ran = (("amplitude", 0.366), ("loading", "tension"))
+
+    assert app_module._critical_limit_block(_make_result(), searched, ran) is None
+
+
+def test_critical_limit_block_refuses_non_converged(app_module):
+    """Only a converged search carries a number worth quoting."""
+    payload = (("amplitude", 0.366),)
+    refused = _make_result(
+        status="non_monotonic",
+        message=_NON_MONOTONIC_MESSAGE,
+        critical_value=None,
+    )
+
+    assert app_module._critical_limit_block(refused, payload, payload) is None
+
+
+def test_critical_limit_block_refuses_missing_state(app_module):
+    """No search, no run, or no payload -> no block (never a crash)."""
+    payload = (("amplitude", 0.366),)
+    assert app_module._critical_limit_block(None, payload, payload) is None
+    assert app_module._critical_limit_block(_make_result(), None, payload) is None
+    assert app_module._critical_limit_block(_make_result(), payload, None) is None
+
+
+def test_critical_limit_block_strength_target(app_module):
+    """A MPa target is recorded with its units so the NCR can print them."""
+    payload = (("amplitude", 0.366),)
+    block = app_module._critical_limit_block(
+        _make_result(
+            target=1020.0,
+            target_is_strength=True,
+            objective_name="strength_MPa",
+            achieved_objective=1020.5,
+        ),
+        payload,
+        payload,
+    )
+
+    assert block is not None
+    assert block["target_units"] == "MPa"
+    assert block["objective"] == "strength_MPa"
+
+
+# ---------------------------------------------------------------------------
+# 3. AppTest — stubbed engine.
+# ---------------------------------------------------------------------------
+
+
+def test_mode_controls_render_without_a_search():
+    """The button and its target input exist before anything is clicked."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    assert _GS_BUTTON in [b.label for b in at.button]
+    assert at.number_input(key="sb_gs_target").value == pytest.approx(0.85)
+    assert at.selectbox(key="sb_gs_parameter").value == "amplitude"
+
+
+def test_converged_stub_renders_metric_row(monkeypatch):
+    """A converged result renders the limit, the achieved objective and the
+    safe-side statement."""
+    from streamlit.testing.v1 import AppTest
+
+    _stub_engine(monkeypatch, _make_result())
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    _click(at, _GS_BUTTON)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    labels = {m.label: m.value for m in at.metric}
+    assert "Largest acceptable amplitude" in labels
+    assert "0.0665" in labels["Largest acceptable amplitude"]
+    assert labels["Achieved knockdown"].startswith("0.850")
+    assert labels["Forward evaluations"] == "5"
+
+    blob = " ".join(s.value for s in at.success)
+    assert "verifies it with an extra forward run" in blob
+    assert "conservative value is the one to quote" in blob
+
+
+def test_refusal_message_is_shown_verbatim(monkeypatch):
+    """``non_monotonic`` surfaces the engine's own message, unparaphrased —
+    it quotes the measurements behind the refusal."""
+    from streamlit.testing.v1 import AppTest
+
+    _stub_engine(
+        monkeypatch,
+        _make_result(
+            status="non_monotonic",
+            message=_NON_MONOTONIC_MESSAGE,
+            critical_value=None,
+            critical_value_root=None,
+            achieved_objective=None,
+            achieved_knockdown=None,
+            sign_changes=2,
+        ),
+    )
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    _click(at, _GS_BUTTON)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    errors = [e.value for e in at.error]
+    assert any(_NON_MONOTONIC_MESSAGE == e for e in errors), errors
+    # No limit is offered alongside a refusal.
+    assert _APPLY_BUTTON not in [b.label for b in at.button]
+
+
+def test_no_crossing_is_a_warning_not_an_error(monkeypatch):
+    """"No crossing in range" can simply mean nothing in range fails the
+    criterion, so it must not be dressed up as a failure."""
+    from streamlit.testing.v1 import AppTest
+
+    message = (
+        "no value of 'amplitude' in [0, 4.392] drives knockdown below the "
+        "target 0.4 (measured minimum 0.424 at 4.392)"
+    )
+    _stub_engine(
+        monkeypatch,
+        _make_result(
+            status="no_crossing",
+            message=message,
+            critical_value=None,
+            critical_value_root=None,
+            achieved_objective=None,
+            sign_changes=0,
+        ),
+    )
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    _click(at, _GS_BUTTON)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    assert any(message == w.value for w in at.warning), [
+        w.value for w in at.warning
+    ]
+    assert not [e.value for e in at.error]
+
+
+def test_apply_seeds_the_amplitude_widget(monkeypatch):
+    """Apply seeds ``sb_amplitude`` with the limit so the user can run the
+    full analysis at it."""
+    from streamlit.testing.v1 import AppTest
+
+    _stub_engine(monkeypatch, _make_result())
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    _click(at, _GS_BUTTON)
+    at.run()
+    _click(at, _APPLY_BUTTON)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    assert at.session_state["sb_amplitude"] == pytest.approx(0.0665)
+    assert at.number_input(key="sb_amplitude").value == pytest.approx(0.0665)
+
+
+def test_editing_an_input_marks_the_search_stale(monkeypatch):
+    """A stored limit describes the inputs it was searched against; say so
+    when they change (same hash-compare as the run staleness banner)."""
+    from streamlit.testing.v1 import AppTest
+
+    _stub_engine(monkeypatch, _make_result())
+
+    at = AppTest.from_file(_app_path(), default_timeout=90)
+    at.run()
+    _click(at, _GS_BUTTON)
+    at.run()
+    assert not any(_STALE_MARKER in w.value for w in at.warning)
+
+    at.number_input(key="sb_wavelength").set_value(24.0)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    assert any(_STALE_MARKER in w.value for w in at.warning), [
+        w.value for w in at.warning
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 4. AppTest — the real engine, analytical path.
+# ---------------------------------------------------------------------------
+
+
+def test_real_analytical_search_on_app_defaults():
+    """End-to-end against the real engine on the app's default sidebar
+    (IM7/8552, [0/45/-45/90]_3s, 1 % compression, analytical path).
+
+    The measured limit is ~0.0665 mm of amplitude for a 0.85 knockdown
+    target; the tolerance is loose on purpose (this pins the wiring and the
+    safe-side contract, not the forward model, which has its own tests).
+    """
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_file(_app_path(), default_timeout=180)
+    at.run()
+    _click(at, _GS_BUTTON)
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    result = at.session_state["goalseek_result"]
+    assert result.status == "converged", result.message
+    assert result.parameter == "amplitude"
+    assert result.analytical_only is True
+    assert result.critical_value == pytest.approx(0.0665, abs=5e-3)
+    # The safe-side contract: the reported value satisfies the criterion
+    # under a real forward evaluation, and is on the acceptable side of
+    # the raw root (knockdown decreases with amplitude).
+    assert result.achieved_knockdown >= 0.85
+    assert result.critical_value <= result.critical_value_root
+
+    labels = {m.label: m.value for m in at.metric}
+    assert "Largest acceptable amplitude" in labels
+    assert labels["Largest acceptable amplitude"].endswith(" mm")

--- a/tests/test_io/test_export.py
+++ b/tests/test_io/test_export.py
@@ -653,6 +653,120 @@ class TestBuildAnalysisSummary:
         assert s["engineering_analysis"]["progressive_damage"] is None
 
 
+# ----------------------------------------------------------------------
+# Acceptance limit from an inverse goal-seek (issue #280)
+# ----------------------------------------------------------------------
+
+CRITICAL_LIMIT = {
+    "parameter": "amplitude",
+    "parameter_units": "mm",
+    "direction": "decreasing",
+    "objective": "knockdown",
+    "target": 0.85,
+    "target_units": None,
+    "critical_value": 0.0665159,
+    "achieved_knockdown": 0.85,
+    "achieved_strength_MPa": 1020.0,
+    "method": "analytical",
+    "n_evaluations": 24,
+    "rtol": 1e-3,
+}
+
+
+class TestSummaryCriticalLimit:
+    """The optional ``critical_limit`` block on the NCR attachment."""
+
+    def test_absent_by_default(self, summary_inputs):
+        """Existing callers are untouched: the key is present but empty."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(defect=defect, engineering=engineering)
+        assert s["critical_limit"] is None
+
+    def test_block_recorded_when_provided(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect,
+            engineering=engineering,
+            critical_limit=CRITICAL_LIMIT,
+        )
+        block = s["critical_limit"]
+        assert block is not None
+        assert block["parameter"] == "amplitude"
+        assert block["parameter_units"] == "mm"
+        assert block["objective"] == "knockdown"
+        assert block["target"] == pytest.approx(0.85)
+        assert block["critical_value"] == pytest.approx(0.0665159)
+        assert block["achieved_knockdown"] == pytest.approx(0.85)
+        assert block["method"] == "analytical"
+        assert block["n_evaluations"] == 24
+        assert block["rtol"] == pytest.approx(1e-3)
+
+    def test_block_states_the_safe_side_basis(self, summary_inputs):
+        """The attachment must say the number is forward-verified, not
+        interpolated off the scan curve."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect,
+            engineering=engineering,
+            critical_limit=CRITICAL_LIMIT,
+        )
+        basis = s["critical_limit"]["basis"]
+        assert "forward evaluation" in basis
+        assert "safe side" in basis
+
+    def test_block_carries_the_mrb_disclaimer(self, summary_inputs):
+        """The limit inherits the summary's existing non-binding language."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect,
+            engineering=engineering,
+            critical_limit=CRITICAL_LIMIT,
+        )
+        note = s["critical_limit"]["note"]
+        assert "Decision support only" in note
+        assert "MRB" in note
+
+    def test_method_is_cited(self, summary_inputs):
+        """The criteria list records how the limit was obtained."""
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect,
+            engineering=engineering,
+            critical_limit=CRITICAL_LIMIT,
+        )
+        cited = " ".join(s["criteria_cited"])
+        assert "Inverse goal-seek acceptance limit" in cited
+        assert "24 evaluations" in cited
+
+    def test_strength_target_units_survive(self, summary_inputs):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect,
+            engineering=engineering,
+            critical_limit={
+                **CRITICAL_LIMIT,
+                "objective": "strength_MPa",
+                "target": 1020.0,
+                "target_units": "MPa",
+            },
+        )
+        assert s["critical_limit"]["target_units"] == "MPa"
+        assert "1020 MPa" in " ".join(s["criteria_cited"])
+
+    def test_summary_is_json_serialisable_with_the_block(
+        self, summary_inputs
+    ):
+        defect, engineering = summary_inputs
+        s = build_analysis_summary(
+            defect=defect,
+            engineering=engineering,
+            critical_limit=CRITICAL_LIMIT,
+        )
+        assert json.loads(json.dumps(s))["critical_limit"]["parameter"] == (
+            "amplitude"
+        )
+
+
 class TestRenderAndExportSummary:
     """Tests for render_summary_markdown / pdf and export_summary."""
 
@@ -720,6 +834,69 @@ class TestRenderAndExportSummary:
             build_analysis_summary(defect=defect, engineering=engineering)
         )
         assert "Progressive-damage evaluation" not in md
+
+    def test_markdown_renders_the_acceptance_limit(self, summary_inputs):
+        """Issue #280: the goal-seek limit, its criterion, how it was
+        obtained, and the same non-binding MRB language."""
+        defect, engineering = summary_inputs
+        md = render_summary_markdown(
+            build_analysis_summary(
+                defect=defect,
+                engineering=engineering,
+                critical_limit=CRITICAL_LIMIT,
+            )
+        )
+        assert "**Acceptance limit (goal-seek)**" in md
+        assert "Largest acceptable amplitude: **0.06652** mm" in md
+        assert "Criterion: knockdown ≥ 0.85" in md
+        assert "analytical path, 24 forward evaluations" in md
+        assert "Decision support only" in md
+        # Section numbering is unconditional: two attachments for the same
+        # case must not cite different section numbers.
+        assert "## 4. Criteria cited" in md
+        assert "## 5. Recommended disposition (NON-BINDING)" in md
+
+    def test_markdown_omits_the_acceptance_limit_when_absent(
+        self, summary_inputs
+    ):
+        """No empty acceptance-limit rows when no search was run."""
+        defect, engineering = summary_inputs
+        md = render_summary_markdown(
+            build_analysis_summary(defect=defect, engineering=engineering)
+        )
+        assert "Acceptance limit" not in md
+        assert "## 4. Criteria cited" in md
+
+    def test_markdown_labels_an_increasing_direction(self, summary_inputs):
+        """For an increasing objective the answer is the *smallest*
+        acceptable value — the label follows the measured direction."""
+        defect, engineering = summary_inputs
+        md = render_summary_markdown(
+            build_analysis_summary(
+                defect=defect,
+                engineering=engineering,
+                critical_limit={**CRITICAL_LIMIT, "direction": "increasing"},
+            )
+        )
+        assert "Smallest acceptable amplitude" in md
+
+    def test_pdf_carries_the_acceptance_limit(self, summary_inputs):
+        """The PDF lays out the rendered Markdown, so the block travels."""
+        pdf = render_summary_pdf(
+            build_analysis_summary(
+                defect=summary_inputs[0],
+                engineering=summary_inputs[1],
+                critical_limit=CRITICAL_LIMIT,
+            )
+        )
+        assert pdf.startswith(b"%PDF")
+        plain = render_summary_pdf(
+            build_analysis_summary(
+                defect=summary_inputs[0], engineering=summary_inputs[1]
+            )
+        )
+        # The extra block makes for a materially longer document.
+        assert len(pdf) > len(plain)
 
     def test_export_md(self, summary_inputs, tmp_path):
         defect, engineering = summary_inputs


### PR DESCRIPTION
## Linked issue

Fixes #280

(The engine, the `wrinklefe critical` subcommand and `examples/09_acceptance_limit.py` landed in #387. This is the final slice — the app surface and the NCR attachment — and completes the issue. **No engine changes**: `src/wrinklefe/goalseek.py` is untouched.)

## Summary

### The mode

The sidebar gains **Find acceptable limit** directly under *Run analysis* — it searches exactly the configuration a run would solve — plus an *Acceptable-limit settings* expander holding the searched parameter (`amplitude` / `wavelength`), the target as either a knockdown factor or an absolute MPa allowable, and, in Expert mode, the bracket, scan-point count and root tolerance. Every new `sb_gs_*` key is registered in `DEFAULTS` (so Reset restores it), and `reset_inputs()` now also drops the stored search — a limit belongs to the configuration it was searched against, and Reset replaces that configuration wholesale.

Cost is stated **before** the click. The engine resolves the solve path itself (analytical unless the config enables an FE-only feature), so the expander warns about the ~25-solve FE path when CZM, surface resin pockets, a non-uniform transverse mode or `tool_flat` is active, and otherwise states the sub-second analytical cost.

Results render in the Analyze tab, independently of any forward run:

- **Converged** — a metric row (the limit, the objective achieved at it, the evaluation count) plus an explicit statement of the safe-side semantics: *`brentq` converges to the root, not to the acceptable side of it, so the search backs the answer off toward safety and verifies it with an extra forward run*. The achieved value shown is that confirming measurement, not an interpolation. `critical_value_root` is quoted for transparency and never presented as the answer.
- **Refused** — the engine's message **verbatim**. It already quotes the measurements behind the refusal and names the knob that has to move; paraphrasing would lose the diagnosis. `no_crossing` is a warning (it can simply mean nothing in range fails the criterion); `non_monotonic` / `flat` / `target_unreachable` are errors. A test asserts byte equality with the message, so a future paraphrase fails CI.
- **Always** — the scanned curve (`CriticalValueResult.plot()`), because the curve is the diagnosis, and the per-evaluation ledger.

**Apply this limit to the sidebar** seeds the geometry widget through the #375 pending-seed mechanism (staged in `session_state`, applied at the top of the sidebar before the widgets instantiate, then a rerun), clamped to the widget's own range. The stored search is flagged stale by the same payload hash-compare the run results use (#374).

### The NCR block and its hash guard

`io.export.build_analysis_summary` gains an optional `critical_limit=` mapping (additive, default `None`; every existing caller is untouched). When given, the summary carries a `critical_limit` block — parameter, target, their units, the conservative critical value, the achieved knockdown/strength, the solve path, evaluation count and rtol — plus a `criteria_cited` entry recording *how* the number was obtained. `render_summary_markdown` renders it as an **Acceptance limit (goal-seek)** sub-block of section 3, alongside the finite-element and progressive-damage sub-blocks; `render_summary_pdf` lays out that Markdown, so it travels unchanged. A section of its own would have to be numbered, and since the block is conditional, two attachments for the same case would then cite different section numbers. The block's disclaimer is composed from the two sentences the module already uses (the disposition note's opening and the closing clause of `criteria_cited`) rather than new legal wording.

The app attaches it **only** when the stored search converged *and* `st.session_state["goalseek_payload"] == st.session_state["cfg_payload"]` — both are the hashable fingerprint `_assemble_cfg_payload` builds, so equality is the whole test. The decision lives in `_critical_limit_block()` and is unit-tested directly. A limit computed for a different laminate, loading or morphology riding along on an NCR is a wrong-number-on-a-controlled-document hazard, and the search range is itself derived from the base config (for `wavelength` the bounds are scaled from the base value), so the result genuinely does not transfer between configurations. When the guard declines, the Export tab captions why, so the omission is visible rather than silent.

### Measured numbers

The real analytical end-to-end `AppTest` drives the app's own defaults (IM7/8552, `[0/45/-45/90]_3s`, 1 % compression, analytical path) with the default 0.85 knockdown target and gets:

| | |
|---|---|
| status | `converged` |
| critical amplitude | **0.066516 mm** (raw root 0.066530 mm) |
| achieved knockdown | **0.8500001** ≥ 0.85 target |
| forward evaluations | 24 |
| wall time | ~0.5 s |

The test asserts the safe-side contract directly — `achieved_knockdown >= target` and `critical_value <= critical_value_root` — with a loose tolerance on the value itself, since the forward model has its own tests. Every other AppTest stubs the engine, so no smoke test pays for a real solve.

No numeric outputs change: `python scripts/validate.py` reports zero drift on every pinned case.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (targeted: `tests/test_app_goalseek.py` 15 passed; `tests/test_io/ tests/test_config_io.py tests/test_param_docs_match.py tests/test_logging_conventions.py` 129 passed; `tests/test_app_reset_inputs.py tests/test_app_tabs.py tests/test_app_staleness.py tests/test_app_config_io.py` 22 passed; `tests/test_goalseek.py` 96 passed; `tests/test_cli.py` 84 passed; `pytest --doctest-modules src/wrinklefe` 25 passed, 4 skipped; the full `-m "not slow"` lane is running locally, CI is authoritative)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (`mypy src/wrinklefe app.py streamlit_viz.py`: 55 files, no issues)
- [x] Docs/README updated if user-facing
- [x] `CHANGELOG.md` `[Unreleased]` updated if the change is user-visible
- [x] `python scripts/validate.py` shows no validation-ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_