### PR TITLE
core: constituent micromechanics — fibre + matrix + Vf to a ply (Part A of #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Core — **constituent-based micromechanics: fibre + matrix + fibre volume
+  fraction to a ply** (issue #379, Part A — the Vf-to-properties capability
+  #379 names as its own blocker; the compaction kinematics that consume it
+  are a separate change). New `wrinklefe.core.micromechanics` supplies
+  `FiberProperties` (transversely isotropic) and `MatrixProperties`
+  (isotropic, with `from_material` so an existing neat-resin card such as
+  `EPOXY_S6C10` can be reused rather than duplicated), the mixing rules —
+  Voigt rule of mixtures for `E1`/`nu12`/`nu23`, Halpin–Tsai for `E2`
+  (ξ = 2) and `G12` (ξ = 1), transverse isotropy for `G23`, Schapery for
+  the thermal expansion coefficients — and cited constituent presets:
+  `FIBER_PRESETS` for the nine fibres behind the library systems (AS4,
+  T300, T700S, IM7, IM10, IM6G, T800S, S-2 glass, Kevlar 49) and
+  `MATRIX_PRESETS` for the two resins with published neat-resin data
+  (3501-6, 8552). `OrthotropicMaterial.from_constituents(fiber, matrix,
+  Vf)` builds the ply and validates it like any other card. **Strengths are
+  not predicted** — no mixing rule here maps Vf to an allowable, so
+  strengths, toughnesses and cohesive tractions are carried over unchanged
+  from `strengths_from=` (or left at the defaults) and do not track Vf.
+  Accuracy is stated from measurement, not aspiration: rebuilt at the Vf
+  each preset documents in its own comment, the model lands within 12 % on
+  `E1`, 26 % on `nu12`, 33 % on `E2`, 32 % on `G12` — except Kevlar-49 /
+  epoxy `G12`, over-predicted by 84 % and recorded as an `xfail` rather
+  than tuned away — and `nu23` is under-predicted throughout.
+  `tests/test_micromechanics.py` pins every deviation. **No behaviour
+  change:** nothing in the analysis pipeline consumes the module yet, no
+  existing preset value moved, and the validation ledger is unaffected.
 - App — **"Find acceptable limit" mode and the acceptance limit on the NCR
   attachment** (issue #280, app slice — *Fixes #280*, completing the issue).
   The Streamlit sidebar gains a **Find acceptable limit** button directly

--- a/README.md
+++ b/README.md
@@ -745,6 +745,65 @@ The Streamlit web app exposes the same exports as **Download results as
 JSON** and **Download per-ply results as CSV** buttons on the Export
 tab.
 
+### Building a ply from its constituents (fibre volume fraction)
+
+The 11 built-in systems above are fixed cards. When the question is
+*"what if my fibre volume fraction is 0.55 rather than 0.60?"*,
+`wrinklefe.core.micromechanics` builds the ply from its constituents —
+a fibre, a neat resin, and a Vf — instead:
+
+```python
+from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
+from wrinklefe.core.micromechanics import FIBER_PRESETS, MATRIX_PRESETS
+
+lib = MaterialLibrary()
+
+ply = OrthotropicMaterial.from_constituents(
+    FIBER_PRESETS["IM10"],            # Hexcel HexTow IM10 carbon
+    MATRIX_PRESETS["EPOXY_8552"],     # HexPly 8552 neat resin
+    0.55,                             # fibre volume fraction
+    strengths_from=lib.get("IM10_8552"),   # allowables carried over as-is
+)
+ply.E1, ply.E2, ply.G12, ply.nu12
+```
+
+The rules are the standard ones, each cited in the module docstring:
+Voigt rule of mixtures for `E1`, `nu12` and `nu23`, Halpin–Tsai for `E2`
+(ξ = 2) and `G12` (ξ = 1), transverse isotropy for `G23`, and Schapery
+for the thermal expansion coefficients. `FIBER_PRESETS` covers the nine
+fibres behind the library systems (AS4, T300, T700S, IM7, IM10, IM6G,
+T800S, S-2 glass, Kevlar 49) and `MATRIX_PRESETS` the two resins with
+published neat-resin data (3501-6, 8552); any isotropic card already in
+the library — `EPOXY_S6C10`, say — can be used as the matrix through
+`MatrixProperties.from_material`. Every constituent constant is sourced
+in a comment: `E1f`/`alpha1f` from the manufacturer data sheet, the
+transverse set from Daniel & Ishai (2006) Table A.2/A.3.
+
+**Two limitations, both deliberate.**
+
+1. **Strengths are not predicted.** No mixing rule here maps Vf to an
+   allowable, so `Xt`/`Xc`/`Yt`/`Yc`/`S12`/… are carried over unchanged
+   from `strengths_from` (or left at the defaults) and do *not* track
+   Vf. Longitudinal strength is set by fibre-strength statistics and
+   misalignment, transverse and shear strengths by the matrix and the
+   fibre–matrix interface; a Vf-scaled strength model would be quietly
+   wrong.
+2. **The elastic predictions are approximate.** Rebuilt from
+   constituents at the Vf each preset documents in its own source
+   comment, the model lands within 12 % on `E1`, 26 % on `nu12`, 33 %
+   on `E2` and 32 % on `G12` — except Kevlar-49/epoxy `G12`, which
+   Halpin–Tsai over-predicts by 84 % (published aramid `G12f` values
+   scatter by an order of magnitude; that case is a recorded `xfail`
+   rather than a tuned fibre constant). `nu23` is under-predicted
+   throughout. `tests/test_micromechanics.py` pins every one of those
+   deviations. Use the model for the *trend* — how properties move with
+   Vf, anchored on a measured ply — not as a source of allowables.
+
+Nothing in the analysis pipeline consumes this yet: it is the
+prerequisite capability for modelling resin squeeze-out under a
+constrained wrinkle (issue #379), where the local Vf varies from
+element to element.
+
 ## Validation
 
 ### What the in-repo tests check

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -8,6 +8,16 @@ Materials
    :members: OrthotropicMaterial, MaterialLibrary
    :show-inheritance:
 
+Constituent micromechanics
+--------------------------
+
+.. automodule:: wrinklefe.core.micromechanics
+   :members: FiberProperties, MatrixProperties, halpin_tsai,
+             e1_rule_of_mixtures, nu12_rule_of_mixtures, e2_halpin_tsai,
+             g12_halpin_tsai, nu23_rule_of_mixtures, g23_transverse_isotropy,
+             alpha1_schapery, alpha2_schapery
+   :show-inheritance:
+
 Laminate and layup
 ------------------
 

--- a/src/wrinklefe/core/__init__.py
+++ b/src/wrinklefe/core/__init__.py
@@ -3,6 +3,12 @@
 from wrinklefe.core.laminate import Laminate, LoadState, Ply
 from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
 from wrinklefe.core.mesh import MeshData, WrinkleMesh
+from wrinklefe.core.micromechanics import (
+    FIBER_PRESETS,
+    MATRIX_PRESETS,
+    FiberProperties,
+    MatrixProperties,
+)
 from wrinklefe.core.morphology import WrinkleConfiguration
 from wrinklefe.core.transforms import (
     reduced_stiffness_matrix,
@@ -25,6 +31,10 @@ from wrinklefe.core.wrinkle import (
 __all__ = [
     "OrthotropicMaterial",
     "MaterialLibrary",
+    "FiberProperties",
+    "MatrixProperties",
+    "FIBER_PRESETS",
+    "MATRIX_PRESETS",
     "rotation_matrix_3d",
     "stress_transformation_3d",
     "strain_transformation_3d",

--- a/src/wrinklefe/core/material.py
+++ b/src/wrinklefe/core/material.py
@@ -18,8 +18,12 @@ import functools
 import json
 from dataclasses import asdict, dataclass, fields, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from wrinklefe.core.micromechanics import FiberProperties, MatrixProperties
 
 
 @dataclass
@@ -386,6 +390,134 @@ class OrthotropicMaterial:
             S12=Ss, S13=Ss, S23=Ss,
             GIc=GIc, GIIc=GIIc,
             name=name,
+        )
+
+    @classmethod
+    def from_constituents(
+        cls,
+        fiber: FiberProperties,
+        matrix: MatrixProperties,
+        Vf: float,
+        *,
+        xi_E2: float = 2.0,
+        xi_G12: float = 1.0,
+        name: str | None = None,
+        strengths_from: OrthotropicMaterial | None = None,
+    ) -> OrthotropicMaterial:
+        """Build a ply card from its constituents and a fibre volume fraction.
+
+        Applies the mixing rules of :mod:`wrinklefe.core.micromechanics`:
+        rule of mixtures for ``E1``, ``nu12`` and ``nu23``, Halpin-Tsai for
+        ``E2`` and ``G12``, and Schapery for the thermal expansion
+        coefficients.  The ply is transversely isotropic about the fibre
+        direction (``E3 = E2``, ``G13 = G12``, ``nu13 = nu12``,
+        ``G23 = E2 / (2 (1 + nu23))``).
+
+        Parameters
+        ----------
+        fiber : FiberProperties
+            Transversely isotropic fibre constituent, e.g. from
+            :data:`~wrinklefe.core.micromechanics.FIBER_PRESETS`.
+        matrix : MatrixProperties
+            Isotropic matrix constituent, e.g. from
+            :data:`~wrinklefe.core.micromechanics.MATRIX_PRESETS` or
+            :meth:`MatrixProperties.from_material
+            <wrinklefe.core.micromechanics.MatrixProperties.from_material>`.
+        Vf : float
+            Fibre volume fraction, in [0, 1].
+        xi_E2, xi_G12 : float, optional
+            Halpin-Tsai reinforcement-geometry factors for ``E2`` and
+            ``G12``.  Defaults 2.0 and 1.0 — the standard values for
+            circular fibres in a unidirectional ply.
+        name : str or None, optional
+            Material identifier.  Defaults to
+            ``"{fiber}_{matrix}_Vf{Vf:.2f}"``.
+        strengths_from : OrthotropicMaterial or None, optional
+            Reference ply whose **non-elastic** properties are carried over:
+            the strength allowables (``Xt``, ``Xc``, ``Yt``, ``Yc``, ``Zt``,
+            ``Zc``, ``S12``, ``S13``, ``S23``), the moisture-expansion
+            coefficients, ``gamma_Y``, ``GIc``/``GIIc``, ``beta_shear``,
+            ``alpha_0`` and the cohesive tractions.  ``None`` leaves the
+            dataclass defaults.
+
+        Returns
+        -------
+        OrthotropicMaterial
+            The predicted ply.  Validation (including compliance
+            positive-definiteness) runs as usual in ``__post_init__``.
+
+        Raises
+        ------
+        ValueError
+            If ``Vf`` is outside [0, 1], or the predicted constants fail
+            :meth:`validate`.
+
+        Notes
+        -----
+        ``nu23`` is the weakest of the predictions — the rule of mixtures
+        under-predicts it by roughly 40 % against measured unidirectional
+        plies (see :func:`~wrinklefe.core.micromechanics.nu23_rule_of_mixtures`).
+        Override it on the returned card when a measured value exists.
+
+        **Strengths are not predicted.**  None of these mixing rules maps
+        ``Vf`` to a strength allowable — longitudinal strength is governed
+        by fibre-strength statistics and misalignment, transverse and shear
+        strengths by the matrix and the fibre-matrix interface.  The
+        strengths on the returned card are copied from ``strengths_from``
+        or left at the defaults; they do **not** track ``Vf``.  See the
+        :mod:`~wrinklefe.core.micromechanics` module documentation.
+
+        Examples
+        --------
+        >>> from wrinklefe.core.micromechanics import FIBER_PRESETS, MATRIX_PRESETS
+        >>> ply = OrthotropicMaterial.from_constituents(
+        ...     FIBER_PRESETS["IM10"], MATRIX_PRESETS["EPOXY_8552"], 0.60)
+        >>> ply.name
+        'IM10_EPOXY_8552_Vf0.60'
+        >>> round(ply.E1 / 1000.0, 1)
+        189.7
+        """
+        # Imported here rather than at module scope: micromechanics imports
+        # this module for its return type, so a top-level import would be
+        # circular.
+        from wrinklefe.core.micromechanics import (
+            alpha1_schapery,
+            alpha2_schapery,
+            e1_rule_of_mixtures,
+            e2_halpin_tsai,
+            g12_halpin_tsai,
+            g23_transverse_isotropy,
+            nu12_rule_of_mixtures,
+            nu23_rule_of_mixtures,
+        )
+
+        E1 = e1_rule_of_mixtures(Vf, fiber, matrix)
+        E2 = e2_halpin_tsai(Vf, fiber, matrix, xi=xi_E2)
+        G12 = g12_halpin_tsai(Vf, fiber, matrix, xi=xi_G12)
+        nu12 = nu12_rule_of_mixtures(Vf, fiber, matrix)
+        nu23 = nu23_rule_of_mixtures(Vf, fiber, matrix)
+        G23 = g23_transverse_isotropy(E2, nu23)
+        alpha1 = alpha1_schapery(Vf, fiber, matrix)
+        alpha2 = alpha2_schapery(Vf, fiber, matrix)
+
+        carried: dict[str, float | None] = {}
+        if strengths_from is not None:
+            for attr in (
+                "Xt", "Xc", "Yt", "Yc", "Zt", "Zc", "S12", "S13", "S23",
+                "beta1", "beta2", "beta3", "gamma_Y",
+                "GIc", "GIIc", "beta_shear", "alpha_0",
+                "sigma_max", "tau_max",
+            ):
+                carried[attr] = getattr(strengths_from, attr)
+
+        return cls(
+            E1=E1, E2=E2, E3=E2,
+            G12=G12, G13=G12, G23=G23,
+            nu12=nu12, nu13=nu12, nu23=nu23,
+            alpha1=alpha1, alpha2=alpha2, alpha3=alpha2,
+            name=name if name is not None
+            else f"{fiber.name}_{matrix.name}_Vf{Vf:.2f}",
+            **carried,  # type: ignore[arg-type]
         )
 
     @classmethod

--- a/src/wrinklefe/core/micromechanics.py
+++ b/src/wrinklefe/core/micromechanics.py
@@ -5,8 +5,10 @@ constants (:class:`~wrinklefe.core.material.OrthotropicMaterial`).  This
 module supplies the missing upstream step: given the **constituents** — a
 transversely isotropic fibre, an isotropic matrix, and a fibre volume
 fraction ``Vf`` — it predicts the cured-ply elastic constants and thermal
-expansion coefficients.  The mixing rules and the cited constituent presets live here; the ply
-constructor that applies them lands next.
+expansion coefficients.  The entry point for building a ply is
+:meth:`OrthotropicMaterial.from_constituents
+<wrinklefe.core.material.OrthotropicMaterial.from_constituents>`, which
+delegates to the mixing rules defined here.
 
 Why it exists
 -------------
@@ -65,6 +67,27 @@ not as a replacement for measured allowables.  The intended workflow is to
 anchor on a measured ply at a known ``Vf`` and read the *ratio* the model
 gives between that ``Vf`` and the local one.
 
+Examples
+--------
+>>> from wrinklefe.core.material import OrthotropicMaterial
+>>> from wrinklefe.core.micromechanics import FIBER_PRESETS, MATRIX_PRESETS
+>>> ply = OrthotropicMaterial.from_constituents(
+...     FIBER_PRESETS["IM10"], MATRIX_PRESETS["EPOXY_8552"], 0.60,
+...     name="IM10_8552_Vf60",
+... )
+>>> round(ply.E1 / 1000.0, 1)          # GPa
+189.7
+>>> round(ply.E2 / 1000.0, 2)          # GPa
+11.35
+>>> round(ply.nu12, 3)
+0.26
+
+Drop the fibre volume fraction and the ply softens:
+
+>>> soft = OrthotropicMaterial.from_constituents(
+...     FIBER_PRESETS["IM10"], MATRIX_PRESETS["EPOXY_8552"], 0.50)
+>>> round(soft.E1 / 1000.0, 1)
+158.8
 """
 
 from __future__ import annotations

--- a/src/wrinklefe/core/micromechanics.py
+++ b/src/wrinklefe/core/micromechanics.py
@@ -1,0 +1,596 @@
+"""Constituent-based micromechanics: fibre + matrix + fibre volume fraction to a ply.
+
+The rest of the package treats a ply as a *given* set of orthotropic
+constants (:class:`~wrinklefe.core.material.OrthotropicMaterial`).  This
+module supplies the missing upstream step: given the **constituents** — a
+transversely isotropic fibre, an isotropic matrix, and a fibre volume
+fraction ``Vf`` — it predicts the cured-ply elastic constants and thermal
+expansion coefficients.  The mixing rules and the cited constituent presets live here; the ply
+constructor that applies them lands next.
+
+Why it exists
+-------------
+It answers "what if my fibre volume fraction is 0.55 rather than 0.60?"
+without hand-editing a material card, and it is the prerequisite for
+modelling resin squeeze-out under a constrained wrinkle (issue #379),
+where the local ``Vf`` varies from element to element.
+
+Mixing rules
+------------
+========================  ==================================================
+Property                  Rule
+========================  ==================================================
+``E1``                    Voigt rule of mixtures (:func:`e1_rule_of_mixtures`)
+``nu12``                  Rule of mixtures (:func:`nu12_rule_of_mixtures`)
+``E2``                    Halpin-Tsai, ``xi = 2`` (:func:`e2_halpin_tsai`)
+``G12``                   Halpin-Tsai, ``xi = 1`` (:func:`g12_halpin_tsai`)
+``nu23``                  Rule of mixtures (:func:`nu23_rule_of_mixtures`)
+``G23``                   ``E2 / (2 (1 + nu23))`` (transverse isotropy,
+                          :func:`g23_transverse_isotropy`)
+``alpha1``, ``alpha2``    Schapery (:func:`alpha1_schapery`,
+                          :func:`alpha2_schapery`)
+========================  ==================================================
+
+References: J. C. Halpin and J. L. Kardos, "The Halpin-Tsai equations: a
+review", Polym. Eng. Sci. 16(5):344-352 (1976); R. A. Schapery, "Thermal
+expansion coefficients of composite materials based on energy principles",
+J. Compos. Mater. 2(3):380-404 (1968); I. M. Daniel and O. Ishai,
+*Engineering Mechanics of Composite Materials*, 2nd ed., Oxford (2006),
+chapter 3 and Tables A.2/A.3.
+
+What is **not** predicted
+-------------------------
+**Strengths are not a function of ``Vf`` in any of these rules.**
+``Xt``/``Xc``/``Yt``/``Yc``/``Zt``/``Zc``/``S12``/``S13``/``S23``, the
+fracture toughnesses, the cohesive tractions and the kink-band parameter
+are *carried over* from a reference ply via ``strengths_from=`` (or left at
+the dataclass defaults).  A "``Vf``-scaled strength" model would be quietly
+wrong: longitudinal strength is set by fibre strength statistics and
+misalignment, and transverse/shear strengths by the matrix and the
+fibre-matrix interface, none of which these stiffness-averaging rules
+describe.  Scale strengths only with a model calibrated for the purpose.
+
+Accuracy
+--------
+The rules are engineering approximations, and the measured spread against
+the six shipped library presets that document their own ``Vf`` is wide:
+``E1`` within 12 %, ``nu12`` within 26 %, ``E2`` within 33 %, ``G12``
+within 32 % — except Kevlar 49 / epoxy, where Halpin-Tsai over-predicts
+``G12`` by 84 % (published aramid ``G12f`` values scatter by an order of
+magnitude).  ``nu23`` is under-predicted by 30-55 % throughout.
+``tests/test_micromechanics.py`` pins every one of those deviations.
+
+Use the predictions as a *trend* model — how properties move with ``Vf`` —
+not as a replacement for measured allowables.  The intended workflow is to
+anchor on a measured ply at a known ``Vf`` and read the *ratio* the model
+gives between that ``Vf`` and the local one.
+
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from wrinklefe.core.material import OrthotropicMaterial
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FiberProperties",
+    "MatrixProperties",
+    "FIBER_PRESETS",
+    "MATRIX_PRESETS",
+    "halpin_tsai",
+    "e1_rule_of_mixtures",
+    "nu12_rule_of_mixtures",
+    "e2_halpin_tsai",
+    "g12_halpin_tsai",
+    "nu23_rule_of_mixtures",
+    "g23_transverse_isotropy",
+    "alpha1_schapery",
+    "alpha2_schapery",
+]
+
+
+# ======================================================================
+# Constituent property containers
+# ======================================================================
+
+@dataclass(frozen=True)
+class FiberProperties:
+    """Transversely isotropic reinforcing fibre.
+
+    Parameters
+    ----------
+    E1f : float
+        Axial (fibre-direction) Young's modulus [MPa].  This is the value
+        quoted on fibre data sheets as "tensile modulus".
+    E2f : float
+        Transverse Young's modulus [MPa].  For PAN carbon and aramid this
+        is *much* smaller than ``E1f`` (the graphitic/polymer chains align
+        with the fibre axis) and is **never** published on a data sheet —
+        it comes from handbook tables (see :data:`FIBER_PRESETS`).  For
+        glass the fibre is isotropic and ``E2f == E1f``.
+    G12f : float
+        Axial shear modulus [MPa].
+    nu12f : float
+        Major Poisson's ratio of the fibre.
+    alpha1f, alpha2f : float
+        Axial and transverse coefficients of thermal expansion [1/K].
+    G23f : float or None, optional
+        Transverse shear modulus [MPa].  Published for only a few fibres;
+        when ``None`` it is estimated as ``E2f / (2 (1 + nu12f))``, i.e.
+        isotropy is assumed in the 2-3 plane.  That is a stated modelling
+        assumption, not measured data.
+    name : str
+        Fibre designation.
+
+    Raises
+    ------
+    ValueError
+        If a modulus is non-positive or ``nu12f`` violates the
+        transversely isotropic stability bound ``nu12f**2 < E1f / E2f``.
+    """
+
+    E1f: float
+    E2f: float
+    G12f: float
+    nu12f: float
+    alpha1f: float
+    alpha2f: float
+    G23f: float | None = None
+    name: str = "fiber"
+
+    def __post_init__(self) -> None:
+        for attr in ("E1f", "E2f", "G12f"):
+            val = float(getattr(self, attr))
+            if val <= 0:
+                raise ValueError(f"{attr} must be positive, got {val}")
+        if self.G23f is not None and self.G23f <= 0:
+            raise ValueError(
+                f"G23f must be positive when provided, got {self.G23f}"
+            )
+        bound = (self.E1f / self.E2f) ** 0.5
+        if not (-bound < self.nu12f < bound):
+            raise ValueError(
+                f"nu12f must satisfy |nu12f| < sqrt(E1f/E2f) = {bound:.3f}, "
+                f"got {self.nu12f}"
+            )
+
+    @property
+    def G23f_effective(self) -> float:
+        """Transverse shear modulus [MPa], estimated when not supplied.
+
+        Returns ``G23f`` when the preset carries a measured value; otherwise
+        ``E2f / (2 (1 + nu12f))`` — 2-3 isotropy assumed.
+        """
+        if self.G23f is not None:
+            return self.G23f
+        return self.E2f / (2.0 * (1.0 + self.nu12f))
+
+    @property
+    def nu23f_effective(self) -> float:
+        """Transverse Poisson's ratio of the fibre.
+
+        ``E2f / (2 G23f) - 1``.  Equals ``nu12f`` when ``G23f`` was not
+        supplied and 2-3 isotropy was assumed.
+        """
+        return self.E2f / (2.0 * self.G23f_effective) - 1.0
+
+
+@dataclass(frozen=True)
+class MatrixProperties:
+    """Isotropic (neat resin) matrix.
+
+    Parameters
+    ----------
+    Em : float
+        Young's modulus [MPa].
+    num : float
+        Poisson's ratio.
+    alpham : float
+        Coefficient of thermal expansion [1/K].
+    name : str
+        Resin designation.
+
+    Raises
+    ------
+    ValueError
+        If ``Em <= 0`` or ``num`` is outside the isotropic stability range
+        ``-1 < num < 0.5``.
+    """
+
+    Em: float
+    num: float
+    alpham: float
+    name: str = "matrix"
+
+    def __post_init__(self) -> None:
+        if self.Em <= 0:
+            raise ValueError(f"Em must be positive, got {self.Em}")
+        if not (-1.0 < self.num < 0.5):
+            raise ValueError(
+                f"num must be in (-1, 0.5) for an isotropic solid, got {self.num}"
+            )
+
+    @property
+    def Gm(self) -> float:
+        """Shear modulus [MPa], ``Em / (2 (1 + num))``."""
+        return self.Em / (2.0 * (1.0 + self.num))
+
+    @classmethod
+    def from_material(cls, material: OrthotropicMaterial) -> MatrixProperties:
+        """Build matrix constituent data from an isotropic material card.
+
+        Lets an existing neat-resin card in the library (e.g.
+        ``EPOXY_S6C10``) be reused as the matrix constituent instead of
+        duplicating the resin data here.
+
+        Parameters
+        ----------
+        material : OrthotropicMaterial
+            An isotropic card — typically one built with
+            :meth:`OrthotropicMaterial.isotropic`.  ``E1``, ``nu12`` and
+            ``alpha1`` are taken as ``Em``, ``num`` and ``alpham``.  A
+            material whose directional constants differ is accepted but
+            logged as a warning, since only the 1-direction values are used.
+
+        Returns
+        -------
+        MatrixProperties
+        """
+        isotropic = (
+            abs(material.E1 - material.E2) <= 1e-9 * abs(material.E1)
+            and abs(material.E1 - material.E3) <= 1e-9 * abs(material.E1)
+            and abs(material.nu12 - material.nu23) <= 1e-9
+        )
+        if not isotropic:
+            logger.warning(
+                "MatrixProperties.from_material: %s is not isotropic "
+                "(E1=%.1f, E2=%.1f, nu12=%.3f, nu23=%.3f); using the "
+                "1-direction constants as the matrix properties.",
+                material.name, material.E1, material.E2,
+                material.nu12, material.nu23,
+            )
+        return cls(
+            Em=material.E1,
+            num=material.nu12,
+            alpham=material.alpha1,
+            name=material.name,
+        )
+
+
+# ======================================================================
+# Mixing rules
+# ======================================================================
+
+def _check_Vf(Vf: float) -> None:
+    """Raise ``ValueError`` unless ``0 <= Vf <= 1``."""
+    if not (0.0 <= Vf <= 1.0):
+        raise ValueError(f"Vf must be in [0, 1], got {Vf}")
+
+
+def halpin_tsai(Vf: float, Pf: float, Pm: float, xi: float) -> float:
+    """Halpin-Tsai semi-empirical estimate of a matrix-dominated property.
+
+    .. math::
+
+        \\eta = \\frac{P_f / P_m - 1}{P_f / P_m + \\xi}, \\qquad
+        P = P_m \\frac{1 + \\xi \\eta V_f}{1 - \\eta V_f}
+
+    The reinforcement-geometry factor ``xi`` interpolates between the
+    Reuss (series, ``xi -> 0``) and Voigt (parallel, ``xi -> inf``) bounds.
+
+    Parameters
+    ----------
+    Vf : float
+        Fibre volume fraction, in [0, 1].
+    Pf, Pm : float
+        The fibre and matrix values of the property (same units).
+    xi : float
+        Reinforcement geometry factor, ``xi >= 0``.
+
+    Returns
+    -------
+    float
+        The predicted composite property; ``Pm`` at ``Vf = 0`` and ``Pf``
+        at ``Vf = 1`` exactly.
+
+    References
+    ----------
+    Halpin & Kardos (1976), Polym. Eng. Sci. 16(5):344-352.
+    """
+    _check_Vf(Vf)
+    if Pf <= 0 or Pm <= 0:
+        raise ValueError(f"Halpin-Tsai needs positive properties, got Pf={Pf}, Pm={Pm}")
+    if xi < 0:
+        raise ValueError(f"xi must be non-negative, got {xi}")
+    ratio = Pf / Pm
+    eta = (ratio - 1.0) / (ratio + xi)
+    return Pm * (1.0 + xi * eta * Vf) / (1.0 - eta * Vf)
+
+
+def e1_rule_of_mixtures(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties
+) -> float:
+    """Longitudinal modulus [MPa] by the Voigt rule of mixtures.
+
+    .. math:: E_1 = V_f E_{1f} + (1 - V_f) E_m
+
+    Iso-strain in the fibre direction.  This is the least approximate of
+    the rules here, but it is an *upper* bound: real laminae fall a few per
+    cent below it because of fibre waviness and misalignment.
+
+    References
+    ----------
+    Daniel & Ishai (2006), *Engineering Mechanics of Composite Materials*,
+    2nd ed., eq. (3.20).
+    """
+    _check_Vf(Vf)
+    return Vf * fiber.E1f + (1.0 - Vf) * matrix.Em
+
+
+def nu12_rule_of_mixtures(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties
+) -> float:
+    """Major Poisson's ratio by the rule of mixtures.
+
+    .. math:: \\nu_{12} = V_f \\nu_{12f} + (1 - V_f) \\nu_m
+
+    References
+    ----------
+    Daniel & Ishai (2006), eq. (3.23).
+    """
+    _check_Vf(Vf)
+    return Vf * fiber.nu12f + (1.0 - Vf) * matrix.num
+
+
+def e2_halpin_tsai(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties, xi: float = 2.0
+) -> float:
+    """Transverse modulus [MPa] by Halpin-Tsai.
+
+    ``xi = 2`` is the standard value for the transverse modulus of a
+    unidirectional ply with circular fibres (Halpin & Kardos 1976); raise
+    it for a more closely packed / less compliant transverse response.
+    """
+    return halpin_tsai(Vf, fiber.E2f, matrix.Em, xi)
+
+
+def g12_halpin_tsai(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties, xi: float = 1.0
+) -> float:
+    """In-plane shear modulus [MPa] by Halpin-Tsai.
+
+    ``xi = 1`` is the standard value for the axial shear modulus of a
+    unidirectional ply with circular fibres (Halpin & Kardos 1976).  It is
+    known to *under*-predict ``G12`` for well-consolidated aerospace
+    prepreg; ``xi`` is exposed so it can be calibrated per system.
+    """
+    return halpin_tsai(Vf, fiber.G12f, matrix.Gm, xi)
+
+
+def nu23_rule_of_mixtures(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties
+) -> float:
+    """Transverse Poisson's ratio by the rule of mixtures.
+
+    .. math:: \\nu_{23} = V_f \\nu_{23f} + (1 - V_f) \\nu_m
+
+    where ``nu23f`` is :attr:`FiberProperties.nu23f_effective`.  The same
+    averaging as :func:`nu12_rule_of_mixtures`, applied in the transverse
+    plane.
+
+    .. warning::
+
+       ``nu23`` is the least reliable of the predicted constants.  This
+       rule keeps it bounded between ``nu23f`` and ``nu_m`` — always
+       physically admissible — but it ignores the constrained,
+       near-incompressible transverse response of the matrix and therefore
+       **under**-predicts ``nu23``: measured unidirectional plies sit
+       around 0.4-0.5, roughly 40 % above this estimate.  The Halpin-Tsai
+       alternative (predict ``G23``, then back out ``nu23``) was rejected
+       because with an isotropic fibre such as glass it returns
+       ``nu23`` up to 0.94 — admissible but not credible.  Override
+       ``nu23`` on the returned card when a measured value is available.
+    """
+    _check_Vf(Vf)
+    return Vf * fiber.nu23f_effective + (1.0 - Vf) * matrix.num
+
+
+def g23_transverse_isotropy(E2: float, nu23: float) -> float:
+    """Transverse shear modulus [MPa] from transverse isotropy.
+
+    .. math:: G_{23} = \\frac{E_2}{2 (1 + \\nu_{23})}
+
+    In the 2-3 plane a transversely isotropic ply is isotropic, so ``G23``
+    is not an independent constant once ``E2`` and ``nu23`` are known.
+    """
+    if E2 <= 0:
+        raise ValueError(f"E2 must be positive, got {E2}")
+    if nu23 <= -1.0:
+        raise ValueError(f"nu23 must be > -1, got {nu23}")
+    return E2 / (2.0 * (1.0 + nu23))
+
+
+def alpha1_schapery(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties
+) -> float:
+    """Longitudinal CTE [1/K] by Schapery's energy-principles result.
+
+    .. math::
+
+        \\alpha_1 = \\frac{V_f E_{1f} \\alpha_{1f}
+                           + (1 - V_f) E_m \\alpha_m}
+                          {V_f E_{1f} + (1 - V_f) E_m}
+
+    The stiffness-weighted average: the fibres dominate, which is why a
+    carbon/epoxy ply has a near-zero (often slightly negative) axial CTE.
+
+    References
+    ----------
+    Schapery (1968), J. Compos. Mater. 2(3):380-404.
+    """
+    _check_Vf(Vf)
+    Vm = 1.0 - Vf
+    num = Vf * fiber.E1f * fiber.alpha1f + Vm * matrix.Em * matrix.alpham
+    return num / (Vf * fiber.E1f + Vm * matrix.Em)
+
+
+def alpha2_schapery(
+    Vf: float, fiber: FiberProperties, matrix: MatrixProperties
+) -> float:
+    """Transverse CTE [1/K] by Schapery's energy-principles result.
+
+    .. math::
+
+        \\alpha_2 = (1 + \\nu_{12f}) \\alpha_{2f} V_f
+                  + (1 + \\nu_m) \\alpha_m (1 - V_f)
+                  - \\alpha_1 \\nu_{12}
+
+    References
+    ----------
+    Schapery (1968), J. Compos. Mater. 2(3):380-404.
+    """
+    _check_Vf(Vf)
+    Vm = 1.0 - Vf
+    alpha1 = alpha1_schapery(Vf, fiber, matrix)
+    nu12 = nu12_rule_of_mixtures(Vf, fiber, matrix)
+    return (
+        (1.0 + fiber.nu12f) * fiber.alpha2f * Vf
+        + (1.0 + matrix.num) * matrix.alpham * Vm
+        - alpha1 * nu12
+    )
+
+
+# ======================================================================
+# Constituent presets
+# ======================================================================
+#
+# Sourcing policy (each entry states its own sources):
+#
+#   * ``E1f`` and ``alpha1f`` come from the fibre manufacturer's product
+#     data sheet wherever one exists — those are the two fibre constants
+#     manufacturers actually publish.
+#   * ``E2f``, ``G12f``, ``nu12f``, ``alpha2f`` (and ``G23f`` where it is
+#     tabulated) come from Daniel & Ishai (2006) Table A.2, "Mechanical and
+#     Thermal Properties of Representative Fibers".  No manufacturer
+#     publishes transverse fibre constants.
+#   * For a fibre that Table A.2 does not tabulate, the transverse set is
+#     taken from the table's nearest same-class column and the substitution
+#     is named explicitly in the comment.  Nothing here is invented: every
+#     number is either a data-sheet value or a handbook value, and where a
+#     handbook value belongs to a *different* fibre of the same class, the
+#     comment says so.
+#
+# Abbreviations used below:
+#   D&I   = I. M. Daniel and O. Ishai, "Engineering Mechanics of Composite
+#           Materials", 2nd ed., Oxford University Press (2006), Table A.2
+#           (fibres) / Table A.3 (matrices).
+#   PDS   = manufacturer product data sheet (revision as noted).
+
+FIBER_PRESETS: dict[str, FiberProperties] = {
+    # --- Standard-modulus PAN carbon -------------------------------------
+    # Hexcel HexTow AS4 PDS (2023): tensile modulus 231 GPa (33.5 Msi),
+    # tensile strength 4501 MPa, CTE -0.63 ppm/degC, density 1.79 g/cm3.
+    # Transverse set from D&I Table A.2, column "AS-4 Carbon"
+    # (E2f 15 GPa, G12f 27 GPa, G23f 7 GPa, nu12f 0.20, alpha2f 15e-6).
+    "AS4": FiberProperties(
+        E1f=231_000.0, E2f=15_000.0, G12f=27_000.0, G23f=7_000.0,
+        nu12f=0.20, alpha1f=-0.63e-6, alpha2f=15.0e-6, name="AS4",
+    ),
+    # Toray TORAYCA T300 PDS: tensile modulus 230 GPa, strength 3530 MPa,
+    # density 1.76 g/cm3 (D&I Table A.2 agrees: 230 GPa).  Transverse set
+    # and CTEs from D&I Table A.2, column "T-300 Carbon".
+    "T300": FiberProperties(
+        E1f=230_000.0, E2f=15_000.0, G12f=27_000.0, G23f=7_000.0,
+        nu12f=0.20, alpha1f=-0.7e-6, alpha2f=12.0e-6, name="T300",
+    ),
+    # Toray TORAYCA T700S PDS: tensile modulus 230 GPa, strength 4900 MPa,
+    # density 1.80 g/cm3.  T700S is not tabulated in D&I Table A.2; the
+    # transverse set and CTEs are taken from the "T-300 Carbon" column —
+    # the same standard-modulus PAN class at an identical axial modulus.
+    "T700S": FiberProperties(
+        E1f=230_000.0, E2f=15_000.0, G12f=27_000.0, G23f=7_000.0,
+        nu12f=0.20, alpha1f=-0.7e-6, alpha2f=12.0e-6, name="T700S",
+    ),
+    # --- Intermediate-modulus PAN carbon ---------------------------------
+    # Hexcel HexTow IM7 PDS (2023): tensile modulus 276 GPa (40.0 Msi,
+    # chord 6000-1000), strength 5670 MPa, CTE -0.64 ppm/degC.  Transverse
+    # set from D&I Table A.2, column "IM7 Carbon" (E2f 21 GPa, G12f 14 GPa,
+    # nu12f 0.20, alpha2f 10e-6); that column quotes E1f = 290 GPa, and the
+    # data-sheet 276 GPa is preferred for the axial modulus.  D&I does not
+    # tabulate G23f for IM7, so it is estimated (see G23f_effective).
+    "IM7": FiberProperties(
+        E1f=276_000.0, E2f=21_000.0, G12f=14_000.0,
+        nu12f=0.20, alpha1f=-0.64e-6, alpha2f=10.0e-6, name="IM7",
+    ),
+    # Hexcel HexTow IM10 PDS (2023): tensile modulus 313 GPa (45.4 Msi),
+    # strength 6826 MPa, CTE -0.70 ppm/degC.  Not in D&I Table A.2; the
+    # transverse set is taken from the "IM7 Carbon" column, the nearest
+    # tabulated intermediate-modulus PAN fibre.
+    "IM10": FiberProperties(
+        E1f=313_000.0, E2f=21_000.0, G12f=14_000.0,
+        nu12f=0.20, alpha1f=-0.70e-6, alpha2f=10.0e-6, name="IM10",
+    ),
+    # Hexcel HexTow IM6 PDS (2023): tensile modulus 279 GPa (40.5 Msi),
+    # strength 5860 MPa.  IM6G is the G-sized grade of the same fibre.  Not
+    # in D&I Table A.2; transverse set and alpha1f from the "IM7 Carbon"
+    # column (the PDS does not quote a CTE for IM6).
+    "IM6G": FiberProperties(
+        E1f=279_000.0, E2f=21_000.0, G12f=14_000.0,
+        nu12f=0.20, alpha1f=-0.2e-6, alpha2f=10.0e-6, name="IM6G",
+    ),
+    # Toray TORAYCA T800S PDS: tensile modulus 294 GPa, strength 5880 MPa,
+    # CTE -0.4e-6 /degC, density 1.80 g/cm3.  Not in D&I Table A.2;
+    # transverse set from the "IM7 Carbon" column (nearest tabulated
+    # intermediate-modulus PAN fibre).
+    "T800S": FiberProperties(
+        E1f=294_000.0, E2f=21_000.0, G12f=14_000.0,
+        nu12f=0.20, alpha1f=-0.4e-6, alpha2f=10.0e-6, name="T800S",
+    ),
+    # --- Glass and aramid ------------------------------------------------
+    # D&I Table A.2, column "S-Glass": E 86 GPa, G 35 GPa, nu 0.23,
+    # alpha 5.6e-6 /degC, strength 4500 MPa.  Glass fibre is isotropic, so
+    # E2f = E1f and G23f = G12f.  Cross-check: the AGY S-2 Glass data sheet
+    # quotes 86.9 GPa and nu = 0.22.
+    "S2_GLASS": FiberProperties(
+        E1f=86_000.0, E2f=86_000.0, G12f=35_000.0, G23f=35_000.0,
+        nu12f=0.23, alpha1f=5.6e-6, alpha2f=5.6e-6, name="S2_GLASS",
+    ),
+    # D&I Table A.2, column "Kevlar 49 Aramid": E1f 131 GPa, E2f 7 GPa,
+    # G12f 21 GPa, nu12f 0.33, alpha1f -2e-6, alpha2f 60e-6 /degC.
+    "KEVLAR49": FiberProperties(
+        E1f=131_000.0, E2f=7_000.0, G12f=21_000.0,
+        nu12f=0.33, alpha1f=-2.0e-6, alpha2f=60.0e-6, name="KEVLAR49",
+    ),
+}
+"""Fibre constituent presets, keyed by fibre designation.
+
+Every value is either a manufacturer data-sheet value or a handbook value;
+see the sourcing policy in the module source above each entry.
+"""
+
+
+MATRIX_PRESETS: dict[str, MatrixProperties] = {
+    # D&I Table A.3, column "EPOXY (3501-6)": Em 4.3 GPa, Gm 1.60 GPa,
+    # nu 0.35, alpha 45e-6 /degC.
+    "EPOXY_3501_6": MatrixProperties(
+        Em=4_300.0, num=0.35, alpham=45.0e-6, name="EPOXY_3501_6",
+    ),
+    # Hexcel HexPly 8552 PDS (2023), "Typical Neat Resin Data": tensile
+    # modulus 4670 MPa, tensile strength 121 MPa, density 1.301 g/cm3.
+    # The PDS publishes no Poisson's ratio or CTE for the neat resin; both
+    # are taken as the typical cured-epoxy values of D&I Table A.3
+    # (nu = 0.35, alpha = 45e-6 /degC).
+    "EPOXY_8552": MatrixProperties(
+        Em=4_670.0, num=0.35, alpham=45.0e-6, name="EPOXY_8552",
+    ),
+}
+"""Matrix (neat resin) constituent presets, keyed by resin designation.
+
+An isotropic card already in :class:`~wrinklefe.core.material.MaterialLibrary`
+— such as ``EPOXY_S6C10`` — can be used directly instead, via
+:meth:`MatrixProperties.from_material`.
+"""

--- a/tests/test_micromechanics.py
+++ b/tests/test_micromechanics.py
@@ -1,0 +1,470 @@
+"""Tests for wrinklefe.core.micromechanics.
+
+The headline test is :class:`TestPresetReproduction`: it rebuilds the
+shipped library presets from their constituents at the fibre volume
+fraction each preset documents in its own source comment, and pins how far
+the prediction lands from the shipped card.  Those deviations are the
+honest accuracy statement for this module — the tolerances below were read
+off the measurement, not chosen first and fitted to.
+"""
+
+import numpy as np
+import pytest
+
+from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
+from wrinklefe.core.micromechanics import (
+    FIBER_PRESETS,
+    MATRIX_PRESETS,
+    FiberProperties,
+    MatrixProperties,
+    alpha1_schapery,
+    alpha2_schapery,
+    e1_rule_of_mixtures,
+    e2_halpin_tsai,
+    g12_halpin_tsai,
+    g23_transverse_isotropy,
+    halpin_tsai,
+    nu12_rule_of_mixtures,
+    nu23_rule_of_mixtures,
+)
+
+
+@pytest.fixture(scope="module")
+def library():
+    return MaterialLibrary()
+
+
+@pytest.fixture(scope="module")
+def generic_epoxy(library):
+    """The library's neat-epoxy card as a matrix constituent (3.5 GPa)."""
+    return MatrixProperties.from_material(library.get("EPOXY_S6C10"))
+
+
+# ======================================================================
+# Preset reproduction — the headline validation
+# ======================================================================
+
+# One entry per library preset whose own source comment documents the
+# fibre volume fraction it was built at (material.py, the _load_builtins
+# block).  Presets that do not state a Vf are excluded: without the Vf the
+# comparison would be a fit, not a prediction.
+#
+#   system            fibre       matrix           Vf     source of the Vf
+PRESET_CASES = [
+    # "computed via micromechanics at Vf ~ 0.60"
+    ("AC318_S6C10", "S2_GLASS", None, 0.60),
+    # "Vf ~ 0.59".  HexPly M21 publishes no neat-resin modulus, so the
+    # library's generic 3.5 GPa epoxy card stands in for the matrix; the
+    # matrix-dominated predictions (E2, G12) are indicative only here.
+    ("T800S_M21", "T800S", None, 0.59),
+    # "Table 1, 60% Vf cured ply properties"
+    ("IM10_8552", "IM10", "EPOXY_8552", 0.60),
+    # "Hsiao & Daniel (1996) ... Table 1 (Vf 0.66)"
+    ("IM6G_3501_6", "IM6G", "EPOXY_3501_6", 0.66),
+    # "Representative cured-ply values at Vf ~ 0.60"
+    ("S2_GLASS_EPOXY", "S2_GLASS", None, 0.60),
+    # "Representative cured-ply values at Vf ~ 0.60"
+    ("KEVLAR49_EPOXY", "KEVLAR49", None, 0.60),
+]
+
+# Measured deviation of the prediction from the shipped card, in per cent
+# (positive = the model is stiffer than the preset).  These are recorded
+# measurements, re-derived by running the module; they are pinned so that a
+# change to a mixing rule or a constituent constant has to be looked at.
+MEASURED_DEVIATION_PCT = {
+    ("AC318_S6C10", "E1"): -8.6,
+    ("AC318_S6C10", "E2"): 28.7,
+    ("AC318_S6C10", "G12"): -17.1,
+    ("AC318_S6C10", "nu12"): -0.7,
+    ("T800S_M21", "E1"): 11.4,
+    ("T800S_M21", "E2"): 13.3,
+    ("T800S_M21", "G12"): -9.8,
+    ("T800S_M21", "nu12"): -25.3,
+    ("IM10_8552", "E1"): 2.5,
+    ("IM10_8552", "E2"): 20.8,
+    ("IM10_8552", "G12"): -13.2,
+    ("IM10_8552", "nu12"): -18.8,
+    ("IM6G_3501_6", "E1"): 9.8,
+    ("IM6G_3501_6", "E2"): 32.8,
+    ("IM6G_3501_6", "G12"): -21.3,
+    ("IM6G_3501_6", "nu12"): -19.0,
+    ("S2_GLASS_EPOXY", "E1"): 1.9,
+    ("S2_GLASS_EPOXY", "E2"): -18.7,
+    ("S2_GLASS_EPOXY", "G12"): -32.0,
+    ("S2_GLASS_EPOXY", "nu12"): -7.3,
+    ("KEVLAR49_EPOXY", "E1"): 5.3,
+    ("KEVLAR49_EPOXY", "E2"): -2.7,
+    # Halpin-Tsai with the handbook aramid G12f = 21 GPa over-predicts the
+    # ply shear modulus by a factor of ~1.8.  See the xfail below.
+    ("KEVLAR49_EPOXY", "G12"): 83.6,
+    ("KEVLAR49_EPOXY", "nu12"): -0.6,
+}
+
+# Tolerances read off the measurements above, with margin.  They are wide
+# on purpose: these are semi-empirical mixing rules compared against cards
+# assembled from test data and several different literature sources, and
+# quoting a tight tolerance would misrepresent the model.
+TOLERANCE_PCT = {"E1": 15.0, "E2": 40.0, "G12": 40.0, "nu12": 30.0}
+
+# (system, property) pairs the model does not reproduce, kept visible as
+# xfail rather than excluded or tuned away.
+KNOWN_FAILURES = {
+    ("KEVLAR49_EPOXY", "G12"): (
+        "Halpin-Tsai over-predicts aramid ply shear by 84 %: Daniel & Ishai "
+        "Table A.2 quotes G12f = 21 GPa for Kevlar 49, but the measured "
+        "axial shear modulus of aramid fibre is contested (published values "
+        "span ~2-21 GPa) because the fibrils shear so readily.  Bending the "
+        "fibre constant to close the gap would make the module useless at a "
+        "Vf other than this one, so the discrepancy stays visible."
+    ),
+}
+
+
+def _build(case, generic_epoxy):
+    system, fiber_key, matrix_key, Vf = case
+    matrix = generic_epoxy if matrix_key is None else MATRIX_PRESETS[matrix_key]
+    return OrthotropicMaterial.from_constituents(
+        FIBER_PRESETS[fiber_key], matrix, Vf, name=f"{system}_predicted"
+    )
+
+
+def _deviation_pct(predicted: float, reference: float) -> float:
+    return 100.0 * (predicted - reference) / reference
+
+
+def _preset_params():
+    params = []
+    for case in PRESET_CASES:
+        for prop in ("E1", "E2", "G12", "nu12"):
+            marks = []
+            reason = KNOWN_FAILURES.get((case[0], prop))
+            if reason is not None:
+                marks.append(pytest.mark.xfail(strict=False, reason=reason))
+            params.append(
+                pytest.param(case, prop, marks=marks, id=f"{case[0]}-{prop}")
+            )
+    return params
+
+
+class TestPresetReproduction:
+    """Rebuild the shipped presets from constituents at their documented Vf."""
+
+    @pytest.mark.parametrize(("case", "prop"), _preset_params())
+    def test_within_tolerance(self, case, prop, library, generic_epoxy):
+        predicted = getattr(_build(case, generic_epoxy), prop)
+        reference = getattr(library.get(case[0]), prop)
+        deviation = _deviation_pct(predicted, reference)
+        assert abs(deviation) <= TOLERANCE_PCT[prop], (
+            f"{case[0]} {prop}: predicted {predicted:.4g} vs preset "
+            f"{reference:.4g} ({deviation:+.1f} %)"
+        )
+
+    @pytest.mark.parametrize(
+        ("case", "prop"),
+        [
+            pytest.param(case, prop, id=f"{case[0]}-{prop}")
+            for case in PRESET_CASES
+            for prop in ("E1", "E2", "G12", "nu12")
+        ],
+    )
+    def test_measured_deviation_is_pinned(self, case, prop, library, generic_epoxy):
+        """The recorded deviations are the module's accuracy claim.
+
+        A change to a mixing rule or a constituent constant moves these, and
+        that has to be a deliberate, re-measured decision — including for
+        the pairs marked xfail above.
+        """
+        predicted = getattr(_build(case, generic_epoxy), prop)
+        reference = getattr(library.get(case[0]), prop)
+        deviation = _deviation_pct(predicted, reference)
+        expected = MEASURED_DEVIATION_PCT[(case[0], prop)]
+        assert deviation == pytest.approx(expected, abs=0.1)
+
+    @pytest.mark.parametrize("case", PRESET_CASES, ids=lambda c: c[0])
+    def test_predicted_card_is_valid(self, case, generic_epoxy):
+        """Every predicted card survives OrthotropicMaterial validation."""
+        ply = _build(case, generic_epoxy)
+        ply.validate()
+        assert np.all(np.linalg.eigvalsh(ply.compliance_matrix) > 0)
+
+
+# ======================================================================
+# Physical limits and monotonicity
+# ======================================================================
+
+class TestLimits:
+    def test_Vf_zero_returns_matrix_properties(self, generic_epoxy):
+        matrix = generic_epoxy
+        ply = OrthotropicMaterial.from_constituents(
+            FIBER_PRESETS["IM7"], matrix, 0.0
+        )
+        assert ply.E1 == pytest.approx(matrix.Em)
+        assert ply.E2 == pytest.approx(matrix.Em)
+        assert ply.E3 == pytest.approx(matrix.Em)
+        assert ply.G12 == pytest.approx(matrix.Gm)
+        assert ply.G23 == pytest.approx(matrix.Gm)
+        assert ply.nu12 == pytest.approx(matrix.num)
+        assert ply.nu23 == pytest.approx(matrix.num)
+        assert ply.alpha1 == pytest.approx(matrix.alpham)
+        assert ply.alpha2 == pytest.approx(matrix.alpham)
+
+    def test_Vf_one_returns_fiber_properties(self, generic_epoxy):
+        fiber = FIBER_PRESETS["IM7"]
+        ply = OrthotropicMaterial.from_constituents(fiber, generic_epoxy, 1.0)
+        assert ply.E1 == pytest.approx(fiber.E1f)
+        assert ply.E2 == pytest.approx(fiber.E2f)
+        assert ply.G12 == pytest.approx(fiber.G12f)
+        assert ply.nu12 == pytest.approx(fiber.nu12f)
+        assert ply.nu23 == pytest.approx(fiber.nu23f_effective)
+        assert ply.alpha1 == pytest.approx(fiber.alpha1f)
+
+    def test_halpin_tsai_is_exact_at_both_limits(self):
+        assert halpin_tsai(0.0, 200.0, 3.5, 2.0) == pytest.approx(3.5)
+        assert halpin_tsai(1.0, 200.0, 3.5, 2.0) == pytest.approx(200.0)
+
+    @pytest.mark.parametrize("fiber_key", sorted(FIBER_PRESETS))
+    def test_E1_increases_monotonically_with_Vf(self, fiber_key, generic_epoxy):
+        fiber = FIBER_PRESETS[fiber_key]
+        Vfs = np.linspace(0.0, 1.0, 21)
+        E1 = [e1_rule_of_mixtures(float(v), fiber, generic_epoxy) for v in Vfs]
+        assert np.all(np.diff(E1) > 0.0)
+
+    @pytest.mark.parametrize("fiber_key", sorted(FIBER_PRESETS))
+    def test_E2_and_G12_increase_monotonically_with_Vf(
+        self, fiber_key, generic_epoxy
+    ):
+        fiber = FIBER_PRESETS[fiber_key]
+        Vfs = np.linspace(0.0, 1.0, 21)
+        E2 = [e2_halpin_tsai(float(v), fiber, generic_epoxy) for v in Vfs]
+        G12 = [g12_halpin_tsai(float(v), fiber, generic_epoxy) for v in Vfs]
+        assert np.all(np.diff(E2) > 0.0)
+        assert np.all(np.diff(G12) > 0.0)
+
+    def test_stiffness_ratio_between_two_Vf_is_the_intended_use(self):
+        """Compaction raises Vf, which must raise E1 and E2."""
+        fiber = FIBER_PRESETS["IM10"]
+        matrix = MATRIX_PRESETS["EPOXY_8552"]
+        nominal = OrthotropicMaterial.from_constituents(fiber, matrix, 0.60)
+        compacted = OrthotropicMaterial.from_constituents(fiber, matrix, 0.68)
+        assert compacted.E1 > nominal.E1
+        assert compacted.E2 > nominal.E2
+        assert compacted.G12 > nominal.G12
+
+
+class TestPositiveDefiniteness:
+    """Bad mixing constants can silently yield a non-physical ply."""
+
+    @pytest.mark.parametrize("fiber_key", sorted(FIBER_PRESETS))
+    @pytest.mark.parametrize(
+        "matrix_key", [*sorted(MATRIX_PRESETS), "EPOXY_S6C10"]
+    )
+    def test_every_preset_pair_is_positive_definite_over_the_Vf_range(
+        self, fiber_key, matrix_key, generic_epoxy
+    ):
+        fiber = FIBER_PRESETS[fiber_key]
+        matrix = (
+            generic_epoxy if matrix_key == "EPOXY_S6C10"
+            else MATRIX_PRESETS[matrix_key]
+        )
+        for Vf in np.linspace(0.30, 0.75, 19):
+            ply = OrthotropicMaterial.from_constituents(fiber, matrix, float(Vf))
+            eigvals = np.linalg.eigvalsh(ply.compliance_matrix)
+            assert np.all(eigvals > 0), f"non-PD at Vf={Vf:.3f}"
+            assert -1.0 < ply.nu23 < 0.5
+
+
+# ======================================================================
+# Strengths are not predicted
+# ======================================================================
+
+class TestStrengthsAreNotPredicted:
+    def test_strengths_do_not_track_Vf(self, generic_epoxy):
+        """Executable statement of the documented limitation."""
+        fiber = FIBER_PRESETS["IM10"]
+        low = OrthotropicMaterial.from_constituents(fiber, generic_epoxy, 0.40)
+        high = OrthotropicMaterial.from_constituents(fiber, generic_epoxy, 0.70)
+        for attr in ("Xt", "Xc", "Yt", "Yc", "S12"):
+            assert getattr(low, attr) == getattr(high, attr)
+
+    def test_strengths_from_carries_the_reference_allowables(
+        self, library, generic_epoxy
+    ):
+        reference = library.get("IM10_8552")
+        ply = OrthotropicMaterial.from_constituents(
+            FIBER_PRESETS["IM10"], MATRIX_PRESETS["EPOXY_8552"], 0.55,
+            strengths_from=reference,
+        )
+        for attr in ("Xt", "Xc", "Yt", "Yc", "Zt", "Zc", "S12", "S13", "S23",
+                     "beta1", "beta2", "beta3", "gamma_Y", "GIc", "GIIc",
+                     "beta_shear", "alpha_0", "sigma_max", "tau_max"):
+            assert getattr(ply, attr) == getattr(reference, attr)
+        # ... but the elastic constants are the predicted ones, not copied.
+        assert ply.E1 != reference.E1
+
+    def test_default_name_records_the_constituents_and_Vf(self, generic_epoxy):
+        ply = OrthotropicMaterial.from_constituents(
+            FIBER_PRESETS["T300"], generic_epoxy, 0.6
+        )
+        assert ply.name == "T300_EPOXY_S6C10_Vf0.60"
+
+
+# ======================================================================
+# Validation
+# ======================================================================
+
+class TestValidation:
+    @pytest.mark.parametrize("Vf", [-0.01, 1.01, 2.0, -1.0])
+    def test_Vf_outside_unit_interval_raises(self, Vf, generic_epoxy):
+        with pytest.raises(ValueError, match=r"Vf must be in \[0, 1\]"):
+            OrthotropicMaterial.from_constituents(
+                FIBER_PRESETS["IM7"], generic_epoxy, Vf
+            )
+
+    @pytest.mark.parametrize("attr", ["E1f", "E2f", "G12f"])
+    def test_non_positive_fiber_modulus_raises(self, attr):
+        kwargs = dict(
+            E1f=230_000.0, E2f=15_000.0, G12f=27_000.0, nu12f=0.2,
+            alpha1f=-0.5e-6, alpha2f=15e-6,
+        )
+        kwargs[attr] = -1.0
+        with pytest.raises(ValueError, match=f"{attr} must be positive"):
+            FiberProperties(**kwargs)
+
+    def test_non_positive_fiber_G23f_raises(self):
+        with pytest.raises(ValueError, match="G23f must be positive"):
+            FiberProperties(
+                E1f=230_000.0, E2f=15_000.0, G12f=27_000.0, G23f=0.0,
+                nu12f=0.2, alpha1f=-0.5e-6, alpha2f=15e-6,
+            )
+
+    def test_inadmissible_fiber_poisson_ratio_raises(self):
+        with pytest.raises(ValueError, match="nu12f must satisfy"):
+            FiberProperties(
+                E1f=15_000.0, E2f=230_000.0, G12f=27_000.0, nu12f=0.9,
+                alpha1f=-0.5e-6, alpha2f=15e-6,
+            )
+
+    def test_non_positive_matrix_modulus_raises(self):
+        with pytest.raises(ValueError, match="Em must be positive"):
+            MatrixProperties(Em=0.0, num=0.35, alpham=45e-6)
+
+    @pytest.mark.parametrize("num", [0.5, 0.7, -1.0, -2.0])
+    def test_inadmissible_matrix_poisson_ratio_raises(self, num):
+        with pytest.raises(ValueError, match=r"num must be in \(-1, 0.5\)"):
+            MatrixProperties(Em=3500.0, num=num, alpham=45e-6)
+
+    def test_negative_halpin_tsai_xi_raises(self):
+        with pytest.raises(ValueError, match="xi must be non-negative"):
+            halpin_tsai(0.5, 200.0, 3.5, -1.0)
+
+    def test_non_positive_halpin_tsai_property_raises(self):
+        with pytest.raises(ValueError, match="positive properties"):
+            halpin_tsai(0.5, -200.0, 3.5, 2.0)
+
+    def test_g23_from_negative_E2_raises(self):
+        with pytest.raises(ValueError, match="E2 must be positive"):
+            g23_transverse_isotropy(-1.0, 0.3)
+
+    def test_g23_from_inadmissible_nu23_raises(self):
+        with pytest.raises(ValueError, match="nu23 must be"):
+            g23_transverse_isotropy(9000.0, -1.5)
+
+    @pytest.mark.parametrize(
+        "func",
+        [e1_rule_of_mixtures, nu12_rule_of_mixtures, nu23_rule_of_mixtures,
+         alpha1_schapery, alpha2_schapery],
+    )
+    def test_mixing_rules_reject_out_of_range_Vf(self, func, generic_epoxy):
+        with pytest.raises(ValueError, match=r"Vf must be in \[0, 1\]"):
+            func(1.5, FIBER_PRESETS["IM7"], generic_epoxy)
+
+
+# ======================================================================
+# Constituent containers
+# ======================================================================
+
+class TestConstituentContainers:
+    def test_matrix_shear_modulus_is_the_isotropic_relation(self):
+        matrix = MatrixProperties(Em=3500.0, num=0.35, alpham=45e-6)
+        assert matrix.Gm == pytest.approx(3500.0 / (2.0 * 1.35))
+
+    def test_from_material_reads_an_isotropic_card(self, library):
+        card = library.get("EPOXY_S6C10")
+        matrix = MatrixProperties.from_material(card)
+        assert matrix.Em == card.E1
+        assert matrix.num == card.nu12
+        assert matrix.alpham == card.alpha1
+        assert matrix.name == "EPOXY_S6C10"
+        assert matrix.Gm == pytest.approx(card.G12)
+
+    def test_from_material_warns_on_an_orthotropic_card(self, library, caplog):
+        with caplog.at_level("WARNING"):
+            matrix = MatrixProperties.from_material(library.get("IM7_8552"))
+        assert "not isotropic" in caplog.text
+        assert matrix.Em == library.get("IM7_8552").E1
+
+    def test_G23f_defaults_to_transverse_isotropy(self):
+        fiber = FiberProperties(
+            E1f=230_000.0, E2f=15_000.0, G12f=27_000.0, nu12f=0.2,
+            alpha1f=-0.5e-6, alpha2f=15e-6,
+        )
+        assert fiber.G23f_effective == pytest.approx(15_000.0 / 2.4)
+        assert fiber.nu23f_effective == pytest.approx(0.2)
+
+    def test_G23f_is_used_when_supplied(self):
+        fiber = FiberProperties(
+            E1f=230_000.0, E2f=15_000.0, G12f=27_000.0, G23f=7_000.0,
+            nu12f=0.2, alpha1f=-0.5e-6, alpha2f=15e-6,
+        )
+        assert fiber.G23f_effective == 7_000.0
+        assert fiber.nu23f_effective == pytest.approx(15_000.0 / 14_000.0 - 1.0)
+
+    @pytest.mark.parametrize("fiber_key", sorted(FIBER_PRESETS))
+    def test_every_fiber_preset_is_named_and_physical(self, fiber_key):
+        fiber = FIBER_PRESETS[fiber_key]
+        assert fiber.name == fiber_key
+        assert fiber.E1f >= fiber.E2f  # no fibre is stiffer across than along
+        assert 0.0 < fiber.nu12f < 0.5
+
+    @pytest.mark.parametrize("matrix_key", sorted(MATRIX_PRESETS))
+    def test_every_matrix_preset_is_named_and_physical(self, matrix_key):
+        matrix = MATRIX_PRESETS[matrix_key]
+        assert matrix.name == matrix_key
+        assert 2_000.0 < matrix.Em < 6_000.0  # cured aerospace epoxy
+        assert 0.3 <= matrix.num < 0.5
+
+
+# ======================================================================
+# Thermal expansion
+# ======================================================================
+
+class TestThermalExpansion:
+    def test_carbon_epoxy_axial_CTE_is_near_zero(self, generic_epoxy):
+        """The fibre dominates alpha1, so a CFRP ply barely grows axially."""
+        alpha1 = alpha1_schapery(0.60, FIBER_PRESETS["IM7"], generic_epoxy)
+        assert abs(alpha1) < 1.0e-6
+
+    def test_transverse_CTE_is_matrix_dominated(self, generic_epoxy):
+        alpha2 = alpha2_schapery(0.60, FIBER_PRESETS["IM7"], generic_epoxy)
+        assert alpha2 > 5.0 * abs(
+            alpha1_schapery(0.60, FIBER_PRESETS["IM7"], generic_epoxy)
+        )
+
+    def test_axial_CTE_falls_towards_the_fibre_value_as_Vf_rises(
+        self, generic_epoxy
+    ):
+        fiber = FIBER_PRESETS["IM7"]
+        low = alpha1_schapery(0.30, fiber, generic_epoxy)
+        high = alpha1_schapery(0.75, fiber, generic_epoxy)
+        assert high < low
+        assert abs(high - fiber.alpha1f) < abs(low - fiber.alpha1f)
+
+    def test_glass_epoxy_axial_CTE_matches_the_preset(self, library, generic_epoxy):
+        """A CTE check the presets can actually adjudicate.
+
+        S2_GLASS_EPOXY documents alpha1 = 6.6e-6 /K at Vf ~ 0.60; Schapery
+        predicts 5.4e-6, i.e. within 1.2e-6 /K.
+        """
+        predicted = alpha1_schapery(0.60, FIBER_PRESETS["S2_GLASS"], generic_epoxy)
+        reference = library.get("S2_GLASS_EPOXY").alpha1
+        assert abs(predicted - reference) < 1.5e-6


### PR DESCRIPTION
## Linked issue

Part A of #379 — *not* a full fix. #379 names its own blocker: *"there is **no fibre-volume-fraction → property model** anywhere … even if thickness varied, local Vf-driven stiffness/strength changes could not be expressed today."* This PR builds exactly that capability and nothing else. Part B — the compaction kinematics, variable ply thickness and per-element Vf field that consume it — is a separate later change.

## Summary

New `src/wrinklefe/core/micromechanics.py` plus `OrthotropicMaterial.from_constituents(fiber, matrix, Vf)`:

- **`FiberProperties`** (transversely isotropic) and **`MatrixProperties`** (isotropic; `from_material` lets an existing neat-resin card such as `EPOXY_S6C10` be reused instead of duplicating resin data).
- **Mixing rules**, each with its formula and citation in the docstring: Voigt rule of mixtures for `E1`, `nu12`, `nu23`; Halpin–Tsai for `E2` (ξ = 2) and `G12` (ξ = 1), with ξ exposed; transverse isotropy for `G23`; Schapery for `alpha1`/`alpha2`.
- **`FIBER_PRESETS`** for the nine fibres behind the library systems and **`MATRIX_PRESETS`** for the two resins with published neat-resin data.
- `from_constituents` returns a normal `OrthotropicMaterial`, so it goes through the existing validation — including the compliance positive-definiteness check at `material.py:183`.

**No behaviour change.** Nothing in the analysis pipeline consumes this module — the capability is deliberately inert in Part A. No existing preset's property values were touched, `resin_pocket.py` / the assembler / `AnalysisConfig` / the CLI / the app are all untouched, and the validation ledger shows zero drift.

### Measured preset reproduction — the headline validation

Six library systems document the Vf they were built at in their own source comments. Rebuilding them from constituents at that Vf gives (deviation of prediction from the shipped card, %):

| System | Vf | matrix used | E1 | E2 | G12 | nu12 |
|---|---|---|---|---|---|---|
| `AC318_S6C10` | 0.60 | `EPOXY_S6C10` (3.5 GPa) | −8.6 | +28.7 | −17.1 | −0.7 |
| `T800S_M21` | 0.59 | `EPOXY_S6C10` (stand-in) | +11.4 | +13.3 | −9.8 | −25.3 |
| `IM10_8552` | 0.60 | `EPOXY_8552` | +2.5 | +20.8 | −13.2 | −18.8 |
| `IM6G_3501_6` | 0.66 | `EPOXY_3501_6` | +9.8 | +32.8 | −21.3 | −19.0 |
| `S2_GLASS_EPOXY` | 0.60 | `EPOXY_S6C10` | +1.9 | −18.7 | −32.0 | −7.3 |
| `KEVLAR49_EPOXY` | 0.60 | `EPOXY_S6C10` | +5.3 | −2.7 | **+83.6** | −0.6 |

Tolerances (E1 15 %, nu12 30 %, E2 40 %, G12 40 %) were **read off these measurements afterwards**, not chosen first. Every deviation above is additionally pinned to 0.1 percentage points, so changing a mixing rule or a constituent constant forces a deliberate re-measurement.

Informationally, for the other constants: `G23` lands −7 % to +51 %, and `nu23` is under-predicted by 30–55 % on every system — the weakest prediction here, called out in the docstring.

### xfail / exclusions, with reasons

- **`KEVLAR49_EPOXY` G12 — `xfail(strict=False)`.** Halpin–Tsai with the handbook aramid `G12f` = 21 GPa (Daniel & Ishai Table A.2) over-predicts by 84 %. Published aramid axial-shear values scatter roughly 2–21 GPa because the fibrils shear so readily. Bending the fibre constant to close this one gap would make the module wrong at every *other* Vf — the only thing it exists to do — so the failure stays visible.
- **Five presets excluded from the reproduction test** (`AS4_3501_6`, `IM7_8552`, `T300_914`, `T700_2510`, `AC318_S6C10_vacbag`): their comments do not document a Vf. Without a documented Vf the comparison would be a fit, not a prediction. (For the record, assuming a nominal 0.60 they land at E1 +11.4 / −5.9 / +1.2 / +5.6 % respectively — but that assumption is exactly what makes them unfit as a test.)
- **`T800S_M21` matrix stand-in.** Hexcel publishes no neat-resin modulus for M21, so the generic 3.5 GPa epoxy card stands in; the matrix-dominated E2/G12 numbers for that row are indicative only. This is stated in the test case comment.

### Fibre data sourcing

No fibre was omitted, and nothing was invented. The stated policy, applied per preset in the source comments:

- `E1f` and `alpha1f` from the manufacturer data sheet: HexTow **AS4** (231 GPa, −0.63 ppm/°C), **IM6** (279 GPa) for IM6G, **IM7** (276 GPa, −0.64), **IM10** (313 GPa, −0.70); TORAYCA **T300** (230 GPa), **T700S** (230 GPa), **T800S** (294 GPa, −0.4).
- The transverse set (`E2f`, `G12f`, `nu12f`, `alpha2f`, and `G23f` where tabulated) from Daniel & Ishai (2006) Table A.2 — no manufacturer publishes transverse fibre constants. **S-2 glass** (86 GPa, ν 0.23, α 5.6e-6; cross-checked against the AGY S-2 data sheet at 86.9 GPa / ν 0.22) and **Kevlar 49** (131 / 7 / 21 GPa, ν 0.33) come wholly from that table.
- For **IM10, IM6G, T800S and T700S**, which Table A.2 does not list, the transverse set is taken from the table's nearest same-class column (IM7 for the intermediate-modulus PAN fibres, T-300 for T700S) and **the substitution is named explicitly in each comment** rather than dressed up as fibre-specific data.
- Matrices: `EPOXY_8552` Em = 4670 MPa from the HexPly 8552 data sheet's "Typical Neat Resin Data"; `EPOXY_3501_6` Em = 4300 MPa, ν 0.35, α 45e-6 from Daniel & Ishai Table A.3. Neither data sheet publishes a neat-resin Poisson ratio, so the typical cured-epoxy value is used and said so.

### Two design calls worth a reviewer's eye

1. **`nu23` by rule of mixtures, not by Halpin–Tsai `G23`.** Predicting `G23` with Halpin–Tsai and backing `nu23` out of transverse isotropy gives `nu23` up to **0.94** for an isotropic (glass) fibre — admissible under the PD check but not credible, and a live trap for Part B, where per-element Vf sweeps would wander into it. The rule-of-mixtures form stays bounded by the constituent values at the cost of under-predicting `nu23`; that trade is documented in the function docstring.
2. **Strengths are not predicted.** No rule here maps Vf to an allowable, so `Xt`/`Xc`/`Yt`/`Yc`/`S12`/… , the toughnesses and the cohesive tractions are carried over unchanged from `strengths_from=` (or left at the defaults). A test asserts they do *not* move with Vf, so the limitation is executable, not just prose.

## Checklist

- [x] Tests added or updated for the change — `tests/test_micromechanics.py`, 148 passed + 1 xfail. Preset reproduction, pinned deviations, Vf = 0 → matrix exactly and Vf = 1 → fibre, monotonicity of E1/E2/G12 in Vf, **compliance positive-definiteness across Vf ∈ [0.30, 0.75] for all 27 fibre × matrix preset pairs** (every ply PD; `nu23` stays in [0.18, 0.35]), validation errors, and the strength-invariance statement.
- [x] `pytest` green — targeted suites green (`test_micromechanics`, `test_material`, `test_io/`, `test_config_io`, `test_param_docs_match`, `test_logging_conventions`, `test_changelog`); the full `-m "not slow"` lane is running and CI is authoritative.
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe` clean (`src/wrinklefe app.py streamlit_viz.py`, 56 files)
- [x] Docs/README updated — README "Building a ply from its constituents" section, `docs/api/core.rst` autodoc entry, `sphinx-build -W docs docs/_build` succeeds, `pytest --doctest-modules src/wrinklefe` green
- [x] `CHANGELOG.md` `[Unreleased]` updated (Added; explicitly no **Numerical results** entry — nothing consumes the module)
- [x] `python scripts/validate.py` — **all cases match the pinned baselines**, zero drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_