### PR TITLE
physics: compaction-driven ply-thickness / local Vf gradient (#379, Part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- Physics — **compaction-driven ply-thickness / local fibre-volume-fraction
+  gradient** (issue #379, Part B — Fixes #379, completing the issue; builds
+  on the Part A micromechanics). New `wrinklefe.core.compaction` derives a
+  per-element local `Vf` from the deformed mesh with the kinematic rule
+  `Vf_local = vf_nominal · h0/h` — fibre content conserved per element while
+  the thickness change absorbs or expels resin — so a wrinkle constrained by
+  rigid tooling thins and thickens its plies instead of being modelled at a
+  constant ply thickness. Stretched trough elements turn resin-rich (low
+  `Vf`, softer); compacted crest elements turn resin-starved (high `Vf`,
+  stiffer), which is the treatment #371 left as a follow-up. Local materials
+  are **ratio-anchored** on the measured preset,
+  `P_local = P_preset · P_micro(Vf_local) / P_micro(vf_nominal)`, applied to
+  the stiffnesses and CTEs, so the micromechanics model contributes only its
+  `Vf` sensitivity and none of its 12–33 % absolute error; at
+  `Vf_local == vf_nominal` every ratio is exactly 1.0 and the preset object
+  itself is used. **Poisson ratios and all strengths stay at the preset
+  values** — no mixing rule maps `Vf` to an allowable, and inventing one
+  would be quietly wrong (local failure indices still move, because the
+  local stiffness redistributes stress). `Vf` is quantized onto an
+  `n_bins`-value grid anchored on the nominal value, so a mesh shares a few
+  dozen material objects rather than one per element. Enabled with
+  `AnalysisConfig(enable_vf_gradient=True)` (plus `vf_nominal`, `vf_fiber`,
+  `vf_matrix`, `vf_max`) or `wrinklefe analyze --vf-gradient`; **opt-in and
+  off by default**, FE-only, and restricted in v1 to
+  `morphology="tool_flat"`, whose flat outer envelope is what keeps the
+  per-column thickness — and hence the resin mass — conserved
+  (`surface_pocket_side="both"` is the two-caul-plate case). Elements
+  compacted past `vf_max` (default 0.75) saturate with a single counted
+  warning: the rule carries no lateral resin flow along the ply. See
+  `examples/10_vf_gradient_compaction.py`.
 - Core — **constituent-based micromechanics: fibre + matrix + fibre volume
   fraction to a ply** (issue #379, Part A — the Vf-to-properties capability
   #379 names as its own blocker; the compaction kinematics that consume it
@@ -727,6 +757,18 @@ version produced a given file.
   imported; native `.inp`/VTK writers need no extra).
 
 ### Numerical results
+- **Compaction Vf gradient (issue #379, Part B)**: opt-in and off by
+  default, so every existing result — the ledger included — is unchanged.
+  When it is switched on for a `tool_flat` run the FE numbers move, as
+  intended and as measured: on a 24-ply UD two-caul case (`tool_flat`,
+  `surface_pocket_side="both"`, A = 0.25 mm, IM7/8552, 40 × 4 mm domain)
+  `modulus_retention_global` goes 0.937591 with the binary surface pockets
+  to 0.944565 with the gradient (+0.006974, +0.744 %) — the compacted crest
+  band stiffens more than the resin-rich trough softens, and the
+  continuous field replaces a binary neat-resin tag. Against a wrinkle with
+  no trough treatment at all (0.957389) the gradient is 0.012824 *softer*,
+  so it lands between the two, as the physics implies. 64 of 1920 elements
+  saturate at the `vf_max = 0.75` cap at that amplitude.
 - **Penetration gate × multi-wrinkle (issue #342)**: with a
   `penetration_gate` preset and the geometry supplied via
   `AnalysisConfig.wrinkles`, the gate previously took its angle from the

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Public link, no account needed.
 - **Cohesive-zone delamination (CZM):** Bilinear traction–separation interface elements (`enable_czm=True`) with per-interface damage, energy and crack-length reporting — including continuous cohesive surfaces across adjacent wrinkles for crest-to-crest delamination link-up (see `examples/08_multi_wrinkle_czm_linkup.py`)
 - **Resin-pocket material zone:** Graded neat-epoxy lens at the wrinkle crest (modulus + fibre-angle blend, counted once) via `wrinklefe.core.resin_pocket`
 - **Tool-flat surfaces & surface resin pockets:** Parts cured against rigid tooling / a caul sheet keep perfectly flat outer surfaces while the fibres undulate internally; the wrinkle troughs fill with neat resin under the flat surface (`enable_surface_resin_pockets`, `surface_pocket_side` = `top`/`bottom`/`both`). FE-only, trough-following, volume-conserving; composes with the crest lens
+- **Compaction Vf / ply-thickness gradient:** Under rigid tooling the resin is squeezed out of the compacted regions and pools where the geometry opens up, so ply thickness and local fibre volume fraction vary through the wrinkle (`enable_vf_gradient`, `tool_flat` only — `surface_pocket_side="both"` is the two-caul-plate case). `Vf_local = vf_nominal · h0/h` per element (fibre content conserved), and the local ply is the preset **scaled by the micromechanics Vf ratio** (`wrinklefe.core.compaction`); FE-only, opt-in, and the continuous generalization of the binary surface pockets
 - **Progressive-damage FE:** Load-stepping `ProgressiveDamageSolver` to ultimate load with optional crack-band (Bažant–Oh) regularization — the first FE route to a UD compression knockdown
 - **Penetration gate (θ, D/T, z):** Closed-form two-parameter UD predictor `KD = 1 − (1 − KD_angle(θ))·S(D/T)·P(z)` with calibrated presets; zero FE cost (`wrinklefe.core.penetration_gate`)
 - **Linear buckling:** Geometric-stiffness eigenvalue solve (`LinearBucklingSolver`) with a microbuckling knockdown — verified structural-buckling infrastructure, but a homogenised-continuum eigenvalue does not capture the *fibre-scale* wrinkle knockdown (it gets the sign wrong: the bifurcation load *rises* with the wrinkle), so it is **not** the production UD predictor (the penetration gate is); see the [modelling findings](docs/wrinkle_modeling_findings.md)
@@ -320,9 +321,36 @@ On the crest side the `surface_transition_plies` transition elements
 bounded — `amplitude ≤ 0.8 · surface_transition_plies · ply_thickness /
 nz_per_ply`; beyond it the elements would invert and construction fails
 with a message naming both remedies (more transition plies, or a smaller
-amplitude). The symmetric-profile limitation under rigid tooling (crests
-physically compact rather than penetrate the tool) is a documented
-follow-up.
+amplitude).
+
+Those compressed crest-side elements are exactly what the **compaction
+Vf gradient** models (issue #379): set `enable_vf_gradient=True` and the
+local fibre volume fraction follows the thickness change,
+`Vf_local = vf_nominal · h0/h`, so the crest band compacts and stiffens
+while the trough turns resin-rich and softens — one continuous field
+instead of a binary neat-resin tag:
+
+```python
+config = AnalysisConfig(
+    morphology="tool_flat", amplitude=0.25, surface_pocket_side="both",
+    enable_vf_gradient=True,          # opt-in; tool_flat only in v1
+    vf_nominal=None,                  # None -> the card's documented Vf
+    vf_max=0.75,                      # compaction cap (square packing)
+    material=lib.get("IM7_8552"), angles=[0.0] * 24, ply_thickness=0.183,
+    analytical_only=False,
+)
+```
+
+The local card is the **preset scaled by the micromechanics ratio**
+`P_micro(Vf_local) / P_micro(vf_nominal)` for the stiffnesses and CTEs, so
+the trend is modelled without importing the micromechanics model's
+absolute error. **Poisson ratios and all strengths stay at the preset
+values** — no mixing rule predicts a strength from `Vf` (local failure
+indices still move, because the local stiffness redistributes stress).
+Elements compacted past `vf_max` saturate, counted in a single warning;
+the rule carries no lateral resin flow along the ply. When the gradient is
+on it supersedes the binary surface-pocket tag (it is its continuous
+generalization); the machined crest resin lens composes unchanged.
 
 ### Penetration gate (θ, D/T, z) — UD, zero FE cost
 
@@ -543,7 +571,8 @@ wrinklefe analyze --transverse-mode gaussian_decay --transverse-width 5 \
 #### Wrinkle-defect capabilities
 
 `analyze` also exposes the newer defect models. The FE-only features
-(`--resin-pocket`, `--surface-resin-pockets`, `--progressive`) force the
+(`--resin-pocket`, `--surface-resin-pockets`, `--vf-gradient`,
+`--progressive`) force the
 full FE solve, so they take precedence over `--analytical-only` / `--no-fe`:
 
 ```bash
@@ -566,6 +595,10 @@ wrinklefe analyze --surface-resin-pockets --surface-pocket-side both
 # is bounded by 0.8 * surface-transition-plies * ply_thickness / nz_per_ply.
 wrinklefe analyze --morphology tool-flat --amplitude 0.35 \
     --surface-pocket-side both --surface-transition-plies 3
+
+# Compaction Vf / ply-thickness gradient — two caul plates (FE, tool_flat)
+wrinklefe analyze --morphology tool-flat --amplitude 0.25 \
+    --surface-pocket-side both --vf-gradient
 ```
 
 | Flag | Config field | Notes |
@@ -575,6 +608,8 @@ wrinklefe analyze --morphology tool-flat --amplitude 0.35 \
 | `--resin-pocket` | `enable_resin_pocket` | Crest resin lens (FE-only) |
 | `--surface-resin-pockets` / `--surface-pocket-side {top,bottom,both}` | `enable_surface_resin_pockets` / `surface_pocket_side` | Tool-flat surface pockets (FE-only). Auto-enabled for `--morphology tool-flat` |
 | `--surface-transition-plies N` | `surface_transition_plies` | `tool_flat` only: amplitude-ramp width (≥ 1, default 2); bounds the amplitude |
+| `--vf-gradient` | `enable_vf_gradient` | Compaction Vf / ply-thickness gradient (FE-only, `tool_flat` only); supersedes the binary surface pockets |
+| `--vf-nominal V` / `--vf-fiber F` / `--vf-matrix M` | `vf_nominal` / `vf_fiber` / `vf_matrix` | Ratio anchor and constituents; omit to use the material card's documented values |
 | `--progressive` / `--increments N` | `enable_progressive_damage` / `progressive_n_increments` | Load-stepping ultimate strength (FE-only) |
 
 The long tail of finer knobs (custom `GateParameters`, resin-pocket

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -51,7 +51,17 @@ Resin pocket
 ------------
 
 .. automodule:: wrinklefe.core.resin_pocket
-   :members: ResinPocketSpec, compute_resin_mask, compute_resin_blend
+   :members: ResinPocketSpec, compute_resin_mask, compute_resin_blend,
+             SurfacePocketSpec, compute_surface_resin_blend,
+             element_heights, element_height_ratio
+   :show-inheritance:
+
+Compaction and fibre-volume-fraction gradient
+---------------------------------------------
+
+.. automodule:: wrinklefe.core.compaction
+   :members: VfGradientSpec, compute_vf_field, build_vf_materials,
+             scale_material_to_vf, resolve_constituents
    :show-inheritance:
 
 Penetration gate

--- a/examples/10_vf_gradient_compaction.py
+++ b/examples/10_vf_gradient_compaction.py
@@ -1,0 +1,103 @@
+"""Compaction Vf gradient: two caul plates squeeze resin out of the crest.
+
+A wrinkle cured between rigid tooling does not keep a constant ply
+thickness. The resin is the mobile phase: it is squeezed out of the
+compacted regions and pools where the geometry opens up, so the local
+fibre volume fraction rises on the crest side and falls in the trough.
+``enable_vf_gradient`` models that directly — per element,
+
+    Vf_local = vf_nominal * h0 / h
+
+(fibre content conserved, the thickness change absorbing or expelling
+resin) — and gives each element a material obtained by scaling the preset
+card with the micromechanics ``Vf`` ratio. Poisson ratios and all
+strengths stay at the preset values: no mixing rule predicts a strength
+from ``Vf``.
+
+This script runs the same 24-ply UD tool-flat coupon three ways — plain
+wrinkle, the binary surface-resin-pocket tag, and the continuous Vf
+gradient — and prints the resulting modulus retention plus the Vf field
+statistics.
+
+Expected runtime: ~30 s (three FE solves).
+Expected output:  a three-row comparison table and the Vf-field summary.
+"""
+
+import numpy as np
+
+from wrinklefe.analysis import AnalysisConfig, WrinkleAnalysis
+from wrinklefe.core.compaction import VfGradientSpec, compute_vf_field
+from wrinklefe.core.material import MaterialLibrary
+
+MATERIAL = "IM7_8552"
+AMPLITUDE = 0.25          # mm; below the tool_flat inversion bound (0.293)
+
+
+def build(**overrides) -> AnalysisConfig:
+    """A 24-ply UD coupon wrinkled between two caul plates."""
+    config = AnalysisConfig(
+        morphology="tool_flat",
+        amplitude=AMPLITUDE, wavelength=16.0, width=12.0,
+        surface_pocket_side="both",       # two caul plates: top AND bottom
+        surface_transition_plies=2,
+        material=MaterialLibrary().get(MATERIAL),
+        angles=[0.0] * 24, ply_thickness=0.183,
+        domain_length=40.0, domain_width=4.0,
+        nx=40, ny=2, nz_per_ply=1,
+        analytical_only=False,
+        **overrides,
+    )
+    return config
+
+
+print("=" * 72)
+print("Compaction Vf gradient — 24-ply UD, tool_flat, two caul plates")
+print("=" * 72)
+
+# 1. Plain wrinkle: no trough treatment at all.
+plain = build()
+plain.enable_surface_resin_pockets = False       # tool_flat auto-enables them
+plain_result = WrinkleAnalysis(plain).run()
+
+# 2. The binary surface resin pocket (the pre-#379 model).
+binary_result = WrinkleAnalysis(build()).run()
+
+# 3. The continuous Vf / ply-thickness gradient.
+gradient_config = build(enable_vf_gradient=True)
+gradient_result = WrinkleAnalysis(gradient_config).run()
+
+rows = (
+    ("no trough treatment", plain_result),
+    ("binary surface pockets", binary_result),
+    ("compaction Vf gradient", gradient_result),
+)
+print(f"{'model':<26}{'modulus_retention_global':>26}")
+print("-" * 72)
+for label, result in rows:
+    print(f"{label:<26}{result.modulus_retention_global:>26.6f}")
+
+delta = (
+    gradient_result.modulus_retention_global
+    - binary_result.modulus_retention_global
+)
+print()
+print(f"gradient - binary pockets: {delta:+.6f} "
+      f"({100.0 * delta / binary_result.modulus_retention_global:+.3f} %)")
+
+# The Vf field itself, recomputed on the solved mesh.
+spec = VfGradientSpec.for_material(MATERIAL)
+vf = compute_vf_field(gradient_result.mesh, spec)
+changed = vf != spec.vf_nominal
+print()
+print(f"Vf field: nominal {spec.vf_nominal:.3f}, "
+      f"range {vf.min():.3f}-{vf.max():.3f}")
+print(f"  resin-rich (Vf < nominal): {int(np.count_nonzero(vf < spec.vf_nominal))} elements")
+print(f"  compacted  (Vf > nominal): {int(np.count_nonzero(vf > spec.vf_nominal))} elements")
+print(f"  saturated at vf_max={spec.vf_max:.2f}: "
+      f"{int(np.count_nonzero(vf >= spec.vf_max))} elements")
+print(f"  re-materialised: {len(gradient_result.mesh.resin_blend_materials)} "
+      f"of {gradient_result.mesh.n_elements} elements, sharing "
+      f"{len({id(m) for m in gradient_result.mesh.resin_blend_materials.values()})} "
+      f"material objects")
+print(f"  (changed from nominal before quantization: "
+      f"{int(np.count_nonzero(changed))} elements)")

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ so they cannot rot.
 | [`07_mesh_convergence.py`](07_mesh_convergence.py) | Mesh-convergence study (`mesh_convergence_study` / `wrinklefe converge`) | ~90 s |
 | [`08_multi_wrinkle_czm_linkup.py`](08_multi_wrinkle_czm_linkup.py) | Crest-to-crest delamination link-up between adjacent wrinkles (`wrinkles` + `enable_czm`) | ~5 s |
 | [`09_acceptance_limit.py`](09_acceptance_limit.py) | Maximum acceptable wrinkle amplitude for a target knockdown (`find_critical_value` / `wrinklefe critical`) | ~5 s |
+| [`10_vf_gradient_compaction.py`](10_vf_gradient_compaction.py) | Compaction Vf / ply-thickness gradient between two caul plates (`enable_vf_gradient`) vs the binary surface pockets | ~30 s |
 | [`transverse_wrinkle_knockdown.py`](transverse_wrinkle_knockdown.py) | Localized (through-width) vs uniform wrinkle knockdown (`transverse_mode`) | ~20 s |
 
 Run any of them from this directory with the package installed

--- a/src/wrinklefe/analysis.py
+++ b/src/wrinklefe/analysis.py
@@ -1340,6 +1340,46 @@ class AnalysisConfig:
     surface_transition_plies: int = 2
 
     # ------------------------------------------------------------------
+    # Compaction-driven fibre-volume-fraction gradient (issue #379).
+    # ------------------------------------------------------------------
+    # A wrinkle constrained by rigid tooling does not keep a constant ply
+    # thickness: resin is squeezed out of the compacted regions and pools
+    # where the geometry opens up.  When ``enable_vf_gradient`` is True the
+    # FE path derives a per-element local fibre volume fraction from the
+    # deformed element height (``Vf_local = vf_nominal * h0 / h``, fibre
+    # content conserved) and installs per-element materials obtained by
+    # scaling the preset card with the micromechanics ``Vf`` ratio
+    # (:mod:`~wrinklefe.core.compaction`): stiffnesses and CTEs move,
+    # Poisson ratios and ALL strengths stay at the preset values (the
+    # mixing rules do not predict strengths — documented limitation).
+    #
+    # Opt-in and FE-only.  v1 requires ``morphology="tool_flat"``, whose
+    # flat outer envelope makes the per-column thickness (and therefore the
+    # resin mass) conserved by construction; ``surface_pocket_side="both"``
+    # is the two-caul-plate case.  When enabled, the gradient SUPERSEDES the
+    # binary surface-pocket tagging (it is the continuous generalization of
+    # it — the resin-rich trough is the low-Vf end of the same field), while
+    # the machined crest resin lens (``enable_resin_pocket``) composes
+    # unchanged.
+    enable_vf_gradient: bool = False
+    # Fibre volume fraction the preset material card represents (the ratio
+    # anchor).  ``None`` resolves from
+    # :data:`~wrinklefe.core.compaction.CONSTITUENT_DEFAULTS` for the
+    # documented library systems; supply it for any other card.
+    vf_nominal: float | None = None
+    # Constituent presets used for the ``Vf`` ratio.  ``None`` resolves from
+    # ``CONSTITUENT_DEFAULTS``; explicit values always win.  ``vf_fiber`` is
+    # a :data:`~wrinklefe.core.micromechanics.FIBER_PRESETS` key,
+    # ``vf_matrix`` a ``MATRIX_PRESETS`` key or an isotropic material-library
+    # card name.
+    vf_fiber: str | None = None
+    vf_matrix: str | None = None
+    # Upper clamp on the local fibre volume fraction (default 0.75, just
+    # under square packing).  Elements compacted past it saturate, which is
+    # counted and warned once: the rule carries no lateral resin flow.
+    vf_max: float = 0.75
+
+    # ------------------------------------------------------------------
     # Progressive-damage FE path (load-stepping ply-discount to ultimate
     # load).  When ``enable_progressive_damage`` is True the FE solve runs
     # the :class:`~wrinklefe.solver.progressive_damage.ProgressiveDamageSolver`
@@ -1948,6 +1988,96 @@ class AnalysisConfig:
                     f"({self.transverse_mode!r}); the tool-flat decay is "
                     "verified for the x-only wrinkle only."
                 )
+
+        # --- Compaction Vf gradient (issue #379) ----------------------
+        if not isinstance(self.enable_vf_gradient, bool):
+            raise ValueError(
+                f"AnalysisConfig.enable_vf_gradient must be a bool, "
+                f"got {self.enable_vf_gradient!r}"
+            )
+        for name in ("vf_nominal",):
+            val = getattr(self, name)
+            if val is not None and not (
+                isinstance(val, (int, float))
+                and not isinstance(val, bool)
+                and math.isfinite(val)
+                and 0.0 < val < 1.0
+            ):
+                raise ValueError(
+                    f"AnalysisConfig.{name} must be a float in (0, 1) or "
+                    f"None, got {val!r}"
+                )
+        if not (
+            isinstance(self.vf_max, (int, float))
+            and not isinstance(self.vf_max, bool)
+            and math.isfinite(self.vf_max)
+            and 0.0 < self.vf_max <= 0.9
+        ):
+            raise ValueError(
+                f"AnalysisConfig.vf_max must be a float in (0, 0.9], got "
+                f"{self.vf_max!r}"
+            )
+        for name in ("vf_fiber", "vf_matrix"):
+            val = getattr(self, name)
+            if val is not None and not isinstance(val, str):
+                raise ValueError(
+                    f"AnalysisConfig.{name} must be a preset name (str) or "
+                    f"None, got {val!r}"
+                )
+        if self.enable_vf_gradient:
+            # FE-only: the gradient is a per-element material field, so an
+            # analytical-only run would silently drop it (same rule as the
+            # resin-pocket / surface-pocket features).
+            if self.analytical_only:
+                raise ValueError(
+                    "AnalysisConfig: enable_vf_gradient requires the FE "
+                    "path (it installs per-element materials in the mesh); "
+                    "it has no effect under analytical_only=True. Set "
+                    "analytical_only=False or disable the Vf gradient."
+                )
+            # v1 restriction: only the tool_flat morphology has a flat outer
+            # envelope, which is what makes the per-column thickness — and
+            # therefore the resin mass — conserved under the kinematic rule.
+            # Every other morphology leaves an undulating outer surface, so
+            # the compaction would create or destroy material.
+            if morph != "tool_flat":
+                raise ValueError(
+                    "AnalysisConfig: enable_vf_gradient is restricted to "
+                    f"morphology='tool_flat' in v1, got {self.morphology!r}. "
+                    "Only a tool-flat outer envelope conserves the "
+                    "per-column thickness (and hence the resin mass) under "
+                    "the compaction rule Vf = vf_nominal * h0/h; an "
+                    "undulating outer surface would create or destroy "
+                    "material. Use morphology='tool_flat' (with "
+                    "surface_pocket_side='both' for the two-caul-plate "
+                    "case) or disable the Vf gradient."
+                )
+            if self.enable_czm:
+                raise NotImplementedError(
+                    "AnalysisConfig: enable_vf_gradient is not yet "
+                    "combinable with enable_czm (the per-element Vf "
+                    "materials and cohesive elements are unverified "
+                    "together)."
+                )
+            # Constituents must resolve now, not deep in the mesh path.
+            from wrinklefe.core.compaction import VfGradientSpec
+
+            material_name = (
+                self.material.name if self.material is not None else ""
+            )
+            try:
+                VfGradientSpec.for_material(
+                    material_name,
+                    fiber=self.vf_fiber,
+                    matrix=self.vf_matrix,
+                    vf_nominal=self.vf_nominal,
+                    vf_max=self.vf_max,
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"AnalysisConfig: enable_vf_gradient cannot resolve the "
+                    f"micromechanics anchor: {exc}"
+                ) from exc
 
         # --- Progressive-damage path ----------------------------------
         if not isinstance(self.enable_progressive_damage, bool):
@@ -2989,9 +3119,26 @@ class WrinkleAnalysis:
 
         # 4a3. Surface resin pockets under a tool-flat surface (issue #361).
         # Runs after the crest lens so the two compose (per-element max)
-        # rather than overwrite.
-        if cfg.enable_surface_resin_pockets:
+        # rather than overwrite.  The compaction Vf gradient (#379) is the
+        # continuous generalization of this binary tag — the resin-rich
+        # trough is simply the low-Vf end of the same field — so when the
+        # gradient is on the binary tagging is skipped rather than applied
+        # on top of it (which would soften the trough twice).
+        if cfg.enable_surface_resin_pockets and not cfg.enable_vf_gradient:
             self._attach_surface_resin_pockets(mesh, laminate, wrinkle_config)
+        elif cfg.enable_surface_resin_pockets:
+            logger.info(
+                "Surface resin pockets superseded by the compaction Vf "
+                "gradient (issue #379): the binary trough tag is the "
+                "resin-rich extreme of the continuous Vf field, so it is "
+                "not applied on top of it."
+            )
+
+        # 4a4. Compaction-driven Vf / ply-thickness gradient (issue #379).
+        # Runs after the crest lens so the lens blend composes on top of the
+        # locally-compacted host material.
+        if cfg.enable_vf_gradient:
+            self._attach_vf_gradient(mesh, laminate)
 
         results.mesh = mesh
 
@@ -4584,6 +4731,98 @@ class WrinkleAnalysis:
                 "(max gap %.3g mm)",
                 cfg.surface_pocket_side, n_surface, mesh.n_elements, max_gap,
             )
+
+    def _attach_vf_gradient(
+        self, mesh: MeshData, laminate: Laminate
+    ) -> None:
+        """Install the compaction-driven local-``Vf`` materials (issue #379).
+
+        Derives the per-element fibre volume fraction from the deformed
+        element heights (``Vf_local = vf_nominal * h0 / h``; see
+        :mod:`~wrinklefe.core.compaction`) and attaches one ratio-anchored
+        material per occupied ``Vf`` bin.
+
+        Channel
+        -------
+        The materials go on ``mesh.resin_blend_materials``, **not**
+        ``mesh.element_material_override``.  The override dict is owned and
+        *mutated in place* by
+        :class:`~wrinklefe.solver.progressive_damage.ProgressiveDamageSolver`
+        as elements fail, so anything parked there would be overwritten by
+        the degraded cards (and the snapshot/restore in
+        :meth:`_run_progressive_path` restores the same mutated object).
+        ``resin_blend_materials`` sits one step lower in
+        :meth:`~wrinklefe.core.mesh.MeshData.element_material` precedence,
+        which is exactly right: damage still wins over compaction, and the
+        assembler / stress recovery / failure evaluator already consume this
+        channel with no solver change.
+
+        ``mesh.resin_blend`` (the fibre-angle suppression weight) is left
+        alone: a compacted or resin-enriched element still has fibres, and
+        they still carry the wrinkle misalignment.  Where the crest resin
+        lens has already blended an element, the blend is re-applied on top
+        of the local-``Vf`` host so the two compose without double-counting.
+        """
+        from wrinklefe.core.compaction import (
+            VfGradientSpec,
+            build_vf_materials,
+            compute_vf_field,
+        )
+
+        cfg = self.config
+        assert cfg.material is not None
+        spec = VfGradientSpec.for_material(
+            cfg.material.name,
+            fiber=cfg.vf_fiber,
+            matrix=cfg.vf_matrix,
+            vf_nominal=cfg.vf_nominal,
+            vf_max=cfg.vf_max,
+        )
+        vf_field = compute_vf_field(mesh, spec)
+
+        # One call per distinct ply material so a mixed-material laminate is
+        # scaled against the right preset card.
+        ply_ids = np.asarray(mesh.ply_ids)
+        vf_materials: dict[int, OrthotropicMaterial] = {}
+        by_material: dict[int, tuple[OrthotropicMaterial, list[int]]] = {}
+        for elem in range(int(mesh.n_elements)):
+            ply_material = laminate.plies[int(ply_ids[elem])].material
+            entry = by_material.setdefault(id(ply_material), (ply_material, []))
+            entry[1].append(elem)
+        for ply_material, elems in by_material.values():
+            vf_materials.update(
+                build_vf_materials(
+                    ply_material, vf_field, spec,
+                    element_ids=np.asarray(elems, dtype=np.int64),
+                )
+            )
+
+        # Compose with an already-attached crest resin lens: rebuild its
+        # blend from the local-Vf host rather than discarding either.
+        blend_weight = mesh.resin_blend
+        existing = dict(mesh.resin_blend_materials or {})
+        if blend_weight is not None and vf_materials:
+            resin_material = cfg.resin_pocket_material
+            if resin_material is None:
+                resin_material = MaterialLibrary().get("EPOXY_S6C10")
+            for elem, material in vf_materials.items():
+                w = float(blend_weight[elem])
+                existing[elem] = (
+                    material.blend(resin_material, w) if w > 0.0 else material
+                )
+        else:
+            existing.update(vf_materials)
+        mesh.resin_blend_materials = existing
+
+        n_sat = int(np.count_nonzero(vf_field >= spec.vf_max))
+        logger.info(
+            "Vf gradient (issue #379): %d/%d elements re-materialised "
+            "(Vf %.3f-%.3f about nominal %.3f, %d shared materials, "
+            "%d saturated at vf_max=%.3f).",
+            len(vf_materials), mesh.n_elements,
+            float(vf_field.min()), float(vf_field.max()), spec.vf_nominal,
+            len({id(m) for m in vf_materials.values()}), n_sat, spec.vf_max,
+        )
 
     def _evaluate_failure(
         self,

--- a/src/wrinklefe/cli.py
+++ b/src/wrinklefe/cli.py
@@ -453,6 +453,48 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_analyze.add_argument(
+        "--vf-gradient", action="store_true", default=False,
+        dest="vf_gradient",
+        help=(
+            "Enable the compaction-driven fibre-volume-fraction / "
+            "ply-thickness gradient (FE-only, issue #379). Derives a local "
+            "Vf per element from the deformed element height "
+            "(Vf = vf_nominal * h0/h, fibre content conserved) and scales "
+            "the ply stiffnesses and CTEs by the micromechanics Vf ratio; "
+            "Poisson ratios and all strengths stay at the preset values. "
+            "Requires --morphology tool-flat (use --surface-pocket-side "
+            "both for the two-caul-plate case); supersedes the binary "
+            "surface resin pockets. Forces the FE path."
+        ),
+    )
+    p_analyze.add_argument(
+        "--vf-nominal", type=float, default=None, dest="vf_nominal",
+        help=(
+            "Fibre volume fraction the material card represents — the "
+            "anchor of the Vf ratio. Omit to use the documented value for "
+            "the library system (e.g. 0.60 for IM7/8552, 0.66 for "
+            "IM6G/3501-6). Required for a material card with no documented "
+            "Vf. Only consulted with --vf-gradient."
+        ),
+    )
+    p_analyze.add_argument(
+        "--vf-fiber", type=str, default=None, dest="vf_fiber",
+        help=(
+            "Fibre constituent preset for the Vf ratio (e.g. IM7, AS4, "
+            "T800S, S2_GLASS). Omit to use the documented constituent for "
+            "the library system. Only consulted with --vf-gradient."
+        ),
+    )
+    p_analyze.add_argument(
+        "--vf-matrix", type=str, default=None, dest="vf_matrix",
+        help=(
+            "Matrix constituent preset for the Vf ratio (e.g. EPOXY_8552, "
+            "EPOXY_3501_6, or an isotropic material-library card such as "
+            "EPOXY_S6C10). Omit to use the documented constituent for the "
+            "library system. Only consulted with --vf-gradient."
+        ),
+    )
+    p_analyze.add_argument(
         "--progressive", action="store_true", default=False,
         dest="progressive",
         help=(
@@ -1297,6 +1339,11 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         overrides["surface_pocket_side"] = args.surface_pocket_side
     if given("surface_transition_plies"):
         overrides["surface_transition_plies"] = args.surface_transition_plies
+    if given("vf_gradient"):
+        overrides["enable_vf_gradient"] = True
+    for name in ("vf_nominal", "vf_fiber", "vf_matrix"):
+        if given(name):
+            overrides[name] = getattr(args, name)
     if given("progressive"):
         overrides["enable_progressive_damage"] = True
     if given("increments"):
@@ -1319,8 +1366,9 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
     # Resolve analytical-only vs. full FE intent.
     #
     # Precedence (highest first):
-    #   1. --enable-czm, --resin-pocket, --surface-resin-pockets, or
-    #      --progressive (or a config with any of them on) -> force FE.
+    #   1. --enable-czm, --resin-pocket, --surface-resin-pockets,
+    #      --vf-gradient or --progressive (or a config with any of them on)
+    #      -> force FE.
     #      These are FE-only features that would silently no-op under
     #      analytical_only, so they take precedence over --analytical-only
     #      / --no-fe just as CZM does (issue #346).
@@ -1339,11 +1387,13 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         overrides.get("enable_resin_pocket", False)
         or overrides.get("enable_surface_resin_pockets", False)
         or overrides.get("enable_progressive_damage", False)
+        or overrides.get("enable_vf_gradient", False)
         or (
             base is not None and (
                 base.enable_resin_pocket
                 or base.enable_surface_resin_pockets
                 or base.enable_progressive_damage
+                or base.enable_vf_gradient
             )
         )
     )

--- a/src/wrinklefe/core/compaction.py
+++ b/src/wrinklefe/core/compaction.py
@@ -1,0 +1,609 @@
+"""Compaction-driven ply-thickness / local fibre-volume-fraction gradient.
+
+A wrinkle cured against rigid tooling does not keep a constant ply
+thickness.  The resin is the mobile phase: it is squeezed **out** of the
+regions the tooling compacts and pools **into** the regions the geometry
+opens up.  The defect is therefore as much a through-thickness ``Vf`` /
+ply-thickness gradient as it is a fibre-angle field (issue #379).
+
+The kinematic rule
+------------------
+Fibre content is conserved per element while the thickness change
+absorbs or expels resin::
+
+    Vf_local = Vf_nominal * h0 / h
+
+where ``h`` is the tilt-invariant deformed element height and ``h0`` the
+nominal one, both from
+:func:`~wrinklefe.core.resin_pocket.element_heights` — the *same* metric
+the surface resin pockets use, so the two features cannot drift apart.
+
+* **Stretched** element (``h > h0``; the trough under a flat tool):
+  ``Vf`` drops — the resin-rich end.  This is the continuous
+  generalization of the binary surface-pocket tag.
+* **Compacted** element (``h < h0``; the crest side): ``Vf`` rises — the
+  resin-starved, over-consolidated end that the binary tag never modelled.
+
+``Vf_local`` is clamped to ``[vf_min, vf_max]``.  The upper clamp matters:
+at the ``tool_flat`` element-inversion bound a crest-side transition
+element compresses to ``h / h0 ~ 0.2``, and the uncapped rule would return
+three times the nominal ``Vf`` — beyond any achievable packing.  The
+clamp stands in for the physics this model does **not** carry: lateral
+resin flow along the ply, which relieves the compaction long before
+hexagonal packing is reached.  Saturation is counted and logged once.
+
+Ratio anchoring (why the micromechanics is used as a *ratio*)
+-------------------------------------------------------------
+:mod:`wrinklefe.core.micromechanics` predicts ply constants from
+constituents, but its absolute accuracy against the shipped presets is
+only 12-33 % (worse for aramid ``G12``).  Feeding those absolute numbers
+into an analysis would replace a measured material card with a worse one.
+So the local material is the **preset scaled by the model's own ``Vf``
+sensitivity**::
+
+    P_local = P_preset * P_micro(Vf_local) / P_micro(Vf_nominal)
+
+for the stiffnesses (``E1``, ``E2``, ``E3``, ``G12``, ``G13``, ``G23``)
+and the CTEs (``alpha1``, ``alpha2``, ``alpha3``).  The model's absolute
+bias cancels in the ratio and only the trend survives.  At
+``Vf_local == Vf_nominal`` every ratio is exactly ``1.0``, so an element
+at nominal thickness keeps the preset card *bit for bit* — the zero-drift
+anchor this feature is built on.
+
+What is **not** scaled
+----------------------
+**Poisson's ratios and every strength allowable stay at the preset
+value.**  The mixing rules do not predict strengths at all (see the
+:mod:`~wrinklefe.core.micromechanics` module docs): longitudinal strength
+is set by fibre-strength statistics and misalignment, transverse and shear
+strengths by the matrix and the fibre-matrix interface.  Inventing a
+``Vf``-strength law here would be quietly wrong, so it is left out — a
+documented limitation of v1.  Local failure indices still move, because
+the local stiffness change redistributes the stress field.
+
+Quantization
+------------
+Materials are shared, not per element: ``Vf`` is quantized onto a grid of
+``n_bins`` values *anchored on* ``Vf_nominal`` (so the nominal value is
+always exactly on the grid) and one material is built per occupied bin.
+A 10 000-element mesh therefore carries a few dozen material objects
+rather than 10 000, which keeps both memory and the ``id()``-keyed
+stiffness caches in the assembler small.
+
+Examples
+--------
+>>> from wrinklefe.core.compaction import VfGradientSpec, scale_material_to_vf
+>>> from wrinklefe.core.material import MaterialLibrary
+>>> base = MaterialLibrary().get("IM7_8552")
+>>> spec = VfGradientSpec.for_material("IM7_8552")
+>>> spec.vf_nominal
+0.6
+>>> same = scale_material_to_vf(base, 0.60, spec)
+>>> same is base                      # exact identity at the nominal Vf
+True
+>>> compacted = scale_material_to_vf(base, 0.66, spec)
+>>> round(compacted.E1 / base.E1, 4)
+1.0972
+
+References
+----------
+- Issue #379 (this feature) and #371 (the tool-flat surface pockets whose
+  height metric is reused here).
+- Hubert, P. & Poursartip, A. (1998). "A review of flow and compaction
+  modelling relevant to thermoset matrix laminate processing",
+  J. Reinf. Plast. Compos. 17(4):286-318 — the consolidation/squeeze-flow
+  process this kinematic rule abstracts.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
+from wrinklefe.core.micromechanics import (
+    FIBER_PRESETS,
+    MATRIX_PRESETS,
+    FiberProperties,
+    MatrixProperties,
+    alpha1_schapery,
+    alpha2_schapery,
+    e1_rule_of_mixtures,
+    e2_halpin_tsai,
+    g12_halpin_tsai,
+    g23_transverse_isotropy,
+    nu23_rule_of_mixtures,
+)
+from wrinklefe.core.resin_pocket import element_height_ratio
+
+if TYPE_CHECKING:
+    from wrinklefe.core.mesh import MeshData
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CONSTITUENT_DEFAULTS",
+    "VfGradientSpec",
+    "compute_vf_field",
+    "build_vf_materials",
+    "scale_material_to_vf",
+    "resolve_constituents",
+]
+
+
+#: Material-preset name -> ``(fibre preset, matrix preset, documented Vf)``.
+#:
+#: Only the systems whose provenance comments in
+#: :class:`~wrinklefe.core.material.MaterialLibrary` state a fibre volume
+#: fraction are listed; the ``Vf`` is that documented value.  The matrix
+#: entry names a key of
+#: :data:`~wrinklefe.core.micromechanics.MATRIX_PRESETS` or an isotropic
+#: card in the material library (resolved via
+#: :meth:`~wrinklefe.core.micromechanics.MatrixProperties.from_material`).
+#:
+#: Substitutions are explicit rather than invented: ``T800S_M21`` has no
+#: M21 constituent card, so the toughened-epoxy ``EPOXY_8552`` stands in,
+#: and the generic ``S2_GLASS_EPOXY`` / ``KEVLAR49_EPOXY`` cards use the
+#: handbook ``EPOXY_3501_6`` resin.  Because the properties are used as a
+#: *ratio* about ``Vf_nominal``, a stand-in matrix shifts only the ``Vf``
+#: sensitivity, not the absolute card.  Supply ``vf_fiber`` / ``vf_matrix``
+#: explicitly to override any of this.
+CONSTITUENT_DEFAULTS: dict[str, tuple[str, str, float]] = {
+    "IM7_8552": ("IM7", "EPOXY_8552", 0.60),
+    "AC318_S6C10": ("S2_GLASS", "EPOXY_S6C10", 0.60),
+    "AC318_S6C10_vacbag": ("S2_GLASS", "EPOXY_S6C10", 0.60),
+    "T800S_M21": ("T800S", "EPOXY_8552", 0.59),
+    "IM10_8552": ("IM10", "EPOXY_8552", 0.60),
+    "IM6G_3501_6": ("IM6G", "EPOXY_3501_6", 0.66),
+    "S2_GLASS_EPOXY": ("S2_GLASS", "EPOXY_3501_6", 0.60),
+    "KEVLAR49_EPOXY": ("KEVLAR49", "EPOXY_3501_6", 0.60),
+}
+
+#: Below this magnitude a reference (nominal-``Vf``) micromechanics value
+#: is treated as "no usable ratio" and the preset property is carried over
+#: unscaled.  Guards the CTE ratios, where the nominal-``Vf`` prediction
+#: for a carbon/epoxy ``alpha1`` can pass through zero and turn a ratio
+#: into a meaningless amplification.
+_RATIO_GUARD = 1e-12
+
+
+def resolve_constituents(
+    fiber: str | FiberProperties,
+    matrix: str | MatrixProperties,
+) -> tuple[FiberProperties, MatrixProperties]:
+    """Resolve constituent names to property objects.
+
+    Parameters
+    ----------
+    fiber : str or FiberProperties
+        A key of :data:`~wrinklefe.core.micromechanics.FIBER_PRESETS`, or
+        a ready-made :class:`~wrinklefe.core.micromechanics.FiberProperties`.
+    matrix : str or MatrixProperties
+        A key of :data:`~wrinklefe.core.micromechanics.MATRIX_PRESETS`, the
+        name of an isotropic card in
+        :class:`~wrinklefe.core.material.MaterialLibrary` (converted with
+        :meth:`~wrinklefe.core.micromechanics.MatrixProperties.from_material`),
+        or a ready-made
+        :class:`~wrinklefe.core.micromechanics.MatrixProperties`.
+
+    Returns
+    -------
+    tuple of (FiberProperties, MatrixProperties)
+
+    Raises
+    ------
+    ValueError
+        If a name resolves to neither a constituent preset nor a library
+        card; the message lists the valid names.
+    """
+    if isinstance(fiber, str):
+        if fiber not in FIBER_PRESETS:
+            raise ValueError(
+                f"Unknown fibre preset {fiber!r}; available fibres are "
+                f"{sorted(FIBER_PRESETS)}. Pass a FiberProperties instance "
+                f"for a fibre that is not shipped."
+            )
+        fiber_props = FIBER_PRESETS[fiber]
+    else:
+        fiber_props = fiber
+
+    if isinstance(matrix, str):
+        if matrix in MATRIX_PRESETS:
+            matrix_props = MATRIX_PRESETS[matrix]
+        else:
+            library = MaterialLibrary()
+            try:
+                card = library.get(matrix)
+            except (KeyError, ValueError) as exc:
+                raise ValueError(
+                    f"Unknown matrix {matrix!r}; available matrix presets "
+                    f"are {sorted(MATRIX_PRESETS)} and isotropic material "
+                    f"cards {sorted(library.list_names())}. Pass a "
+                    f"MatrixProperties instance for a resin that is not "
+                    f"shipped."
+                ) from exc
+            matrix_props = MatrixProperties.from_material(card)
+    else:
+        matrix_props = matrix
+
+    return fiber_props, matrix_props
+
+
+@dataclass(frozen=True)
+class VfGradientSpec:
+    """Constituents and bounds for the compaction ``Vf`` gradient.
+
+    Parameters
+    ----------
+    fiber : str or FiberProperties
+        Fibre constituent; see :func:`resolve_constituents`.
+    matrix : str or MatrixProperties
+        Matrix constituent; see :func:`resolve_constituents`.
+    vf_nominal : float, optional
+        The fibre volume fraction the *preset* material card represents —
+        the anchor of the ratio.  Default 0.60.  Must satisfy
+        ``0 < vf_nominal < vf_max``.
+    vf_max : float, optional
+        Upper clamp on the local fibre volume fraction (default 0.75, just
+        under the 0.785 square-packing limit and short of the 0.907
+        hexagonal one).  Stands in for the lateral resin flow this model
+        does not carry.
+    vf_min : float, optional
+        Lower clamp (default 0.03), so a fully-stretched element
+        approaches neat resin without reaching the ``Vf = 0`` edge cases of
+        the ratio.
+    n_bins : int, optional
+        Number of quantization bins for the shared materials (default 64).
+        The grid is anchored on ``vf_nominal``.
+
+    Raises
+    ------
+    ValueError
+        If the bounds are not ordered / finite, or ``n_bins < 2``.
+    """
+
+    fiber: str | FiberProperties
+    matrix: str | MatrixProperties
+    vf_nominal: float = 0.60
+    vf_max: float = 0.75
+    vf_min: float = 0.03
+    n_bins: int = 64
+
+    def __post_init__(self) -> None:
+        for name in ("vf_nominal", "vf_max", "vf_min"):
+            val = getattr(self, name)
+            if not (isinstance(val, (int, float)) and np.isfinite(val)):
+                raise ValueError(
+                    f"VfGradientSpec.{name} must be a finite float, "
+                    f"got {val!r}"
+                )
+        if not (0.0 < self.vf_min < self.vf_nominal < self.vf_max <= 0.9):
+            raise ValueError(
+                "VfGradientSpec requires 0 < vf_min < vf_nominal < vf_max "
+                f"<= 0.9, got vf_min={self.vf_min}, "
+                f"vf_nominal={self.vf_nominal}, vf_max={self.vf_max}"
+            )
+        if not isinstance(self.n_bins, int) or isinstance(self.n_bins, bool):
+            raise ValueError(
+                f"VfGradientSpec.n_bins must be an int, got {self.n_bins!r}"
+            )
+        if self.n_bins < 2:
+            raise ValueError(
+                f"VfGradientSpec.n_bins must be >= 2, got {self.n_bins}"
+            )
+        # Fail at construction rather than deep in the material build.
+        resolve_constituents(self.fiber, self.matrix)
+
+    @classmethod
+    def for_material(
+        cls,
+        material_name: str,
+        *,
+        fiber: str | FiberProperties | None = None,
+        matrix: str | MatrixProperties | None = None,
+        vf_nominal: float | None = None,
+        vf_max: float = 0.75,
+        vf_min: float = 0.03,
+        n_bins: int = 64,
+    ) -> VfGradientSpec:
+        """Build a spec for a library material, filling gaps from defaults.
+
+        Explicit arguments always win; anything left ``None`` is taken from
+        :data:`CONSTITUENT_DEFAULTS`.
+
+        Parameters
+        ----------
+        material_name : str
+            Name of the ply material card the analysis uses.
+        fiber, matrix : str or constituent or None, optional
+            Explicit constituents; ``None`` resolves from the defaults map.
+        vf_nominal : float or None, optional
+            Explicit nominal ``Vf``; ``None`` resolves from the defaults map.
+        vf_max, vf_min, n_bins
+            Passed through to :class:`VfGradientSpec`.
+
+        Returns
+        -------
+        VfGradientSpec
+
+        Raises
+        ------
+        ValueError
+            If a needed value is neither supplied nor known for
+            *material_name*; the message names the missing knobs.
+        """
+        default = CONSTITUENT_DEFAULTS.get(material_name)
+        if default is None and (
+            fiber is None or matrix is None or vf_nominal is None
+        ):
+            raise ValueError(
+                f"No documented fibre/matrix/Vf for material "
+                f"{material_name!r}; the fibre-volume-fraction gradient "
+                f"cannot infer its anchor. Supply vf_fiber, vf_matrix and "
+                f"vf_nominal explicitly, or use one of "
+                f"{sorted(CONSTITUENT_DEFAULTS)}."
+            )
+        d_fiber, d_matrix, d_vf = (
+            default if default is not None else ("", "", 0.0)
+        )
+        return cls(
+            fiber=fiber if fiber is not None else d_fiber,
+            matrix=matrix if matrix is not None else d_matrix,
+            vf_nominal=vf_nominal if vf_nominal is not None else d_vf,
+            vf_max=vf_max,
+            vf_min=vf_min,
+            n_bins=n_bins,
+        )
+
+    @property
+    def constituents(self) -> tuple[FiberProperties, MatrixProperties]:
+        """The resolved ``(fibre, matrix)`` property objects."""
+        return resolve_constituents(self.fiber, self.matrix)
+
+
+# =======================================================================
+# The Vf field
+# =======================================================================
+
+
+def compute_vf_field(mesh: MeshData, spec: VfGradientSpec) -> np.ndarray:
+    """Per-element local fibre volume fraction from the compaction.
+
+    Applies ``Vf_local = Vf_nominal * h0 / h`` (fibre content conserved,
+    thickness change absorbing or expelling resin) and clamps the result to
+    ``[vf_min, vf_max]``.  Elements whose deformed height is non-positive
+    (an inverted element, which the ``tool_flat`` amplitude bound already
+    rejects) are treated as fully compacted, i.e. ``vf_max``.
+
+    When any element saturates, **one** warning is logged naming the count
+    and the un-modelled physics (lateral resin flow along the ply).
+
+    Parameters
+    ----------
+    mesh : MeshData
+        Generated (deformed) hex8 mesh.
+    spec : VfGradientSpec
+        Constituents, nominal ``Vf`` and the clamps.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n_elements,)`` float array of local fibre volume
+        fractions.  Exactly ``spec.vf_nominal`` where the element keeps its
+        nominal height.
+    """
+    ratio = element_height_ratio(mesh)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        vf = np.where(ratio > 0.0, spec.vf_nominal / ratio, spec.vf_max)
+    vf = np.asarray(vf, dtype=np.float64)
+
+    n_high = int(np.count_nonzero(vf > spec.vf_max))
+    n_low = int(np.count_nonzero(vf < spec.vf_min))
+    vf = np.clip(vf, spec.vf_min, spec.vf_max)
+
+    if n_high or n_low:
+        logger.warning(
+            "Vf gradient saturated on %d/%d elements (%d at the vf_max=%.3f "
+            "compaction cap, %d at the vf_min=%.3f resin-rich floor). The "
+            "kinematic rule Vf = Vf_nominal * h0/h has no lateral resin "
+            "flow along the ply, so an extreme thickness change would "
+            "otherwise return an unachievable packing fraction; the clamp "
+            "stands in for that missing physics.",
+            n_high + n_low, vf.size, n_high, spec.vf_max, n_low, spec.vf_min,
+        )
+    return vf
+
+
+# =======================================================================
+# Ratio-anchored local materials
+# =======================================================================
+
+
+def _micro_properties(
+    vf: float, fiber: FiberProperties, matrix: MatrixProperties
+) -> dict[str, float]:
+    """Micromechanics predictions used as ratio numerators/denominators."""
+    E2 = e2_halpin_tsai(vf, fiber, matrix)
+    nu23 = nu23_rule_of_mixtures(vf, fiber, matrix)
+    return {
+        "E1": e1_rule_of_mixtures(vf, fiber, matrix),
+        "E2": E2,
+        "G12": g12_halpin_tsai(vf, fiber, matrix),
+        "G23": g23_transverse_isotropy(E2, nu23),
+        "alpha1": alpha1_schapery(vf, fiber, matrix),
+        "alpha2": alpha2_schapery(vf, fiber, matrix),
+    }
+
+
+def _ratio(local: float, reference: float) -> float:
+    """``local / reference``, or ``1.0`` when the reference is unusable."""
+    if abs(reference) <= _RATIO_GUARD or not np.isfinite(local):
+        return 1.0
+    value = local / reference
+    if not np.isfinite(value):
+        return 1.0
+    return float(value)
+
+
+def scale_material_to_vf(
+    base: OrthotropicMaterial, vf: float, spec: VfGradientSpec
+) -> OrthotropicMaterial:
+    """Ratio-anchor a preset ply card to a local fibre volume fraction.
+
+    Returns ``P_preset * P_micro(vf) / P_micro(vf_nominal)`` for the
+    stiffnesses and CTEs, with Poisson's ratios and **all** strengths left
+    at their preset values (the mixing rules do not predict them — see the
+    module docstring).  At ``vf == spec.vf_nominal`` the *same object* is
+    returned, so a nominal-thickness element is bit-identical to the
+    unscaled analysis.
+
+    If the scaled card fails :meth:`OrthotropicMaterial.validate` (its
+    compliance matrix must stay positive-definite — the Poisson ratios are
+    held fixed while the moduli move, so an extreme ratio can in principle
+    break the stability bounds), the local ``Vf`` is walked back halfway
+    toward the nominal value until it validates, and a warning names the
+    clamp.
+
+    Parameters
+    ----------
+    base : OrthotropicMaterial
+        The measured preset card, valid at ``spec.vf_nominal``.
+    vf : float
+        The local fibre volume fraction.
+    spec : VfGradientSpec
+        Constituents and the nominal anchor.
+
+    Returns
+    -------
+    OrthotropicMaterial
+        The scaled card (or *base* itself at the nominal ``Vf``).
+    """
+    if vf == spec.vf_nominal:
+        return base
+
+    fiber, matrix = spec.constituents
+    ref = _micro_properties(spec.vf_nominal, fiber, matrix)
+
+    vf_try = float(vf)
+    for _attempt in range(24):
+        loc = _micro_properties(vf_try, fiber, matrix)
+        r_E1 = _ratio(loc["E1"], ref["E1"])
+        r_E2 = _ratio(loc["E2"], ref["E2"])
+        r_G12 = _ratio(loc["G12"], ref["G12"])
+        r_G23 = _ratio(loc["G23"], ref["G23"])
+        r_a1 = _ratio(loc["alpha1"], ref["alpha1"])
+        r_a2 = _ratio(loc["alpha2"], ref["alpha2"])
+        try:
+            return replace(
+                base,
+                E1=base.E1 * r_E1,
+                E2=base.E2 * r_E2,
+                E3=base.E3 * r_E2,
+                G12=base.G12 * r_G12,
+                G13=base.G13 * r_G12,
+                G23=base.G23 * r_G23,
+                alpha1=base.alpha1 * r_a1,
+                alpha2=base.alpha2 * r_a2,
+                alpha3=base.alpha3 * r_a2,
+                name=f"{base.name}_Vf{vf_try:.4f}",
+            )
+        except ValueError:
+            vf_try = 0.5 * (vf_try + spec.vf_nominal)
+            logger.warning(
+                "Ratio-anchored ply at Vf=%.4f is not positive-definite "
+                "(Poisson ratios are held at the preset values while the "
+                "moduli scale); retrying at Vf=%.4f, halfway back to the "
+                "nominal %.4f.",
+                vf, vf_try, spec.vf_nominal,
+            )
+    logger.warning(
+        "Could not build a positive-definite ply for Vf=%.4f; keeping the "
+        "preset card %r unscaled for those elements.", vf, base.name,
+    )
+    return base
+
+
+def _quantize(vf: np.ndarray, spec: VfGradientSpec) -> np.ndarray:
+    """Snap ``Vf`` onto an ``n_bins`` grid anchored on ``vf_nominal``.
+
+    The grid *contains* ``vf_nominal`` exactly, so an element at nominal
+    thickness quantizes to the nominal value and its material stays the
+    untouched preset (the zero-drift anchor).
+    """
+    step = (spec.vf_max - spec.vf_min) / (spec.n_bins - 1)
+    snapped = spec.vf_nominal + np.round(
+        (vf - spec.vf_nominal) / step
+    ) * step
+    return np.clip(snapped, spec.vf_min, spec.vf_max)
+
+
+def build_vf_materials(
+    base_material: OrthotropicMaterial,
+    vf_field: np.ndarray,
+    spec: VfGradientSpec,
+    *,
+    element_ids: np.ndarray | None = None,
+) -> dict[int, OrthotropicMaterial]:
+    """Per-element ratio-anchored materials, sharing one card per ``Vf`` bin.
+
+    ``Vf`` is quantized onto ``spec.n_bins`` values (grid anchored on
+    ``vf_nominal``) and one :class:`OrthotropicMaterial` is built per
+    occupied bin, then shared by every element in that bin — so a large
+    mesh carries a few dozen material objects, not one per element, and the
+    ``id()``-keyed element-stiffness caches stay small.
+
+    Elements that quantize to ``vf_nominal`` are **omitted** from the
+    mapping: their material is unchanged, and leaving them out keeps the
+    downstream resolution (and therefore the numbers) identical to a run
+    with the feature off.
+
+    Parameters
+    ----------
+    base_material : OrthotropicMaterial
+        The preset ply card these elements would otherwise use.
+    vf_field : np.ndarray
+        Per-element local ``Vf`` from :func:`compute_vf_field`.
+    spec : VfGradientSpec
+        Constituents, nominal anchor and bin count.
+    element_ids : np.ndarray or None, optional
+        Restrict the mapping to these element indices (used when a laminate
+        mixes materials, so each ply material is scaled on its own
+        elements).  ``None`` (default) covers every element in *vf_field*.
+
+    Returns
+    -------
+    dict of int -> OrthotropicMaterial
+        Element index to its local material, for the elements whose ``Vf``
+        differs from nominal.
+    """
+    vf = np.asarray(vf_field, dtype=np.float64)
+    ids = (
+        np.arange(vf.size, dtype=np.int64)
+        if element_ids is None
+        else np.asarray(element_ids, dtype=np.int64)
+    )
+    if ids.size == 0:
+        return {}
+
+    binned = _quantize(vf[ids], spec)
+    materials: dict[int, OrthotropicMaterial] = {}
+    cache: dict[float, OrthotropicMaterial] = {}
+    for value in np.unique(binned):
+        vf_bin = float(value)
+        if vf_bin == spec.vf_nominal:
+            continue
+        cache[vf_bin] = scale_material_to_vf(base_material, vf_bin, spec)
+    for elem, value in zip(ids.tolist(), binned.tolist(), strict=True):
+        material = cache.get(float(value))
+        if material is not None:
+            materials[int(elem)] = material
+    logger.debug(
+        "Vf gradient: %d elements mapped onto %d shared materials "
+        "(Vf %.3f-%.3f, nominal %.3f).",
+        len(materials), len(cache),
+        float(binned.min()), float(binned.max()), spec.vf_nominal,
+    )
+    return materials

--- a/src/wrinklefe/core/resin_pocket.py
+++ b/src/wrinklefe/core/resin_pocket.py
@@ -271,6 +271,89 @@ def compute_resin_blend(mesh: MeshData, spec: ResinPocketSpec) -> np.ndarray:
 
 
 # =======================================================================
+# Shared deformed-height metric
+# =======================================================================
+
+
+def element_heights(mesh: MeshData) -> tuple[np.ndarray, float, float]:
+    """Deformed element heights, the nominal height and laminate thickness.
+
+    The single source of truth for "how tall is this element compared with
+    the pristine laminate", shared by the surface-pocket tagging here and
+    by the compaction / fibre-volume-fraction gradient
+    (:mod:`wrinklefe.core.compaction`) so the two cannot drift apart.
+
+    The deformed height is the *vertical* (through-thickness) stretch: the
+    mean-z of the element's top face minus the mean-z of its bottom face.
+    This is tilt-invariant — unlike a ``z.max - z.min`` bounding box, a
+    rigidly translated/sheared element (an interior ply riding the wrinkle
+    at full amplitude) keeps its nominal height, so only genuine
+    through-thickness stretch registers (the issue #371 fix).  Bounding-box
+    height instead conflates the wrinkle's in-plane slope with the gap,
+    which for a realistically-localized wrinkle swamps the true stretch
+    and, for a one-sided tool-flat surface, tags the whole interior.
+
+    The nominal element height ``h0`` comes from the laminate when the mesh
+    carries one, so a wavy (non-tool-flat) outer surface does not inflate
+    the reference; it falls back to the deformed bounding box for bare
+    hand-built fixtures that carry no laminate.
+
+    Parameters
+    ----------
+    mesh : MeshData
+        Generated (deformed) hex8 mesh.
+
+    Returns
+    -------
+    height : np.ndarray
+        Shape ``(n_elements,)`` deformed element heights (mm).
+    h0 : float
+        Nominal (undeformed) element height (mm); ``0.0`` when ``nz == 0``.
+    nominal_thickness : float
+        Nominal laminate thickness (mm).
+    """
+    ez = mesh.nodes[mesh.elements][:, :, 2]
+    # hex8 node order: 0-3 bottom face (k), 4-7 top face (k+1).
+    height: np.ndarray = ez[:, 4:8].mean(axis=1) - ez[:, 0:4].mean(axis=1)
+
+    if mesh.laminate is not None:
+        zc = np.asarray(mesh.laminate.z_coords(), dtype=np.float64)
+        nominal_thickness = float(zc[-1] - zc[0])
+    else:
+        nominal_thickness = float(mesh.nodes[:, 2].max() - mesh.nodes[:, 2].min())
+    nz = int(mesh.nz)
+    # Structured mesh: every element has the same nominal height.
+    h0 = nominal_thickness / nz if nz > 0 else 0.0
+    return height, h0, nominal_thickness
+
+
+def element_height_ratio(mesh: MeshData) -> np.ndarray:
+    """Per-element deformed/nominal height ratio ``h / h0``.
+
+    ``1`` where the element keeps its nominal height, ``> 1`` where it is
+    stretched (the resin-rich trough under a flat tool) and ``< 1`` where
+    it is compacted (the crest side).  Returns an all-ones array when the
+    nominal height is degenerate (``h0 == 0``), so callers get the
+    "no change" answer rather than a divide-by-zero.
+
+    Parameters
+    ----------
+    mesh : MeshData
+        Generated (deformed) hex8 mesh.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n_elements,)`` float array of ``h / h0``.
+    """
+    height, h0, _ = element_heights(mesh)
+    if h0 <= 0.0:
+        return np.ones_like(height)
+    ratio: np.ndarray = height / h0
+    return ratio
+
+
+# =======================================================================
 # Surface resin pockets (tool-flat outer surface, trough-following)
 # =======================================================================
 
@@ -420,30 +503,7 @@ def compute_surface_resin_blend(
     ncol = int(mesh.nx) * int(mesh.ny)
     n_elem = int(mesh.n_elements)
 
-    # Per-element deformed height as the *vertical* (through-thickness)
-    # stretch: the mean-z of the top face minus the mean-z of the bottom
-    # face.  This is tilt-invariant — unlike a ``z.max - z.min`` bounding
-    # box, a rigidly translated/sheared element (an interior ply riding the
-    # wrinkle at full amplitude) keeps its nominal height, so only genuine
-    # through-thickness stretch (the resin gap) registers.  Bounding-box
-    # height instead conflates the wrinkle's in-plane slope with the gap,
-    # which for a realistically-localized wrinkle swamps the true stretch
-    # and, for a one-sided tool-flat surface, tags the whole interior.
-    ez = mesh.nodes[mesh.elements][:, :, 2]
-    # hex8 node order: 0-3 bottom face (k), 4-7 top face (k+1).
-    height = ez[:, 4:8].mean(axis=1) - ez[:, 0:4].mean(axis=1)
-
-    # Nominal (undeformed) element height.  Taken from the laminate when
-    # available so a wavy (non-tool-flat) outer surface does not inflate the
-    # reference; falls back to the deformed bounding box for the bare
-    # hand-built fixtures that carry no laminate.
-    if mesh.laminate is not None:
-        zc = np.asarray(mesh.laminate.z_coords(), dtype=np.float64)
-        nominal_thickness = float(zc[-1] - zc[0])
-    else:
-        nominal_thickness = float(mesh.nodes[:, 2].max() - mesh.nodes[:, 2].min())
-    # Structured mesh: every element has the same nominal height.
-    h0 = nominal_thickness / nz if nz > 0 else 0.0
+    height, h0, nominal_thickness = element_heights(mesh)
 
     n_plies = int(mesh.ply_ids.max()) + 1 if mesh.ply_ids.size else 1
     ply_thickness = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -749,6 +749,44 @@ def test_analyze_surface_resin_pockets_maps_side():
     assert cfg.analytical_only is False
 
 
+def test_analyze_vf_gradient_maps_and_forces_fe():
+    """--vf-gradient enables the FE-only Vf field and overrides --no-fe."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--no-fe", "--morphology", "tool-flat",
+            "--amplitude", "0.2", "--vf-gradient",
+        ])
+    cfg = captured["config"]
+    assert cfg.enable_vf_gradient is True
+    assert cfg.analytical_only is False
+    assert captured["analytical_only"] is False
+
+
+def test_analyze_vf_gradient_maps_constituent_overrides():
+    """--vf-nominal / --vf-fiber / --vf-matrix reach AnalysisConfig."""
+    captured, patcher = _stub_analysis_run()
+    with patcher:
+        cli_main([
+            "analyze", "--morphology", "tool-flat", "--amplitude", "0.2",
+            "--vf-gradient", "--vf-nominal", "0.58",
+            "--vf-fiber", "AS4", "--vf-matrix", "EPOXY_3501_6",
+        ])
+    cfg = captured["config"]
+    assert cfg.vf_nominal == 0.58
+    assert cfg.vf_fiber == "AS4"
+    assert cfg.vf_matrix == "EPOXY_3501_6"
+
+
+def test_analyze_vf_gradient_rejects_non_tool_flat():
+    """The v1 morphology restriction surfaces as a clean CLI error."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main([
+            "analyze", "--morphology", "stack", "--vf-gradient",
+        ])
+    assert exc_info.value.code == 2
+
+
 def test_analyze_progressive_maps_increments_and_forces_fe():
     captured, patcher = _stub_analysis_run()
     with patcher:

--- a/tests/test_compaction_vf_gradient.py
+++ b/tests/test_compaction_vf_gradient.py
@@ -1,0 +1,514 @@
+"""Compaction-driven Vf / ply-thickness gradient (issue #379, Part B).
+
+Covers the core physics of :mod:`wrinklefe.core.compaction` (fast,
+mesh-only) plus the ``analysis.py`` config surface, validation and FE
+wiring; the FE solves are marked ``integration``/``slow`` per issue #267.
+
+The properties pinned here are the ones the design rests on:
+
+* **Exactness at nominal** — an element that keeps its nominal height gets
+  ratios of exactly 1.0 and therefore the preset material *object* itself.
+  This is what makes the feature zero-drift when it is off and
+  bit-identical outside the compacted band when it is on.
+* **Fibre conservation** — ``sum(Vf_local * h)`` over a column equals
+  ``Vf_nominal * sum(h0)`` to machine precision for ``tool_flat`` (before
+  the ``vf_max`` clamp engages), which is the whole justification for the
+  kinematic rule.
+* **Direction** — stretched (trough) elements soften, compacted (crest)
+  elements stiffen.
+* **Saturation** — the clamp engages at a realistic amplitude and says so.
+* **Positive-definiteness** — every quantized bin material across an
+  amplitude sweep is a valid ``OrthotropicMaterial``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+from wrinklefe.analysis import AnalysisConfig
+from wrinklefe.core.compaction import (
+    CONSTITUENT_DEFAULTS,
+    VfGradientSpec,
+    build_vf_materials,
+    compute_vf_field,
+    resolve_constituents,
+    scale_material_to_vf,
+)
+from wrinklefe.core.laminate import Laminate
+from wrinklefe.core.material import MaterialLibrary, OrthotropicMaterial
+from wrinklefe.core.mesh import WrinkleMesh
+from wrinklefe.core.morphology import WrinkleConfiguration
+from wrinklefe.core.resin_pocket import element_height_ratio, element_heights
+from wrinklefe.core.wrinkle import GaussianSinusoidal
+
+PLY_T = 0.183
+N_PLIES = 24
+LX = 40.0
+LY = 4.0
+MATERIAL = "IM7_8552"
+
+
+def _build_tool_flat_mesh(
+    *,
+    amplitude: float = 0.25,
+    tool_side: str = "both",
+    transition_plies: int = 2,
+    nx: int = 40,
+    ny: int = 2,
+):
+    """A tool-flat wrinkled mesh: flat outer surface(s), undulating core."""
+    material = MaterialLibrary().get(MATERIAL)
+    laminate = Laminate.from_angles([0.0] * N_PLIES, material, PLY_T)
+    profile = GaussianSinusoidal(
+        amplitude=amplitude, wavelength=16.0, width=12.0, center=LX / 2.0
+    )
+    config = WrinkleConfiguration.from_morphology_name(
+        "tool_flat", profile,
+        interface1=N_PLIES // 2 - 1, interface2=N_PLIES // 2,
+        tool_side=tool_side, surface_transition_plies=transition_plies,
+    )
+    mesh = WrinkleMesh(
+        laminate=laminate, wrinkle_config=config,
+        Lx=LX, Ly=LY, nx=nx, ny=ny, nz_per_ply=1,
+    ).generate()
+    return mesh, laminate
+
+
+def _spec(**kwargs) -> VfGradientSpec:
+    return VfGradientSpec.for_material(MATERIAL, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — the shared height metric
+# ---------------------------------------------------------------------------
+
+
+def test_height_helper_is_the_surface_pocket_metric():
+    """``element_height_ratio`` is ``h / h0`` from the shared helper."""
+    mesh, _ = _build_tool_flat_mesh()
+    height, h0, thickness = element_heights(mesh)
+    assert h0 == pytest.approx(thickness / mesh.nz)
+    assert thickness == pytest.approx(N_PLIES * PLY_T)
+    np.testing.assert_allclose(element_height_ratio(mesh), height / h0)
+
+
+def test_tool_flat_column_heights_sum_to_the_nominal_thickness():
+    """The flat outer envelope keeps every column at nominal thickness."""
+    mesh, _ = _build_tool_flat_mesh()
+    height, h0, _ = element_heights(mesh)
+    columns = height.reshape(mesh.nz, mesh.nx * mesh.ny).sum(axis=0)
+    np.testing.assert_allclose(columns, mesh.nz * h0, rtol=0.0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — the Vf field
+# ---------------------------------------------------------------------------
+
+
+def test_vf_field_follows_the_kinematic_rule():
+    """``Vf_local == Vf_nominal * h0 / h`` wherever the clamps are inactive."""
+    mesh, _ = _build_tool_flat_mesh()
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    expected = spec.vf_nominal / element_height_ratio(mesh)
+    free = (expected > spec.vf_min) & (expected < spec.vf_max)
+    assert free.sum() > 0
+    np.testing.assert_allclose(vf[free], expected[free], rtol=1e-12)
+    assert vf.min() >= spec.vf_min and vf.max() <= spec.vf_max
+
+
+def test_vf_direction_stretched_soft_compacted_stiff():
+    """Stretched elements lose fibre, compacted elements gain it."""
+    mesh, _ = _build_tool_flat_mesh()
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    ratio = element_height_ratio(mesh)
+    stretched = ratio > 1.0 + 1e-9
+    compacted = ratio < 1.0 - 1e-9
+    assert stretched.sum() > 0 and compacted.sum() > 0
+    assert np.all(vf[stretched] < spec.vf_nominal)
+    assert np.all(vf[compacted] > spec.vf_nominal)
+    # Untouched elements sit on the nominal value (to floating point; the
+    # quantization in ``build_vf_materials`` snaps that dust back exactly).
+    nominal = ~(stretched | compacted)
+    np.testing.assert_allclose(vf[nominal], spec.vf_nominal, rtol=1e-12)
+
+
+def test_fibre_conservation_per_column():
+    """``sum(Vf_local * h) == Vf_nominal * sum(h0)`` per column, to 1e-9."""
+    # Amplitude chosen so no element reaches the vf_max cap: the tool_flat
+    # crest band compacts by ``A / surface_transition_plies`` per element,
+    # so the clamp engages above A ~ 0.073 mm here.
+    mesh, _ = _build_tool_flat_mesh(amplitude=0.05)
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    assert np.all(vf < spec.vf_max)      # no clamp: conservation is exact
+    height, h0, _ = element_heights(mesh)
+    nz, ncol = mesh.nz, mesh.nx * mesh.ny
+    fibre = (vf.reshape(nz, ncol) * height.reshape(nz, ncol)).sum(axis=0)
+    np.testing.assert_allclose(
+        fibre, spec.vf_nominal * nz * h0, rtol=1e-9, atol=0.0
+    )
+
+
+def test_conservation_holds_for_a_single_tool_side():
+    """The single-tool (one caul plate) case conserves fibre too."""
+    mesh, _ = _build_tool_flat_mesh(amplitude=0.05, tool_side="top")
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    assert np.all(vf < spec.vf_max)
+    height, h0, _ = element_heights(mesh)
+    nz, ncol = mesh.nz, mesh.nx * mesh.ny
+    fibre = (vf.reshape(nz, ncol) * height.reshape(nz, ncol)).sum(axis=0)
+    np.testing.assert_allclose(
+        fibre, spec.vf_nominal * nz * h0, rtol=1e-9, atol=0.0
+    )
+
+
+def test_saturation_is_clamped_and_warned(caplog):
+    """At a large amplitude the compaction cap engages and says so."""
+    mesh, _ = _build_tool_flat_mesh(amplitude=0.29)
+    spec = _spec()
+    with caplog.at_level(logging.WARNING, logger="wrinklefe.core.compaction"):
+        vf = compute_vf_field(mesh, spec)
+    n_saturated = int(np.count_nonzero(vf == spec.vf_max))
+    assert n_saturated > 0
+    assert vf.max() == spec.vf_max
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("saturated" in m and "lateral resin flow" in m
+               for m in messages)
+    assert any(str(n_saturated) in m for m in messages)
+
+
+def test_flat_mesh_leaves_vf_at_nominal():
+    """A wrinkle-free mesh has no compaction: Vf is nominal everywhere."""
+    mesh, _ = _build_tool_flat_mesh(amplitude=0.0)
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    np.testing.assert_allclose(vf, spec.vf_nominal, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — ratio-anchored materials
+# ---------------------------------------------------------------------------
+
+
+def test_nominal_vf_returns_the_preset_object():
+    """The zero-drift anchor: at nominal Vf the preset card is untouched."""
+    base = MaterialLibrary().get(MATERIAL)
+    spec = _spec()
+    assert scale_material_to_vf(base, spec.vf_nominal, spec) is base
+
+
+def test_ratio_anchoring_scales_stiffness_and_holds_strengths():
+    """Stiffnesses/CTEs move with Vf; Poisson ratios and strengths do not."""
+    base = MaterialLibrary().get(MATERIAL)
+    spec = _spec()
+    stiff = scale_material_to_vf(base, 0.70, spec)
+    soft = scale_material_to_vf(base, 0.45, spec)
+
+    for attr in ("E1", "E2", "E3", "G12", "G13", "G23"):
+        assert getattr(stiff, attr) > getattr(base, attr)
+        assert getattr(soft, attr) < getattr(base, attr)
+    # Documented limitation: no Vf-strength model, so strengths and the
+    # Poisson ratios are carried over verbatim.
+    for attr in ("Xt", "Xc", "Yt", "Yc", "Zt", "Zc", "S12", "S13", "S23",
+                 "nu12", "nu13", "nu23", "gamma_Y", "GIc", "GIIc"):
+        assert getattr(stiff, attr) == getattr(base, attr)
+        assert getattr(soft, attr) == getattr(base, attr)
+
+
+def test_ratio_equals_the_micromechanics_ratio():
+    """``P_local / P_preset`` is exactly ``P_micro(Vf) / P_micro(Vf_nom)``."""
+    from wrinklefe.core.micromechanics import (
+        e1_rule_of_mixtures,
+        e2_halpin_tsai,
+    )
+
+    base = MaterialLibrary().get(MATERIAL)
+    spec = _spec()
+    fiber, matrix = spec.constituents
+    local = scale_material_to_vf(base, 0.68, spec)
+    assert local.E1 / base.E1 == pytest.approx(
+        e1_rule_of_mixtures(0.68, fiber, matrix)
+        / e1_rule_of_mixtures(spec.vf_nominal, fiber, matrix),
+        rel=1e-12,
+    )
+    assert local.E2 / base.E2 == pytest.approx(
+        e2_halpin_tsai(0.68, fiber, matrix)
+        / e2_halpin_tsai(spec.vf_nominal, fiber, matrix),
+        rel=1e-12,
+    )
+
+
+@pytest.mark.parametrize("preset", sorted(CONSTITUENT_DEFAULTS))
+def test_every_documented_preset_stays_positive_definite(preset):
+    """Every bin material over the full Vf range is a valid ply card."""
+    base = MaterialLibrary().get(preset)
+    spec = VfGradientSpec.for_material(preset)
+    for vf in np.linspace(spec.vf_min, spec.vf_max, 40):
+        material = scale_material_to_vf(base, float(vf), spec)
+        material.validate()          # raises if not positive-definite
+        assert isinstance(material, OrthotropicMaterial)
+
+
+def test_materials_are_shared_across_elements():
+    """Quantization yields far fewer material objects than elements."""
+    mesh, _ = _build_tool_flat_mesh()
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    materials = build_vf_materials(MaterialLibrary().get(MATERIAL), vf, spec)
+    assert len(materials) > 0
+    distinct = {id(m) for m in materials.values()}
+    assert len(distinct) <= spec.n_bins
+    assert len(distinct) < len(materials)
+
+
+def test_nominal_elements_are_omitted_from_the_mapping():
+    """Elements at nominal Vf keep the ply material (no entry at all)."""
+    mesh, _ = _build_tool_flat_mesh()
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    materials = build_vf_materials(MaterialLibrary().get(MATERIAL), vf, spec)
+    at_nominal = np.flatnonzero(vf == spec.vf_nominal)
+    assert at_nominal.size > 0
+    assert not (set(at_nominal.tolist()) & set(materials))
+
+
+def test_element_ids_restricts_the_mapping():
+    """``element_ids`` scopes the build to one ply material's elements."""
+    mesh, _ = _build_tool_flat_mesh()
+    spec = _spec()
+    vf = compute_vf_field(mesh, spec)
+    subset = np.arange(0, mesh.n_elements, 2, dtype=np.int64)
+    materials = build_vf_materials(
+        MaterialLibrary().get(MATERIAL), vf, spec, element_ids=subset
+    )
+    assert set(materials) <= set(subset.tolist())
+
+
+# ---------------------------------------------------------------------------
+# Part 4 — spec resolution and errors
+# ---------------------------------------------------------------------------
+
+
+def test_constituent_defaults_all_resolve():
+    """Every entry of the defaults map names real presets/cards."""
+    for name, (fiber, matrix, vf) in CONSTITUENT_DEFAULTS.items():
+        resolve_constituents(fiber, matrix)
+        assert 0.0 < vf < 1.0
+        assert MaterialLibrary().get(name) is not None
+
+
+def test_unknown_material_names_the_missing_knobs():
+    """An undocumented card is an actionable error, not a guess."""
+    with pytest.raises(ValueError, match="vf_fiber"):
+        VfGradientSpec.for_material("NOT_A_MATERIAL")
+
+
+def test_explicit_constituents_override_the_defaults():
+    """Config values always win over the documented defaults."""
+    spec = VfGradientSpec.for_material(
+        MATERIAL, fiber="AS4", matrix="EPOXY_3501_6", vf_nominal=0.55
+    )
+    assert spec.fiber == "AS4" and spec.matrix == "EPOXY_3501_6"
+    assert spec.vf_nominal == 0.55
+
+
+def test_unknown_constituents_are_rejected():
+    with pytest.raises(ValueError, match="Unknown fibre preset"):
+        resolve_constituents("NOPE", "EPOXY_8552")
+    with pytest.raises(ValueError, match="Unknown matrix"):
+        resolve_constituents("IM7", "NOPE")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"vf_nominal": 0.8, "vf_max": 0.75},     # nominal above the cap
+        {"vf_min": 0.0},                          # non-positive floor
+        {"vf_max": 0.95},                         # beyond the packing limit
+        {"n_bins": 1},                            # degenerate grid
+    ],
+)
+def test_spec_bounds_are_validated(kwargs):
+    with pytest.raises(ValueError):
+        VfGradientSpec(fiber="IM7", matrix="EPOXY_8552", **kwargs)
+
+
+def test_library_isotropic_card_works_as_a_matrix():
+    """A material-library isotropic card resolves as the matrix."""
+    _, matrix = resolve_constituents("S2_GLASS", "EPOXY_S6C10")
+    assert matrix.Em == pytest.approx(3_500.0)
+
+
+# ---------------------------------------------------------------------------
+# Part 5 — AnalysisConfig surface
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**kwargs) -> AnalysisConfig:
+    base = dict(
+        morphology="tool_flat",
+        amplitude=0.25,
+        angles=[0.0] * N_PLIES,
+        ply_thickness=PLY_T,
+        surface_pocket_side="both",
+        domain_length=LX,
+        domain_width=LY,
+        nx=40, ny=2, nz_per_ply=1,
+        analytical_only=False,
+    )
+    base.update(kwargs)
+    return AnalysisConfig(**base)
+
+
+def test_disabled_by_default():
+    assert AnalysisConfig().enable_vf_gradient is False
+    assert AnalysisConfig().vf_nominal is None
+    assert AnalysisConfig().vf_max == 0.75
+
+
+def test_non_tool_flat_morphology_is_rejected():
+    """v1 restriction: only a flat outer envelope conserves resin mass."""
+    with pytest.raises(ValueError, match="restricted to morphology='tool_flat'"):
+        _cfg(morphology="stack", enable_vf_gradient=True)
+
+
+def test_analytical_only_is_rejected():
+    with pytest.raises(ValueError, match="requires the FE path"):
+        _cfg(enable_vf_gradient=True, analytical_only=True)
+
+
+def test_unresolvable_constituents_are_rejected():
+    with pytest.raises(ValueError, match="cannot resolve the micromechanics"):
+        _cfg(
+            enable_vf_gradient=True,
+            material=OrthotropicMaterial(name="unknown_card"),
+        )
+
+
+def test_explicit_constituents_accept_an_unknown_card():
+    cfg = _cfg(
+        enable_vf_gradient=True,
+        material=OrthotropicMaterial(name="unknown_card"),
+        vf_fiber="IM7", vf_matrix="EPOXY_8552", vf_nominal=0.58,
+    )
+    assert cfg.vf_nominal == 0.58
+
+
+def test_czm_combination_is_rejected():
+    with pytest.raises(NotImplementedError, match="enable_czm"):
+        _cfg(enable_vf_gradient=True, enable_czm=True, czm_interfaces=[1])
+
+
+def test_config_round_trip_carries_the_new_fields():
+    cfg = _cfg(enable_vf_gradient=True, vf_max=0.72, vf_nominal=0.61)
+    restored = AnalysisConfig.from_dict(cfg.to_dict())
+    assert restored.enable_vf_gradient is True
+    assert restored.vf_max == 0.72
+    assert restored.vf_nominal == 0.61
+    assert restored == cfg
+
+
+# ---------------------------------------------------------------------------
+# Part 6 — end-to-end FE wiring (integration; solves are slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_gradient_installs_shared_materials():
+    """The FE path attaches local-Vf materials on the blend channel."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    result = WrinkleAnalysis(_cfg(enable_vf_gradient=True)).run()
+    mesh = result.mesh
+    materials = mesh.resin_blend_materials
+    assert materials
+    # Shared, not one per element (memory + the id()-keyed caches).
+    assert len({id(m) for m in materials.values()}) < len(materials)
+    # The binary surface-pocket tag is superseded, not composed.
+    assert mesh.resin_blend is None
+    assert mesh.resin_mask is None
+    # The progressive-damage channel is left free.
+    assert mesh.element_material_override is None
+    base = MaterialLibrary().get(MATERIAL)
+    stiffer = [m for m in materials.values() if m.E1 > base.E1]
+    softer = [m for m in materials.values() if m.E1 < base.E1]
+    assert stiffer and softer
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_off_is_the_untouched_baseline():
+    """Off (the default) leaves the tool_flat result exactly as it was."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    a = WrinkleAnalysis(_cfg()).run()
+    b = WrinkleAnalysis(_cfg(enable_vf_gradient=False)).run()
+    assert a.modulus_retention_global == b.modulus_retention_global
+    # Off, the binary surface pockets still own the trough.
+    assert a.mesh.resin_blend is not None
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_two_caul_significance():
+    """Two-caul-plate case: the gradient measurably moves the retention.
+
+    MEASURED on this configuration (24-ply UD, tool_flat, side="both",
+    A = 0.25 mm): binary surface pockets give
+    ``modulus_retention_global = 0.94824`` and the Vf gradient
+    ``0.95468`` — the gradient is +0.0064 (+0.68 %) *stiffer*, because the
+    compacted crest band (Vf up to the 0.75 cap) stiffens more than the
+    resin-rich trough softens, and because the continuous field replaces a
+    binary neat-resin tag.  Against a wrinkle with no trough treatment at
+    all (0.96494) the gradient is 0.0103 *softer*, i.e. it lands between
+    the two, which is the physically expected ordering.
+
+    The floor below is deliberately loose (a third of the measured delta)
+    so mesh/solver noise cannot flake it while a regression that silently
+    disables the feature still fails.
+    """
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    binary = WrinkleAnalysis(_cfg()).run()
+    gradient = WrinkleAnalysis(_cfg(enable_vf_gradient=True)).run()
+
+    delta = (
+        gradient.modulus_retention_global - binary.modulus_retention_global
+    )
+    assert abs(delta) > 0.002, (
+        f"Vf gradient changed modulus_retention_global by only {delta:+.5f}; "
+        f"expected the measured ~+0.0064."
+    )
+    # Direction, as measured: the compacted band dominates.
+    assert delta > 0.0
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_fe_composes_with_the_crest_lens():
+    """The machined crest lens still blends, on top of the local-Vf host."""
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    result = WrinkleAnalysis(
+        _cfg(enable_vf_gradient=True, enable_resin_pocket=True)
+    ).run()
+    mesh = result.mesh
+    assert mesh.resin_blend is not None          # the lens weight survives
+    assert int((mesh.resin_blend > 0).sum()) > 0
+    assert mesh.resin_blend_materials
+    # Lens elements are blended toward the soft isotropic resin card.
+    resin = MaterialLibrary().get("EPOXY_S6C10")
+    lens = np.flatnonzero(mesh.resin_blend > 0.5)
+    assert lens.size > 0
+    for elem in lens[:20].tolist():
+        material = mesh.resin_blend_materials.get(elem)
+        if material is not None:
+            assert material.E1 < MaterialLibrary().get(MATERIAL).E1
+            assert material.E1 >= resin.E1 * 0.5

--- a/tests/test_compaction_vf_gradient.py
+++ b/tests/test_compaction_vf_gradient.py
@@ -460,15 +460,16 @@ def test_fe_off_is_the_untouched_baseline():
 def test_fe_two_caul_significance():
     """Two-caul-plate case: the gradient measurably moves the retention.
 
-    MEASURED on this configuration (24-ply UD, tool_flat, side="both",
-    A = 0.25 mm): binary surface pockets give
-    ``modulus_retention_global = 0.94824`` and the Vf gradient
-    ``0.95468`` — the gradient is +0.0064 (+0.68 %) *stiffer*, because the
-    compacted crest band (Vf up to the 0.75 cap) stiffens more than the
+    MEASURED on exactly this configuration (24-ply UD, tool_flat,
+    side="both", A = 0.25 mm, 40 x 4 mm domain): binary surface pockets
+    give ``modulus_retention_global = 0.937591`` and the Vf gradient
+    ``0.944565`` — the gradient is +0.006974 (+0.744 %) *stiffer*, because
+    the compacted crest band (Vf up to the 0.75 cap) stiffens more than the
     resin-rich trough softens, and because the continuous field replaces a
     binary neat-resin tag.  Against a wrinkle with no trough treatment at
-    all (0.96494) the gradient is 0.0103 *softer*, i.e. it lands between
-    the two, which is the physically expected ordering.
+    all (0.957389) the gradient is 0.012824 *softer*, i.e. it lands between
+    the two, which is the physically expected ordering.  64 of the 1920
+    elements saturate at the ``vf_max`` cap here.
 
     The floor below is deliberately loose (a third of the measured delta)
     so mesh/solver noise cannot flake it while a regression that silently
@@ -484,7 +485,7 @@ def test_fe_two_caul_significance():
     )
     assert abs(delta) > 0.002, (
         f"Vf gradient changed modulus_retention_global by only {delta:+.5f}; "
-        f"expected the measured ~+0.0064."
+        f"expected the measured ~+0.0070."
     )
     # Direction, as measured: the compacted band dominates.
     assert delta > 0.0


### PR DESCRIPTION
## Linked issue

Fixes #379

(Part A — the constituent micromechanics #379 named as its own blocker — merged as #389. This is Part B, the compaction kinematics that consume it, and it completes the issue.)

## Summary

A wrinkle constrained by rigid tooling does not keep a constant ply thickness. Resin is the mobile phase: it is squeezed **out** of the compacted regions and pools where the geometry opens up. The old model tagged the trough as neat resin at a constant ply thickness and left the crest side alone. This adds the continuous field the issue asks for.

**`wrinklefe.core.compaction`** — per element, fibre content is conserved while the thickness change absorbs or expels resin:

```
Vf_local = vf_nominal * h0 / h
```

`h` is the tilt-invariant deformed element height and `h0` the nominal one. That metric is **factored out of `resin_pocket.compute_surface_resin_blend`** into shared `element_heights` / `element_height_ratio` helpers and reused, rather than duplicated, so the surface pockets and the gradient cannot drift apart.

### The locked design

1. **Ratio anchoring.** The local card is the measured preset scaled by the micromechanics' own `Vf` sensitivity, `P_local = P_preset · P_micro(Vf_local) / P_micro(vf_nominal)`, for the stiffnesses (`E1`, `E2`, `E3`, `G12`, `G13`, `G23`) and the CTEs. Part A's 12–33 % absolute error cancels in the ratio; only the trend survives. At `Vf_local == vf_nominal` every ratio is exactly 1.0 and the **preset object itself** is returned — the zero-drift anchor, pinned by a test.
2. **Kinematic rule** as above, clamped to `[vf_min, vf_max]` (defaults 0.03 / 0.75). At the `tool_flat` inversion bound a crest element compresses to `h/h0 ≈ 0.2`, which uncapped would give ~3× nominal `Vf`. Saturation is counted and logged in one warning naming the un-modelled physics (lateral resin flow along the ply).
3. **v1 restricted to `morphology="tool_flat"`.** Only a flat outer envelope keeps the per-column thickness — and hence the resin mass — conserved; any other morphology leaves an undulating outer surface and the compaction would create or destroy material. Other morphologies raise an actionable `ValueError`. `surface_pocket_side="both"` **is** the two-caul-plate case, so both acceptance sub-cases (single tool, two caul plates) come free.
4. **Opt-in** (`enable_vf_gradient=False` by default): zero ledger drift, and every pinned `tool_flat` result is untouched when off.
5. **When on, the gradient supersedes the binary surface-pocket tag** (it is its continuous generalization — the resin-rich trough is the low-`Vf` end of the same field), so the trough is not softened twice. The machined crest resin **lens** composes unchanged: its blend is re-applied on top of the local-`Vf` host material.
6. **Quantized materials**: `Vf` is snapped onto an `n_bins` (default 64) grid *anchored on* `vf_nominal`, so a 1920-element mesh carries ~21 shared material objects, not 1920 — memory and the `id()`-keyed element-stiffness caches stay small.

### Documented limitation (deliberate)

**Poisson ratios and every strength allowable stay at the preset value.** No mixing rule in Part A maps `Vf` to a strength — longitudinal strength is set by fibre-strength statistics and misalignment, transverse/shear strengths by the matrix and the interface — so a `Vf`-strength law is not invented here. Local failure indices still move, because the local stiffness redistributes stress.

### Per-element material channel (collision analysis)

The local-`Vf` cards go on **`mesh.resin_blend_materials`**, not `mesh.element_material_override`. The override dict is owned and **mutated in place** by `ProgressiveDamageSolver` (`progressive_damage.py:184-186`) as elements fail, and `_run_progressive_path` snapshots/restores the same object — anything parked there would be silently overwritten by degraded cards. `resin_blend_materials` sits one step lower in `MeshData.element_material` precedence, which is the right order (damage beats compaction) and is already consumed by the assembler, stress recovery and the failure evaluator with **zero solver changes**. `mesh.resin_blend` (the fibre-angle suppression weight) is deliberately left alone: a compacted or resin-enriched element still has fibres carrying the wrinkle misalignment.

### Measured effect (not guessed)

24-ply UD, `tool_flat`, `surface_pocket_side="both"` (two caul plates), A = 0.25 mm, IM7/8552, 40 × 4 mm domain, `modulus_retention_global`:

| model | retention | vs binary pockets |
| --- | --- | --- |
| no trough treatment | 0.957389 | — |
| binary surface pockets (pre-#379) | 0.937591 | — |
| **compaction Vf gradient** | **0.944565** | **+0.006974 (+0.744 %)** |

The direction was measured first, then pinned: the gradient is *stiffer* than the binary pockets (the compacted crest band, `Vf` up to the 0.75 cap, stiffens more than the resin-rich trough softens, and a continuous field replaces a binary neat-resin tag) and *softer* than the untreated wrinkle by 0.012824 — it lands between the two, which is the physically expected ordering. **64 of 1920 elements** saturate at `vf_max = 0.75` at that amplitude. The integration test pins a deliberately loose `|Δ| > 0.002` floor so solver noise cannot flake it.

Conservation: per-column `Σ Vf_local·h` equals `vf_nominal·Σ h0` to **5e-16 relative** (test asserts 1e-9) for both the single-tool and two-caul cases at an amplitude below the clamp; the clamp is what breaks conservation (up to 4.6 % in a saturated column), which is exactly the modelling debt the warning names.

### Surface

`AnalysisConfig(enable_vf_gradient=True, vf_nominal=…, vf_fiber=…, vf_matrix=…, vf_max=…)` and `wrinklefe analyze --vf-gradient [--vf-nominal V --vf-fiber F --vf-matrix M]` (SUPPRESS precedence, so `--config` composes; joins the FE-forcing set so the flag cannot no-op under `--analytical-only`). Constituents resolve from `CONSTITUENT_DEFAULTS` for the eight library systems whose provenance comments document their `Vf`; config values always override, and an unknown card errors with the knobs to supply. **No Streamlit app exposure in this PR** — the feature is fully reachable from the config/CLI, and app surfacing is a later polish item.

Also: `examples/10_vf_gradient_compaction.py` (~30 s, minimal-install-safe — numpy only), README + sphinx autodoc, CHANGELOG under Added and Numerical results.

## Checklist

- [x] Tests added or updated for the change (42 in `tests/test_compaction_vf_gradient.py` + 3 CLI mapping tests; FE solves marked `integration`/`slow` per #267)
- [x] `pytest` green (`-m "not slow"` lane plus the full new-file run including the slow FE solves)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean
- [x] Docs/README updated (README feature bullet, tool_flat section, CLI flag table, `docs/api/core.rst`, `sphinx-build -W` green)
- [x] `CHANGELOG.md` `[Unreleased]` updated, with the measured shift under **Numerical results**
- [x] `python scripts/validate.py` — **all cases match the pinned baselines** (zero drift; the feature is off by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_