### PR TITLE
app: live progress for FE/CZM runs via progress_callback + manual result cache (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ version produced a given file.
 ## [Unreleased]
 
 ### Added
+- App — **live progress for FE/CZM runs** (issue #377 — Fixes #377). The
+  *Run analysis* status box now carries a real progress bar driven by the
+  engine's existing `WrinkleAnalysis.run(progress_callback=...)` hook, so a
+  long solve reports the phase it is in rather than sitting at a frozen
+  10 %: *Building laminate* (0 %) → *Computing analytical predictions*
+  (5 %) → *Assembling FE mesh* (10 %) → *Solving FE system* (25 %) →
+  *Evaluating failure criteria* (75 %) → *Computing retention factors*
+  (90 %) → *Analysis complete* (100 %), with the percentage in the bar text
+  and the current phase echoed in the status label. Users on a 30–90 s
+  Streamlit Cloud CZM run can now tell a slow solve from a hung one. The
+  callback is defensive by construction — fractions are clamped and any
+  widget error is swallowed and logged at debug — so a cosmetic update can
+  never abort a solve that is already minutes in. **Coarse during CZM and
+  progressive-damage solves:** `AnalysisResults`' CZM / progressive
+  sub-paths do not emit progress of their own, so those runs hold at
+  *Solving FE system* (25 %) for the whole Newton-Raphson / load-increment
+  loop before completing; finer emits inside those loops would be an engine
+  change and are left as a follow-up.
 - Physics — **compaction-driven ply-thickness / local fibre-volume-fraction
   gradient** (issue #379, Part B — Fixes #379, completing the issue; builds
   on the Part A micromechanics). New `wrinklefe.core.compaction` derives a
@@ -666,6 +684,21 @@ version produced a given file.
   access in `max_angle` / `fiber_angles_at_nodes`.
 
 ### Changed
+- App — **the analysis run is no longer wrapped in `@st.cache_data`**
+  (issue #377 — Fixes #377). That decorator was what blocked live progress
+  widgets (issue #242: Streamlit refuses element calls made inside a
+  cache-decorated function against a layout block created outside it). The
+  solve now runs uncached and the *result dict* is cached by hand in
+  `st.session_state`, keyed on exactly the same hashable `cfg_payload` the
+  decorator used to hash — so re-running an identical configuration is
+  still instant and returns the same object. Unlike `@st.cache_data`, the
+  manual cache is **bounded to the 4 most recently used payloads**: FE
+  results carry mesh, displacement, stress and failure-index arrays, and
+  keeping every distinct run of a browsing session was needless memory.
+  *Reset to defaults* clears the cache along with the displayed results.
+  `run_analysis_cached(cfg_payload, progress_callback=None)` remains the
+  entry point and returns an unchanged result-dict shape; the solve itself
+  now lives in an undecorated `_run_analysis`.
 - Solver — **the ILU→diagonal preconditioner fallback is now loud and
   narrow** (issue #265). When the iterative solver's ILU factorisation
   fails, `StaticSolver._solve_iterative` emits a `logging.WARNING`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ portable `AnalysisConfig` JSON — round-tripping with the CLI `--config` /
 `--save-config` flags — or **load** a saved case (JSON/YAML) back into the
 sidebar.
 
+A run reports live progress while it solves: the status box tracks the
+pipeline phase by phase (building the laminate → analytical predictions →
+assembling the FE mesh → solving → evaluating failure → retention
+factors), so a long FE or CZM solve is distinguishable from a hung one.
+Re-running an identical configuration is served from a small in-session
+result cache instead of re-solving; *Reset to defaults* clears it.
+
 A second sidebar button, **Find acceptable limit**, runs the inverse
 search on those same inputs — the browser form of
 [`wrinklefe critical`](#finding-the-maximum-acceptable-defect). Set a

--- a/app.py
+++ b/app.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import csv
 import io
 import json
+import logging
+import math
 import sys
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -59,6 +61,8 @@ from wrinklefe.viz.style import (  # noqa: E402
     MORPHOLOGY_COLORS,
     TENSION_MECHANISM_COLORS,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Page config
@@ -271,6 +275,14 @@ DEFAULTS: dict[str, object] = {
 }
 
 
+# Session-state key and size cap for the manual analysis-result cache that
+# replaced ``@st.cache_data`` on the run path (issue #377). Defined up here so
+# ``reset_inputs`` can clear the cache; the cache helpers themselves live next
+# to ``_run_analysis`` further down.
+_RUN_CACHE_KEY = "_run_cache"
+_RUN_CACHE_MAX = 4
+
+
 def reset_inputs() -> None:
     """Restore every sidebar input widget to its default value.
 
@@ -291,8 +303,12 @@ def reset_inputs() -> None:
     # Drop the results and the payload they were computed from so a Reset
     # returns the Analyze tab to its empty state instead of showing a stale
     # run against default inputs.
+    # ``_run_cache`` is the manual result cache the run handler consults
+    # instead of ``@st.cache_data`` (issue #377); a Reset drops it too so the
+    # next run genuinely re-solves rather than replaying a pre-Reset result.
     for run_key in (
         "results", "cfg_payload", "goalseek_result", "goalseek_payload",
+        _RUN_CACHE_KEY,
     ):
         st.session_state.pop(run_key, None)
     # st.session_state keys are ``str | int``; annotate so the reused loop
@@ -2072,13 +2088,77 @@ def _config_from_payload(cfg_payload: tuple) -> AnalysisConfig:
     )
 
 
-@st.cache_data(show_spinner=False)
-def run_analysis_cached(cfg_payload: tuple) -> dict:
-    """Cached analysis run. cfg_payload is a hashable tuple of config items."""
+# ---------------------------------------------------------------------------
+# Analysis run + manual result cache (issue #377)
+#
+# The solve used to sit behind ``@st.cache_data``. That made repeat-identical
+# runs instant but froze the progress bar: Streamlit refuses to record widget
+# calls made inside a cache-decorated function against a layout block created
+# outside it (issue #242), so the engine's ``progress_callback`` could not
+# drive ``st.progress`` and the bar sat at a hard-coded 10 % for the whole
+# solve — indistinguishable from a hung run on a 30-90 s CZM job.
+#
+# So the run is uncached now (``_run_analysis``) and the *result dict* is
+# cached by hand in ``st.session_state`` keyed on the hashable ``cfg_payload``
+# — the same key ``@st.cache_data`` hashed. FE result dicts carry mesh /
+# stress / failure-index arrays, so the cache is bounded to the
+# ``_RUN_CACHE_MAX`` most recently used payloads instead of growing for the
+# life of the session.
+# ---------------------------------------------------------------------------
+
+def _run_cache() -> MutableMapping[tuple, dict]:
+    """Return the session-scoped result cache, creating it on first use."""
+    cache = st.session_state.get(_RUN_CACHE_KEY)
+    if not isinstance(cache, dict):
+        cache = {}
+        st.session_state[_RUN_CACHE_KEY] = cache
+    return cache
+
+
+def _run_cache_get(cfg_payload: tuple) -> dict | None:
+    """Look up a previous run's result dict, refreshing its recency.
+
+    Returns ``None`` on a miss. A hit moves the entry to the most-recent end
+    so a payload the user keeps re-running is never the one evicted.
+    """
+    cache = _run_cache()
+    if cfg_payload not in cache:
+        return None
+    result = cache.pop(cfg_payload)
+    cache[cfg_payload] = result
+    return result
+
+
+def _run_cache_put(cfg_payload: tuple, result: dict) -> None:
+    """Store a result dict, evicting least-recently-used entries past the cap."""
+    cache = _run_cache()
+    cache.pop(cfg_payload, None)  # re-insert so the entry lands at the end
+    cache[cfg_payload] = result
+    while len(cache) > _RUN_CACHE_MAX:
+        # ``dict`` preserves insertion order, so the first key is the
+        # least-recently used one.
+        cache.pop(next(iter(cache)))
+
+
+def _run_analysis(
+    cfg_payload: tuple,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> dict:
+    """Run the analysis and package the results for the app (uncached).
+
+    ``cfg_payload`` is the hashable tuple of config items assembled by
+    :func:`_assemble_cfg_payload`. ``progress_callback`` is forwarded
+    verbatim to :meth:`WrinkleAnalysis.run`, which calls it as
+    ``callback(label, fraction)`` at every phase boundary.
+
+    Callers should go through :func:`run_analysis_cached`, which adds the
+    session-scoped result cache.
+    """
     cfg_dict = dict(cfg_payload)
     cfg = _config_from_payload(cfg_payload)
     result = WrinkleAnalysis(cfg).run(
         analytical_only=cfg_dict["analytical_only"],
+        progress_callback=progress_callback,
     )
 
     fe: dict | None = None
@@ -2254,6 +2334,28 @@ def run_analysis_cached(cfg_payload: tuple) -> dict:
             else None
         ),
     }
+
+
+def run_analysis_cached(
+    cfg_payload: tuple,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> dict:
+    """Run the analysis, reusing the result of an identical earlier run.
+
+    Thin wrapper over :func:`_run_analysis`: a session-scoped, bounded
+    lookup on ``cfg_payload`` (see :data:`_RUN_CACHE_MAX`) returns a
+    previous run's result dict instantly, and a miss solves — forwarding
+    ``progress_callback`` so the caller can drive live progress widgets
+    (issue #377). The returned dict has exactly the shape
+    :func:`_run_analysis` builds; a cache hit hands back the *same* object,
+    so callers must not mutate it.
+    """
+    cached = _run_cache_get(cfg_payload)
+    if cached is not None:
+        return cached
+    result = _run_analysis(cfg_payload, progress_callback=progress_callback)
+    _run_cache_put(cfg_payload, result)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -2819,15 +2921,52 @@ if run_clicked or _demo_pending:
                 "Use the **Stop** button in the top-right toolbar to "
                 "cancel a long FE solve."
             )
-        # A streamlit progress widget can't be driven from inside the
-        # @st.cache_data-decorated solve (Streamlit refuses to record an
-        # element call against a layout block created outside the cached
-        # function — see issue #242). We keep a static progress bar for
-        # visual confirmation and let the status spinner + write lines
-        # carry the "something is happening" signal.
-        progress_bar = st.progress(0.1, text="Solving…")
+        # Live progress (issue #377). The solve runs uncached now — the old
+        # @st.cache_data boundary was what stopped a widget created out here
+        # from being driven from inside the run (issue #242), which is why
+        # this bar used to be a hard-coded, frozen 10 %. The engine's
+        # ``progress_callback`` fires at every phase boundary
+        # (mesh -> assemble -> solve -> failure -> retention), and repeat
+        # runs of an identical payload come back from the manual session
+        # cache without re-solving.
+        progress_bar = st.progress(0.0, text="Starting…")
+        # One-element list rather than a flag: this handler is defined at
+        # module scope, so it has no enclosing function to declare nonlocal
+        # against.
+        _progress_widget_warned: list[bool] = [False]
+
+        def _on_progress(label: str, fraction: float) -> None:
+            """Drive the status widgets from the engine's phase callback.
+
+            Deliberately total: a bad fraction is clamped and any widget
+            error is swallowed (logged once at debug), because a cosmetic
+            progress update must never abort a solve that is already
+            minutes in.
+            """
+            try:
+                frac = float(fraction)
+            except (TypeError, ValueError):
+                frac = 0.0
+            if not math.isfinite(frac):
+                frac = 0.0
+            frac = max(0.0, min(1.0, frac))
+            try:
+                progress_bar.progress(
+                    frac, text=f"{label}… ({int(round(frac * 100.0))} %)"
+                )
+                status.update(label=f"Running analysis — {label}…")
+            except Exception:
+                if not _progress_widget_warned[0]:
+                    _progress_widget_warned[0] = True
+                    logger.debug(
+                        "Progress widget update failed; continuing the solve.",
+                        exc_info=True,
+                    )
+
         try:
-            results = run_analysis_cached(cfg_payload)
+            results = run_analysis_cached(
+                cfg_payload, progress_callback=_on_progress
+            )
         except ValueError as exc:
             status.update(label="Invalid input", state="error", expanded=True)
             st.error(f"Invalid input: {exc}")

--- a/tests/test_app_live_progress.py
+++ b/tests/test_app_live_progress.py
@@ -1,0 +1,333 @@
+"""Live-progress + manual result cache coverage for the app (issue #377).
+
+The Streamlit app used to run the solve behind ``@st.cache_data``, which
+made repeat-identical runs instant but froze the progress bar at a
+hard-coded 10 %: Streamlit refuses widget calls made inside a
+cache-decorated function against a layout block created outside it
+(issue #242), so ``WrinkleAnalysis.run(progress_callback=...)`` could not
+reach the bar.
+
+The app now runs uncached (``_run_analysis``) and caches the *result dict*
+by hand in ``session_state`` keyed on the same hashable ``cfg_payload``.
+These tests guard the three halves of that change:
+
+1. ``run_analysis_cached`` still short-circuits an identical re-run, and
+   the manual cache is bounded (FE result dicts carry mesh / stress /
+   failure-index arrays, so it must not grow for the life of a session).
+2. ``reset_inputs()`` clears the cache.
+3. The run handler threads a live callback into the engine, and that
+   callback survives out-of-range fractions without killing the solve.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.viz
+
+# ``app.py`` lives at the repo root, not under ``src/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("streamlit", reason="Streamlit not installed.")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    """Import ``app.py`` for its module-level helpers."""
+    import app as app_module  # noqa: WPS433 - test-time import.
+    return app_module
+
+
+@pytest.fixture
+def fake_state(app_module, monkeypatch):
+    """Swap ``st.session_state`` for a plain dict for the duration of a test."""
+    state: dict[str, object] = {}
+    monkeypatch.setattr(app_module.st, "session_state", state)
+    return state
+
+
+def _analytical_payload(**overrides) -> tuple:
+    """Build a hashable analytical-only ``cfg_payload``.
+
+    Mirrors what ``_assemble_cfg_payload`` produces for the default sidebar
+    (which is analytical-only, so the run is fast), without needing a live
+    Streamlit session to read the widgets from.
+    """
+    from wrinklefe.core.material import MaterialLibrary
+
+    material_dict = MaterialLibrary().get("IM7_8552").to_dict()
+    items: dict = {
+        "amplitude": 0.5,
+        "wavelength": 10.0,
+        "width": 5.0,
+        "morphology": "stack",
+        "decay_floor": 0.0,
+        "amplitude_profile": "constant",
+        "amplitude_profile_decay_length": 5.0,
+        "amplitude_profile_axis": "x",
+        "loading": "compression",
+        "ply_thickness": 0.125,
+        "angles_tuple": (0.0, 45.0, -45.0, 90.0),
+        "applied_strain": 0.01,
+        "material_tuple": tuple(sorted(material_dict.items())),
+        "analytical_only": True,
+    }
+    items.update(overrides)
+    return tuple(items.items())
+
+
+def _stub_run_analysis(app_module, monkeypatch) -> list[tuple]:
+    """Replace the solve with a counting stub; returns the call log."""
+    calls: list[tuple] = []
+
+    def _fake(cfg_payload, progress_callback=None):
+        calls.append(cfg_payload)
+        if progress_callback is not None:
+            progress_callback("Stub phase", 0.5)
+        return {"summary": "stub", "fe": None, "czm": None}
+
+    monkeypatch.setattr(app_module, "_run_analysis", _fake)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# 1. Manual result cache
+# ---------------------------------------------------------------------------
+
+
+def test_identical_rerun_is_a_cache_hit(app_module, fake_state, monkeypatch):
+    """An identical payload must not re-solve (issue #377 criterion 2)."""
+    calls = _stub_run_analysis(app_module, monkeypatch)
+    payload = _analytical_payload()
+
+    first = app_module.run_analysis_cached(payload)
+    second = app_module.run_analysis_cached(payload)
+
+    assert len(calls) == 1, "identical re-run re-solved instead of hitting cache"
+    assert second is first, "cache hit returned a different object"
+
+
+def test_changed_payload_resolves(app_module, fake_state, monkeypatch):
+    """Changing any sidebar value must miss the cache and re-solve."""
+    calls = _stub_run_analysis(app_module, monkeypatch)
+
+    app_module.run_analysis_cached(_analytical_payload())
+    app_module.run_analysis_cached(_analytical_payload(amplitude=0.75))
+
+    assert len(calls) == 2
+
+
+def test_cache_is_bounded_and_evicts_oldest(app_module, fake_state, monkeypatch):
+    """FE results carry arrays, so the cache keeps only the newest entries."""
+    _stub_run_analysis(app_module, monkeypatch)
+    cap = app_module._RUN_CACHE_MAX
+    payloads = [_analytical_payload(amplitude=0.1 * (i + 1)) for i in range(cap + 1)]
+
+    for payload in payloads:
+        app_module.run_analysis_cached(payload)
+
+    cache = fake_state[app_module._RUN_CACHE_KEY]
+    assert len(cache) == cap, f"cache grew past {cap}: {len(cache)} entries"
+    assert payloads[0] not in cache, "oldest entry survived eviction"
+    for payload in payloads[1:]:
+        assert payload in cache
+
+
+def test_cache_hit_refreshes_recency(app_module, fake_state, monkeypatch):
+    """A payload the user keeps re-running must not be the one evicted."""
+    calls = _stub_run_analysis(app_module, monkeypatch)
+    cap = app_module._RUN_CACHE_MAX
+    payloads = [_analytical_payload(amplitude=0.1 * (i + 1)) for i in range(cap + 1)]
+
+    for payload in payloads[:cap]:
+        app_module.run_analysis_cached(payload)
+    # Touch the oldest entry, then overflow the cache by one.
+    app_module.run_analysis_cached(payloads[0])
+    app_module.run_analysis_cached(payloads[cap])
+
+    cache = fake_state[app_module._RUN_CACHE_KEY]
+    assert len(calls) == cap + 1, "the refresh touch re-solved"
+    assert payloads[0] in cache, "the refreshed entry was evicted"
+    assert payloads[1] not in cache, "the least-recently-used entry survived"
+
+
+def test_reset_inputs_clears_the_run_cache(app_module, fake_state, monkeypatch):
+    """After a Reset the same payload must genuinely re-solve."""
+    calls = _stub_run_analysis(app_module, monkeypatch)
+    payload = _analytical_payload()
+
+    app_module.run_analysis_cached(payload)
+    app_module.reset_inputs()
+    assert app_module._RUN_CACHE_KEY not in fake_state
+
+    app_module.run_analysis_cached(payload)
+    assert len(calls) == 2, "Reset did not clear the manual result cache"
+
+
+# ---------------------------------------------------------------------------
+# 2. Callback wiring through the wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_forwards_the_progress_callback(app_module, fake_state, monkeypatch):
+    """``run_analysis_cached`` must thread the callback down to the solve."""
+    seen: list = []
+
+    def _fake(cfg_payload, progress_callback=None):
+        seen.append(progress_callback)
+        return {"summary": "stub"}
+
+    monkeypatch.setattr(app_module, "_run_analysis", _fake)
+
+    def _callback(label: str, fraction: float) -> None:
+        pass
+
+    app_module.run_analysis_cached(_analytical_payload(), progress_callback=_callback)
+
+    assert seen == [_callback]
+
+
+def test_real_analytical_run_reports_progress_and_keeps_shape(
+    app_module, fake_state
+):
+    """An un-stubbed analytical run must emit progress and return the same
+    result-dict shape the cached path used to return.
+
+    Guards the decorator-removal refactor: the keys the Analyze tab, the
+    JSON export, and the CZM renderer read must all still be there.
+    """
+    events: list[tuple[str, float]] = []
+    payload = _analytical_payload()
+
+    result = app_module._run_analysis(
+        payload, progress_callback=lambda label, frac: events.append((label, frac))
+    )
+
+    assert events, "no progress events were emitted"
+    assert all(0.0 <= frac <= 1.0 for _, frac in events), events
+    assert events[-1][1] == pytest.approx(1.0), "final event was not 100 %"
+    assert all(isinstance(label, str) and label for label, _ in events)
+
+    for key in (
+        "summary",
+        "loading",
+        "applied_strain_abs",
+        "max_angle_deg",
+        "effective_angle_deg",
+        "morphology_factor",
+        "gamma_Y_eff",
+        "analytical_knockdown",
+        "analytical_modulus_knockdown",
+        "analytical_strength_MPa",
+        "damage_index",
+        "tension_mechanisms",
+        "fe",
+        "czm",
+        "progressive",
+    ):
+        assert key in result, f"result dict lost the {key!r} key"
+    # Analytical-only: no FE / CZM / progressive sub-payloads.
+    assert result["fe"] is None
+    assert result["czm"] is None
+    assert result["progressive"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end through the real script
+# ---------------------------------------------------------------------------
+
+
+def _app_path() -> str:
+    return str(_REPO_ROOT / "app.py")
+
+
+def _click(at, label: str) -> None:
+    for b in at.button:
+        if b.label == label:
+            b.click()
+            return
+    raise AssertionError(
+        f"button {label!r} not found; have {[b.label for b in at.button]}"
+    )
+
+
+def test_run_handler_drives_a_live_callback(monkeypatch):
+    """The run handler must hand the engine a real callback, and that
+    callback must survive nonsense fractions rather than killing the solve.
+
+    The app re-imports ``wrinklefe.analysis`` on every script execution, so
+    patching the class method is enough to spy on what the app passes in.
+    """
+    pytest.importorskip(
+        "streamlit.testing.v1", reason="Streamlit testing API not available."
+    )
+    from streamlit.testing.v1 import AppTest
+
+    from wrinklefe.analysis import WrinkleAnalysis
+
+    seen: dict[str, object] = {}
+    real_run = WrinkleAnalysis.run
+
+    def _spy(self, analytical_only=None, progress_callback=None):
+        seen["callback"] = progress_callback
+        if progress_callback is not None:
+            # Values the engine would never emit — the app's guard must
+            # clamp them instead of raising out of the solve.
+            for bad in (-0.5, 42.0, float("nan")):
+                progress_callback("Stub phase", bad)
+        return real_run(
+            self,
+            analytical_only=analytical_only,
+            progress_callback=progress_callback,
+        )
+
+    monkeypatch.setattr(WrinkleAnalysis, "run", _spy)
+
+    at = AppTest.from_file(_app_path(), default_timeout=60)
+    at.run()
+    _click(at, "Run analysis")
+    at.run()
+
+    assert not at.exception, [str(e.value) for e in at.exception]
+    assert callable(seen.get("callback")), (
+        "the run handler did not pass a progress_callback to WrinkleAnalysis.run"
+    )
+    assert "results" in at.session_state
+
+
+def test_app_run_populates_and_reuses_the_manual_cache():
+    """A real run must fill the session cache, and a second identical run
+    must be served from it instead of re-solving."""
+    pytest.importorskip(
+        "streamlit.testing.v1", reason="Streamlit testing API not available."
+    )
+    from streamlit.testing.v1 import AppTest
+
+    import app as app_module
+
+    at = AppTest.from_file(_app_path(), default_timeout=60)
+    at.run()
+    _click(at, "Run analysis")
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+
+    cache = at.session_state[app_module._RUN_CACHE_KEY]
+    assert len(cache) == 1
+    cached_result = next(iter(cache.values()))
+    assert at.session_state["results"] is cached_result
+
+    # Re-run the same (untouched) configuration: same object back, no solve.
+    _click(at, "Run analysis")
+    at.run()
+    assert not at.exception, [str(e.value) for e in at.exception]
+    assert len(at.session_state[app_module._RUN_CACHE_KEY]) == 1
+    assert at.session_state["results"] is cached_result


### PR DESCRIPTION
## Linked issue

Fixes #377

## Summary

The app's progress bar was a hard-coded `st.progress(0.1, text="Solving…")` that
never moved. The cause was the `@st.cache_data` boundary on the solve: Streamlit
refuses element calls made inside a cache-decorated function against a layout
block created outside it (#242), so the engine's already-existing
`WrinkleAnalysis.run(progress_callback=...)` hook had no way to reach the widget.
On a 30–90 s Streamlit Cloud CZM run that made a slow solve indistinguishable
from a hung one.

This sidesteps the cache boundary rather than fighting it, exactly as the issue
suggested: run uncached with the callback driving the bar, and cache the *result
dict* by hand.

**App-only. No `src/wrinklefe/` engine changes** — the API hook was already
correct, so nothing about predictions moves.

### What a user sees

The status box now carries a real bar that steps through the pipeline, with the
percentage in the bar text and the live phase echoed in the status label
(`Running analysis — Solving FE system…`):

| Bar text | % |
|---|---|
| Building laminate… | 0 |
| Computing analytical predictions… | 5 |
| Assembling FE mesh… | 10 |
| Solving FE system… | 25 |
| Evaluating failure criteria… | 75 |
| Computing retention factors… | 90 |
| Analysis complete | 100 |

An analytical-only run jumps `Building laminate` → `Analytical predictions
complete` (100 %), which is the engine's documented rescale for that path.

The callback is deliberately total: the fraction is coerced, NaN-checked and
clamped to `[0, 1]`, and every widget call is wrapped in `try/except` that logs
once at debug. A cosmetic progress update can never abort a solve that is
already minutes in.

### Manual cache + eviction

`run_analysis_cached(cfg_payload, progress_callback=None)` stays the entry point
and the result-dict shape is byte-for-byte what it was (`fe` / `czm` /
`progressive` sub-dicts included) — the old body is now an undecorated
`_run_analysis(cfg_payload, progress_callback=None)`.

The wrapper is a session-scoped lookup on the same hashable `cfg_payload`
`@st.cache_data` used to hash, so re-running an identical configuration is still
instant and hands back the same object. Unlike `@st.cache_data`, it is
**bounded**: FE result dicts carry mesh, displacement, per-element stress and
per-gauss failure-index arrays, and retaining every distinct run of a browsing
session was needless memory. The cache keeps the `_RUN_CACHE_MAX = 4` most
recently *used* payloads — a plain insertion-ordered dict, where a hit pops and
re-inserts the entry (so a payload the user keeps re-running is never the one
dropped) and a put evicts from the front until the cap holds. `reset_inputs()`
clears `_run_cache` alongside `results` / `cfg_payload`, so a Reset genuinely
re-solves.

### CZM / progressive coverage (finding — not fixed here, by design)

`WrinkleAnalysis.run` emits at phase boundaries only. `_run_czm_path` and
`_run_progressive_path` are called *between* emits and receive no callback of
their own, so a CZM run holds at **`Solving FE system` (25 %)** for the entire
Newton-Raphson load-increment loop and then completes at 100 %; a
progressive-damage run holds at 25 % until the linear solve finishes and the
failure phase (75 %) begins. The bar still moves phase-to-phase and the run is
visibly alive, which is what #377 asks for, but per-increment resolution during
those loops would require emits inside the engine — out of scope for this
app-only PR, and worth a follow-up issue if the coarseness bites.

### Test seam

No existing test patched `run_analysis_cached` (the AppTest suites patch the
*library* symbols the app re-imports on each script execution, e.g.
`wrinklefe.goalseek.find_critical_value`). Nothing needed updating; the new
tests follow that same pattern, spying on `WrinkleAnalysis.run` for the
end-to-end case and stubbing `_run_analysis` for the cache unit tests.

New `tests/test_app_live_progress.py` (9 tests) covers: identical re-run is a
cache hit returning the same object; a changed payload re-solves; the cache is
bounded and evicts the least-recently-used entry; a hit refreshes recency; Reset
clears the cache; the wrapper forwards the callback; an un-stubbed analytical run
emits in-range progress ending at 1.0 while keeping every result-dict key (this
one guards the decorator removal directly); and, through `AppTest`, the run
handler hands the engine a real callback and survives `-0.5` / `42.0` / `NaN`
fractions, with a second identical run served from the cache.

## Checklist

- [x] Tests added or updated for the change
- [x] `pytest` green (`tests/test_app_*.py` 88 passed; guard set — `tests/test_io/`, `test_config_io`, `test_param_docs_match`, `test_logging_conventions` — 129 passed; doctests 28 passed / 4 skipped; the full `-m "not slow"` lane is running and CI is authoritative)
- [x] `ruff check .` clean
- [x] `mypy src/wrinklefe app.py streamlit_viz.py` clean (0 errors in 57 files)
- [x] Docs/README updated if user-facing
- [x] `CHANGELOG.md` `[Unreleased]` updated — `### Added` (live progress) and `### Changed` (cache replacement). No **Numerical results** entry: predictions are unchanged.
- [x] `python scripts/validate.py` shows no validation-ledger drift ("All cases match the pinned baselines")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcqsMZfyvv6ue9s3c3JAY)_